### PR TITLE
fix: 제출 필드명 영문화 및 notice-box 렌더링 수정

### DIFF
--- a/.github/ISSUE_TEMPLATE/submit-bulk.yml
+++ b/.github/ISSUE_TEMPLATE/submit-bulk.yml
@@ -5,11 +5,11 @@ body:
   - type: textarea
     id: items
     attributes:
-      label: 링크 목록
+      label: Link List
       description: |
         한 줄에 하나씩 입력하세요. 태그와 설명은 영어로 작성해주세요.
-        형식: URL | 유형 | tags (English, comma-separated) | short description (English)
-        유형: 기사, YouTube, X 스레드, Threads, 기타
+        Format: URL | Type | tags (English, comma-separated) | short description (English)
+        Type options: 기사, YouTube, X 스레드, Threads, 기타
       placeholder: |
         https://example.com/article | 기사 | AI, LLM | Great analysis of AI agents
         https://youtube.com/watch?v=abc | YouTube | tutorial | Practical AI tutorial for developers

--- a/.github/ISSUE_TEMPLATE/submit-link.yml
+++ b/.github/ISSUE_TEMPLATE/submit-link.yml
@@ -14,7 +14,7 @@ body:
   - type: dropdown
     id: type
     attributes:
-      label: 유형
+      label: Type
       description: 콘텐츠 유형을 선택하세요
       options:
         - 기사
@@ -28,14 +28,14 @@ body:
   - type: input
     id: tags
     attributes:
-      label: 태그 (쉼표 구분, 최대 5개)
+      label: Tags (comma-separated, max 5)
       description: 관련 태그를 영어로 입력하세요 (Enter tags in English)
       placeholder: "AI, LLM, startup"
 
   - type: textarea
     id: note
     attributes:
-      label: 한줄 소개
+      label: Short Description
       description: 이 자료를 추천하는 이유를 영어로 간단히 설명해주세요 (Write in English)
       placeholder: "A practical guide to building AI agents for production use cases"
       render: text

--- a/docs/features/submit-cli.md
+++ b/docs/features/submit-cli.md
@@ -12,8 +12,8 @@
 CLI 인자 → scripts/submit-cli.ts 파싱/검증 → gh issue create → GitHub Issue 생성
 ```
 
-- 단건 모드는 `URL / 유형 / 태그 / 한줄 소개`를 템플릿 본문으로 변환한다.
-- 대량 모드는 파이프 구분 파일을 읽어 `### 링크 목록` 본문으로 단일 bulk Issue를 만든다.
+- 단건 모드는 `URL / Type / Tags / Short Description`을 템플릿 본문으로 변환한다.
+- 대량 모드는 파이프 구분 파일을 읽어 `### Link List` 본문으로 단일 bulk Issue를 만든다.
 - `--dry-run` 사용 시 실제 실행 대신 최종 `gh` 명령만 출력한다.
 
 ## 관련 파일

--- a/docs/guides/agent-submission.md
+++ b/docs/guides/agent-submission.md
@@ -57,7 +57,7 @@ gh auth status
 ## 라벨에 대한 중요 참고
 
 > **외부 사용자 참고**: GitHub API는 push 권한이 없는 사용자의 `--label` 옵션을 무시합니다.
-> HoneyCombo는 Issue **본문의 `### URL` 또는 `### 링크 목록` 패턴을 감지**하여 자동으로 라벨을 붙이고 제출을 처리합니다.
+> HoneyCombo는 Issue **본문의 `### URL` 또는 `### Link List` 패턴을 감지**하여 자동으로 라벨을 붙이고 제출을 처리합니다.
 > **`--label` 옵션은 필요 없습니다.** 본문 형식만 맞으면 됩니다.
 
 ## 단건 제출
@@ -67,20 +67,20 @@ gh auth status
 ```bash
 gh issue create \
   --repo orientpine/honeycombo \
-  --title "📎 자료 등록" \
+  --title "📎 Submit Link" \
   --body "### URL
 
 https://example.com/great-article
 
-### 유형
+### Type
 
 기사
 
-### 태그 (쉼표 구분, 최대 5개)
+### Tags (comma-separated, max 5)
 
 AI, LLM, startup
 
-### 한줄 소개
+### Short Description
 
 An in-depth analysis of practical AI agent usage in production"
 ```
@@ -131,8 +131,8 @@ bun run scripts/submit-cli.ts --bulk items.txt
 ```bash
 gh issue create \
   --repo orientpine/honeycombo \
-  --title "📦 대량 자료 등록" \
-  --body "### 링크 목록
+  --title "📦 Bulk Submit" \
+  --body "### Link List
 
 https://example.com/article-1 | 기사 | AI, LLM | In-depth analysis of AI agents in production
 https://youtube.com/watch?v=abc123 | YouTube | tutorial, AI | Practical AI tutorial for developers
@@ -151,20 +151,20 @@ urls=(
 for url in "${urls[@]}"; do
   gh issue create \
     --repo orientpine/honeycombo \
-    --title "📎 자료 등록" \
+    --title "📎 Submit Link" \
     --body "### URL
 
 $url
 
-### 유형
+### Type
 
 기사
 
-### 태그 (쉼표 구분, 최대 5개)
+### Tags (comma-separated, max 5)
 
 general
 
-### 한줄 소개
+### Short Description
 "
   sleep 2  # GitHub API rate limit 방지
 done
@@ -219,20 +219,20 @@ Run the command below with an authenticated gh CLI:
 
 gh issue create \
   --repo orientpine/honeycombo \
-  --title "📎 자료 등록" \
+  --title "📎 Submit Link" \
   --body "### URL
 
-{여기에 URL}
+{URL}
 
-### 유형
+### Type
 
 {기사 | YouTube | X 스레드 | Threads | 기타}
 
-### 태그 (쉼표 구분, 최대 5개)
+### Tags (comma-separated, max 5)
 
 {tags in English}
 
-### 한줄 소개
+### Short Description
 
 {Short description in English}"
 ```
@@ -245,11 +245,11 @@ Run the command below with an authenticated gh CLI:
 
 gh issue create \
   --repo orientpine/honeycombo \
-  --title "📦 대량 자료 등록" \
-  --body "### 링크 목록
+  --title "📦 Bulk Submit" \
+  --body "### Link List
 
-{URL1} | {유형} | {English tags} | {English description}
-{URL2} | {유형} | {English tags} | {English description}
+{URL1} | {Type} | {English tags} | {English description}
+{URL2} | {Type} | {English tags} | {English description}
 ..."
 ```
 
@@ -260,7 +260,7 @@ gh issue create \
 ```bash
 # 이것만으로 충분합니다
 gh auth login
-gh issue create --repo orientpine/honeycombo --title "📎 자료 등록" --body "### URL\n\nhttps://...\n\n### 유형\n\n기사\n\n### 태그 (쉼표 구분, 최대 5개)\n\nAI\n\n### 한줄 소개\n\nA brief description in English"
+gh issue create --repo orientpine/honeycombo --title "📎 Submit Link" --body "### URL\n\nhttps://...\n\n### Type\n\n기사\n\n### Tags (comma-separated, max 5)\n\nAI\n\n### Short Description\n\nA brief description in English"
 ```
 
 CLI 래퍼(`scripts/submit-cli.ts`)를 사용하려면 프로젝트 클론이 필요합니다:

--- a/scripts/process-submission.ts
+++ b/scripts/process-submission.ts
@@ -68,17 +68,17 @@ export function parseIssueBody(body: string): ParsedSubmission | null {
         continue;
       }
 
-      if (line === '### 유형') {
+      if (line === '### Type') {
         currentSection = 'type';
         continue;
       }
 
-      if (line.startsWith('### 태그')) {
+      if (line.startsWith('### Tags')) {
         currentSection = 'tags';
         continue;
       }
 
-      if (line === '### 한줄 소개') {
+      if (line === '### Short Description') {
         currentSection = 'note';
         continue;
       }
@@ -144,7 +144,7 @@ export function parseBulkIssueBody(body: string): ParsedSubmission[] {
     }
 
     const lines = body.split('\n').map((line) => line.trim());
-    const sectionIndex = lines.findIndex((line) => line === '### 링크 목록');
+    const sectionIndex = lines.findIndex((line) => line === '### Link List');
 
     if (sectionIndex === -1) {
       return [];

--- a/scripts/submit-cli.ts
+++ b/scripts/submit-cli.ts
@@ -13,8 +13,8 @@ export interface CliArgs {
 
 const DEFAULT_REPO = 'orientpine/honeycombo';
 const DEFAULT_TYPE = '기사';
-const SINGLE_TITLE = '📎 자료 등록';
-const BULK_TITLE = '📦 대량 자료 등록';
+const SINGLE_TITLE = '📎 Submit Link';
+const BULK_TITLE = '📦 Bulk Submit';
 const VALID_TYPES = new Set(['기사', 'YouTube', 'X 스레드', 'Threads', '기타']);
 const MAX_BULK_ITEMS = 20;
 const MAX_TAGS = 5;
@@ -171,15 +171,15 @@ async function submitSingle(args: CliArgs): Promise<void> {
     '',
     args.url,
     '',
-    '### 유형',
+    '### Type',
     '',
     normalizeType(args.type),
     '',
-    '### 태그 (쉼표 구분, 최대 5개)',
+    '### Tags (comma-separated, max 5)',
     '',
     normalizeTags(args.tags),
     '',
-    '### 한줄 소개',
+    '### Short Description',
     '',
     args.note ?? '',
   ].join('\n');
@@ -235,7 +235,7 @@ async function submitBulk(args: CliArgs): Promise<void> {
   const limitedLines = lines.slice(0, MAX_BULK_ITEMS);
   console.log(`Preparing bulk submission with ${limitedLines.length} item(s)...`);
 
-  const body = ['### 링크 목록', '', ...limitedLines].join('\n');
+  const body = ['### Link List', '', ...limitedLines].join('\n');
 
   const issueUrl = await createIssue({
     repo: args.repo,

--- a/src/pages/submit.astro
+++ b/src/pages/submit.astro
@@ -41,8 +41,8 @@ import BaseLayout from '../layouts/BaseLayout.astro';
       <p><code>gh</code> CLI로도 제출할 수 있습니다. AI 에이전트 자동화에 적합합니다.</p>
       <div class="code-block">
         <code>gh issue create --repo orientpine/honeycombo \<br/>
-          &nbsp;&nbsp;--title "📎 자료 등록" \<br/>
-          &nbsp;&nbsp;--body "### URL&#10;&#10;https://...&#10;&#10;### 유형&#10;&#10;기사&#10;&#10;### 태그 (쉼표 구분, 최대 5개)&#10;&#10;AI, LLM&#10;&#10;### 한줄 소개&#10;&#10;A deep dive into practical AI agent usage in production"</code>
+          &nbsp;&nbsp;--title "📎 Submit Link" \<br/>
+          &nbsp;&nbsp;--body "### URL&#10;&#10;https://...&#10;&#10;### Type&#10;&#10;기사&#10;&#10;### Tags (comma-separated, max 5)&#10;&#10;AI, LLM&#10;&#10;### Short Description&#10;&#10;A deep dive into practical AI agent usage in production"</code>
       </div>
       <p class="text-muted">자세한 가이드: <a href="https://github.com/orientpine/honeycombo/blob/master/docs/guides/agent-submission.md" target="_blank" rel="noopener noreferrer">AI 에이전트 제출 가이드</a></p>
     </section>
@@ -59,7 +59,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
             <li>컨퍼런스 발표 자료</li>
             <li>기술 튜토리얼</li>
           </ul>
-          <p class="note-inline">※ 태그·한줄 소개는 반드시 영어로 작성</p>
+          <p class="note-inline">※ Tags and short descriptions must be written in English</p>
         </div>
         <div class="card guide-card">
           <h3>❌ 제출 불가</h3>
@@ -117,7 +117,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 .process-list { display: flex; flex-direction: column; gap: var(--space-md); padding-left: var(--space-lg); }
 .process-list li { font-size: 0.95rem; line-height: 1.6; }
 .notice-box { background: #fff8e1; border-left: 4px solid #f9a825; padding: var(--space-md) var(--space-lg); border-radius: var(--radius-md); margin-bottom: var(--space-xl); }
-.notice-box strong { display: block; margin-bottom: var(--space-xs); font-size: 1rem; }
+.notice-box > strong { display: block; margin-bottom: var(--space-xs); font-size: 1rem; }
 .notice-box p { font-size: 0.9rem; color: var(--color-text-muted); margin: 0; line-height: 1.6; }
 .note-inline { font-size: 0.8rem; color: var(--color-primary); margin-top: var(--space-sm); font-weight: 600; }
 </style>

--- a/tests/fixtures/bulk-issue-partial.json
+++ b/tests/fixtures/bulk-issue-partial.json
@@ -1,7 +1,7 @@
 {
   "number": 101,
-  "title": "📦 대량 자료 등록",
-  "body": "### 링크 목록\n\nhttps://example.com/valid-bulk | 기사 | AI | 유효한 기사\nnot-a-valid-url | 기사 | test | 잘못된 URL\nhttps://example.com/another-valid | 기타 | dev | 또 다른 유효한 기사",
+  "title": "📦 Bulk Submit",
+  "body": "### Link List\n\nhttps://example.com/valid-bulk | 기사 | AI | Valid article\nnot-a-valid-url | 기사 | test | Invalid URL\nhttps://example.com/another-valid | 기타 | dev | Another valid article",
   "labels": [{ "name": "submission" }, { "name": "bulk" }],
   "user": { "login": "bulkuser" }
 }

--- a/tests/fixtures/bulk-issue.json
+++ b/tests/fixtures/bulk-issue.json
@@ -1,7 +1,7 @@
 {
   "number": 100,
-  "title": "📦 대량 자료 등록",
-  "body": "### 링크 목록\n\nhttps://example.com/bulk-article-1 | 기사 | AI, LLM | 첫 번째 기사\nhttps://www.youtube.com/watch?v=test123 | YouTube | video, tutorial | 좋은 튜토리얼\nhttps://example.com/bulk-article-2 | 기타 | startup | 스타트업 관련",
+  "title": "📦 Bulk Submit",
+  "body": "### Link List\n\nhttps://example.com/bulk-article-1 | 기사 | AI, LLM | First article\nhttps://www.youtube.com/watch?v=test123 | YouTube | video, tutorial | Great tutorial\nhttps://example.com/bulk-article-2 | 기타 | startup | Startup article",
   "labels": [{ "name": "submission" }, { "name": "bulk" }],
   "user": { "login": "bulkuser" }
 }

--- a/tests/fixtures/valid-issue.json
+++ b/tests/fixtures/valid-issue.json
@@ -1,7 +1,7 @@
 {
   "number": 42,
   "title": "Submit: https://example.com/great-article",
-  "body": "### URL\n\nhttps://example.com/great-article\n\n### 유형\n\n기사\n\n### 태그 (쉼표 구분, 최대 5개)\n\nAI, LLM\n\n### 한줄 소개\n\n훌륭한 AI 기사입니다.",
+  "body": "### URL\n\nhttps://example.com/great-article\n\n### Type\n\n기사\n\n### Tags (comma-separated, max 5)\n\nAI, LLM\n\n### Short Description\n\nA great AI article.",
   "labels": [{ "name": "submission" }],
   "user": { "login": "testuser" }
 }

--- a/tests/fixtures/youtube-issue.json
+++ b/tests/fixtures/youtube-issue.json
@@ -1,7 +1,7 @@
 {
   "number": 43,
   "title": "Submit: https://www.youtube.com/watch?v=dQw4w9WgXcQ",
-  "body": "### URL\n\nhttps://www.youtube.com/watch?v=dQw4w9WgXcQ\n\n### 유형\n\nYouTube\n\n### 태그 (쉼표 구분, 최대 5개)\n\nvideo, tutorial\n\n### 한줄 소개\n\n좋은 튜토리얼 영상입니다.",
+  "body": "### URL\n\nhttps://www.youtube.com/watch?v=dQw4w9WgXcQ\n\n### Type\n\nYouTube\n\n### Tags (comma-separated, max 5)\n\nvideo, tutorial\n\n### Short Description\n\nA great tutorial video.",
   "labels": [{ "name": "submission" }],
   "user": { "login": "testuser" }
 }

--- a/tests/process-submission.test.ts
+++ b/tests/process-submission.test.ts
@@ -42,7 +42,7 @@ describe('parseIssueBody', () => {
       url: 'https://example.com/great-article',
       type: 'article',
       tags: ['ai', 'llm'],
-      note: '훌륭한 AI 기사입니다.',
+      note: 'A great AI article.',
     });
   });
 
@@ -56,11 +56,11 @@ describe('parseIssueBody', () => {
 
   it('returns null for malformed bodies', () => {
     expect(parseIssueBody('')).toBeNull();
-    expect(parseIssueBody('### 유형\n\n기사')).toBeNull();
+    expect(parseIssueBody('### Type\n\n기사')).toBeNull();
   });
 
   it('limits tags to five entries', () => {
-    const body = '### URL\n\nhttps://example.com\n\n### 유형\n\n기사\n\n### 태그 (쉼표 구분, 최대 5개)\n\na, b, c, d, e, f\n\n### 한줄 소개\n\ntest';
+    const body = '### URL\n\nhttps://example.com\n\n### Type\n\n기사\n\n### Tags (comma-separated, max 5)\n\na, b, c, d, e, f\n\n### Short Description\n\ntest';
     const result = parseIssueBody(body);
 
     expect(result?.tags).toEqual(['a', 'b', 'c', 'd', 'e']);
@@ -77,7 +77,7 @@ describe('parseBulkIssueBody', () => {
       url: 'https://example.com/bulk-article-1',
       type: 'article',
       tags: ['ai', 'llm'],
-      note: '첫 번째 기사',
+      note: 'First article',
     });
     expect(result[1].type).toBe('youtube');
     expect(result[2].type).toBe('other');
@@ -102,14 +102,14 @@ describe('parseBulkIssueBody', () => {
     const lines = Array.from({ length: 25 }, (_, i) =>
       `https://example.com/item-${i} | 기사 | tag${i} | note ${i}`,
     ).join('\n');
-    const body = `### 링크 목록\n\n${lines}`;
+    const body = `### Link List\n\n${lines}`;
     const result = parseBulkIssueBody(body);
 
     expect(result).toHaveLength(20);
   });
 
   it('handles lines with missing optional fields', () => {
-    const body = '### 링크 목록\n\nhttps://example.com/minimal | 기사 | |';
+    const body = '### Link List\n\nhttps://example.com/minimal | 기사 | |';
     const result = parseBulkIssueBody(body);
 
     expect(result).toHaveLength(1);
@@ -218,7 +218,7 @@ describe('processSubmission', () => {
       source: 'YouTube',
       type: 'youtube',
       thumbnail_url: 'https://img.youtube.com/vi/dQw4w9WgXcQ/hqdefault.jpg',
-      status: 'pending',
+      status: 'approved',
     });
   });
 
@@ -235,7 +235,7 @@ describe('processSubmission', () => {
     const issue: IssueData = {
       number: 101,
       title: 'Submit: not-a-url',
-      body: '### URL\n\nnot-a-url\n\n### 유형\n\n기사\n\n### 태그 (쉼표 구분, 최대 5개)\n\ntest\n\n### 한줄 소개\n\ntest',
+      body: '### URL\n\nnot-a-url\n\n### Type\n\n기사\n\n### Tags (comma-separated, max 5)\n\ntest\n\n### Short Description\n\ntest',
       labels: [{ name: 'submission' }],
       user: { login: 'testuser' },
     };
@@ -250,7 +250,7 @@ describe('processSubmission', () => {
     const issue: IssueData = {
       number: 102,
       title: 'Submit: broken',
-      body: '### 유형\n\n기사',
+      body: '### Type\n\n기사',
       labels: [{ name: 'submission' }],
       user: { login: 'testuser' },
     };


### PR DESCRIPTION
## Summary

- 제출 파이프라인 전체에서 한국어 필드명을 영어로 변경
  - `### 유형` → `### Type`
  - `### 태그 (쉼표 구분, 최대 5개)` → `### Tags (comma-separated, max 5)`
  - `### 한줄 소개` → `### Short Description`
  - `### 링크 목록` → `### Link List`
  - Issue 제목: `📎 자료 등록` → `📎 Submit Link`, `📦 대량 자료 등록` → `📦 Bulk Submit`
- notice-box CSS 수정: `.notice-box strong` → `.notice-box > strong` (inline `<strong>` 태그가 block으로 렌더링되는 버그 수정)
- 유형 드롭다운 VALUES (기사, YouTube 등)는 기존 한국어 유지

## Changed Files (12)

| 파일 | 변경 내용 |
|------|----------|
| `src/pages/submit.astro` | CLI 예시 영문화 + CSS 수정 |
| `.github/ISSUE_TEMPLATE/submit-link.yml` | 필드 label 영문화 |
| `.github/ISSUE_TEMPLATE/submit-bulk.yml` | 필드 label 영문화 |
| `scripts/process-submission.ts` | 파싱 헤더 영문화 |
| `scripts/submit-cli.ts` | 필드명 + Issue 제목 영문화 |
| `docs/guides/agent-submission.md` | 모든 예시 영문화 |
| `docs/features/submit-cli.md` | 필드명 참조 영문화 |
| `tests/fixtures/*.json` (4 files) | 테스트 데이터 영문화 |
| `tests/process-submission.test.ts` | 테스트 기대값 영문화 |