### PR TITLE
fix: submitted article not visible in source filter + buttons unresponsive after page navigation

### DIFF
--- a/docs/troubleshooting/submitted-article-invisible-and-page-navigation-buttons.md
+++ b/docs/troubleshooting/submitted-article-invisible-and-page-navigation-buttons.md
@@ -1,0 +1,89 @@
+# 제출 기사 미노출 및 페이지 네비게이션 후 버튼 비반응
+
+> 제출 기사가 source filter 카운트에는 잡히지만 카드가 렌더링되지 않고, 페이지 2 이동 후 필터 버튼이 반응하지 않는 버그
+
+## 증상
+
+1. `/articles/?origin=submitted` 접속 시 "제출 기사 1" 카운트는 표시되지만 "이 페이지에 해당하는 기사가 없습니다" 메시지 출력
+2. `/articles/` → "다음 →" 클릭으로 `/articles/page/2/` 이동 후, SourceFilter/TagFilter/PersonalizationBar 버튼 클릭 무반응
+
+**재현 환경**: Astro SSG + ClientRouter (View Transitions), Cloudflare Pages
+
+## 원인
+
+### 버그 1: 제출 기사 정렬 오류
+
+`article-sort.ts`의 `SortableArticle._type`이 `'curated' | 'feed'`만 허용하고 `'submitted'`를 누락.
+`getArticleDate()`가 `_type === 'curated'`일 때만 `submitted_at`을 사용하므로, submitted 기사는 `published_at`(존재하지 않음)을 참조 → `new Date(0)` = epoch 1970 → 전체 기사 중 최하단 정렬 → 마지막 페이지로 밀림.
+
+### 버그 2: SourceFilter DOM-only 필터링
+
+`SourceFilter.astro`가 `document.querySelectorAll('[data-testid="article-card"]')`로 현재 페이지 DOM 카드만 필터링.
+서버 사이드 pagination으로 페이지당 20개만 렌더되므로, 다른 페이지의 기사는 필터 불가.
+카운트는 전체 기사 기준(서버 사이드)이라 "1"이지만, DOM에 해당 카드가 없어 0건 표시.
+
+### 버그 3: astro:page-load 조건부 등록
+
+```javascript
+// 문제 패턴
+if (document.readyState === 'loading') {
+  document.addEventListener('astro:page-load', initFn);
+} else {
+  initFn();
+}
+```
+
+`document.readyState`가 `'loading'`이 아닌 경우(캐시된 페이지 등) `astro:page-load` 리스너가 등록되지 않아, ClientRouter의 클라이언트 사이드 네비게이션 후 init 함수 미실행.
+
+## 해결 방법
+
+### 1. article-sort.ts
+
+```diff
+- _type: 'curated' | 'feed';
++ _type: 'curated' | 'submitted' | 'feed';
+
+- const raw = a._type === 'curated' ? a.submitted_at : a.published_at;
++ const raw = (a._type === 'curated' || a._type === 'submitted') ? a.submitted_at : a.published_at;
+```
+
+### 2. SourceFilter → TagFilter 이벤트 위임
+
+SourceFilter가 직접 DOM 카드를 조작하는 대신, `source-filter-changed` CustomEvent를 dispatch.
+TagFilter가 이 이벤트를 수신하여 내장 JSON 데이터에서 origin 필터를 적용한 크로스 페이지 렌더링 수행.
+
+### 3. astro:page-load 무조건 등록
+
+```diff
+- if (document.readyState === 'loading') {
+-   document.addEventListener('astro:page-load', initFn);
+- } else {
+-   initFn();
+- }
++ document.addEventListener('astro:page-load', initFn);
+```
+
+Astro ClientRouter 환경에서 `astro:page-load`는 초기 로드 시에도 발생하므로 조건 분기 불필요.
+
+## 관련 파일
+
+| 파일 | 변경 내용 |
+|------|----------|
+| `src/lib/article-sort.ts` | `'submitted'` 타입 추가, `getArticleDate` 수정 |
+| `src/components/SourceFilter.astro` | DOM 필터링 → 이벤트 dispatch 방식으로 변경, `astro:page-load` 패턴 수정 |
+| `src/components/TagFilter.astro` | origin 필터링 로직 추가, `source-filter-changed` 이벤트 리스너, `astro:page-load` 패턴 수정 |
+| `src/components/PersonalizationBar.astro` | `astro:page-load` 패턴 수정 |
+
+## 예방 조치
+
+1. Astro ClientRouter 사용 시 스크립트 초기화는 **항상** `document.addEventListener('astro:page-load', ...)` 패턴 사용. `readyState` 조건 분기 금지.
+2. 클라이언트 사이드 필터링이 서버 사이드 pagination과 공존할 때, JSON 데이터 기반 크로스 페이지 렌더링 방식 사용. DOM 카드 show/hide는 현재 페이지만 커버.
+3. `SortableArticle` 등 타입 정의 변경 시, 해당 타입을 참조하는 모든 함수 동시 검토.
+
+---
+
+## 변경 이력
+
+| 날짜 | 변경 내용 |
+|------|----------|
+| 2026-04-13 | 최초 작성 |

--- a/docs/troubleshooting/submitted-article-invisible-and-page-navigation-buttons.md
+++ b/docs/troubleshooting/submitted-article-invisible-and-page-navigation-buttons.md
@@ -80,6 +80,11 @@ Astro ClientRouter 환경에서 `astro:page-load`는 초기 로드 시에도 발
 2. 클라이언트 사이드 필터링이 서버 사이드 pagination과 공존할 때, JSON 데이터 기반 크로스 페이지 렌더링 방식 사용. DOM 카드 show/hide는 현재 페이지만 커버.
 3. `SortableArticle` 등 타입 정의 변경 시, 해당 타입을 참조하는 모든 함수 동시 검토.
 
+## 관련 문서
+
+- [아키텍처 개요](../architecture/overview.md)
+- [제출 CLI 가이드](../guides/agent-submission.md)
+
 ---
 
 ## 변경 이력

--- a/src/components/PersonalizationBar.astro
+++ b/src/components/PersonalizationBar.astro
@@ -149,11 +149,7 @@ function initPersonalization() {
   prioritizeArticles();
 }
 
-if (document.readyState === 'loading') {
-  document.addEventListener('astro:page-load', initPersonalization);
-} else {
-  initPersonalization();
-}
+document.addEventListener('astro:page-load', initPersonalization);
 </script>
 
 <style>

--- a/src/components/SourceFilter.astro
+++ b/src/components/SourceFilter.astro
@@ -28,25 +28,13 @@ const { curatedCount, submittedCount, feedCount } = Astro.props;
 
 <script>
 function filterByOrigin(origin: string) {
-  const cards = document.querySelectorAll<HTMLElement>('[data-testid="article-card"]');
   const buttons = document.querySelectorAll<HTMLElement>('[data-testid="source-filter"] .source-filter-btn');
-  const emptyState = document.querySelector<HTMLElement>('[data-testid="source-filter-empty"]');
 
   buttons.forEach(btn => {
     btn.classList.toggle('active', btn.dataset.origin === origin);
   });
 
-  let visibleCount = 0;
-  cards.forEach(card => {
-    const show = origin === 'all' || card.dataset.origin === origin;
-    card.style.display = show ? '' : 'none';
-    if (show) visibleCount++;
-  });
-
-  if (emptyState) {
-    emptyState.style.display = visibleCount === 0 && origin !== 'all' ? '' : 'none';
-  }
-
+  // Update URL
   const url = new URL(window.location.href);
   if (origin === 'all') {
     url.searchParams.delete('origin');
@@ -54,6 +42,9 @@ function filterByOrigin(origin: string) {
     url.searchParams.set('origin', origin);
   }
   window.history.pushState({}, '', url.toString());
+
+  // Dispatch event so TagFilter handles cross-page rendering
+  document.dispatchEvent(new CustomEvent('source-filter-changed', { detail: { origin } }));
 }
 
 function initSourceFilter() {
@@ -75,11 +66,7 @@ function initSourceFilter() {
   }
 }
 
-if (document.readyState === 'loading') {
-  document.addEventListener('astro:page-load', initSourceFilter);
-} else {
-  initSourceFilter();
-}
+document.addEventListener('astro:page-load', initSourceFilter);
 </script>
 
 <style>

--- a/src/components/TagFilter.astro
+++ b/src/components/TagFilter.astro
@@ -118,59 +118,86 @@ function renderCard(a: ClientArticle): string {
 </article>`;
 }
 
-function filterByTag(tag: string) {
+function getActiveOrigin(): string {
+  const active = document.querySelector<HTMLElement>('[data-testid="source-filter"] .source-filter-btn.active');
+  return active?.dataset.origin || 'all';
+}
+
+function getActiveTag(): string {
+  const active = document.querySelector<HTMLElement>('[data-testid="tag-filter"] .tag.active');
+  return active?.dataset.tag || 'all';
+}
+
+function applyFilters(tag: string, origin?: string) {
   const ssrCards = document.querySelectorAll('[data-testid="article-list"] [data-testid="article-card"]');
-  const buttons = document.querySelectorAll('[data-testid="tag-filter"] .tag');
+  const tagButtons = document.querySelectorAll('[data-testid="tag-filter"] .tag');
   const ssrList = document.querySelector('[data-testid="article-list"]') as HTMLElement | null;
   const pagination = document.querySelector('.pagination') as HTMLElement | null;
   const filteredContainer = document.getElementById('tag-filtered-results');
   const filteredGrid = document.getElementById('tag-filtered-grid');
   const filteredCount = document.getElementById('tag-filtered-count');
+  const emptyState = document.querySelector<HTMLElement>('[data-testid="source-filter-empty"]');
 
-  // Update active button state
-  buttons.forEach(btn => {
+  const activeOrigin = origin ?? getActiveOrigin();
+
+  // Update tag button active state
+  tagButtons.forEach(btn => {
     btn.classList.toggle('active', (btn as HTMLElement).dataset.tag === tag);
   });
 
-  if (tag === 'all') {
-    // Restore original SSR-rendered view
+  const needsJsonRendering = tag !== 'all' || activeOrigin !== 'all';
+
+  if (!needsJsonRendering) {
+    // Both filters at 'all' — restore original SSR-rendered view
     ssrCards.forEach(card => {
       (card as HTMLElement).style.display = '';
     });
     if (ssrList) ssrList.style.display = '';
     if (pagination) pagination.style.display = '';
     if (filteredContainer) filteredContainer.style.display = 'none';
-
-    // Re-apply source filter if active
-    const activeOrigin = document.querySelector<HTMLElement>('[data-testid="source-filter"] .source-filter-btn.active');
-    if (activeOrigin && activeOrigin.dataset.origin && activeOrigin.dataset.origin !== 'all') {
-      const origin = activeOrigin.dataset.origin;
-      ssrCards.forEach(card => {
-        const el = card as HTMLElement;
-        el.style.display = el.dataset.origin === origin ? '' : 'none';
-      });
-    }
+    if (emptyState) emptyState.style.display = 'none';
   } else {
-    // Load all articles from embedded JSON and filter by tag
-    const articles = getAllArticles();
-    const matched = articles.filter(a => a.tags.includes(tag));
+    // Load all articles from embedded JSON and apply both filters
+    let articles = getAllArticles();
+    if (tag !== 'all') {
+      articles = articles.filter(a => a.tags.includes(tag));
+    }
+    if (activeOrigin !== 'all') {
+      articles = articles.filter(a => a.articleOrigin === activeOrigin);
+    }
 
     // Hide SSR-rendered list and pagination
     if (ssrList) ssrList.style.display = 'none';
     if (pagination) pagination.style.display = 'none';
 
+    // Build label
+    const labels: string[] = [];
+    if (activeOrigin !== 'all') {
+      const originLabels: Record<string, string> = { curated: '에디터 추천', submitted: '제출 기사', feed: 'RSS 피드' };
+      labels.push(originLabels[activeOrigin] || activeOrigin);
+    }
+    if (tag !== 'all') {
+      labels.push(`"${escapeHtml(tag)}" 태그`);
+    }
+
     // Render filtered results
     if (filteredContainer && filteredGrid && filteredCount) {
       filteredContainer.style.display = '';
-      filteredCount.textContent = `"${escapeHtml(tag)}" 태그 기사 ${matched.length}건`;
-      filteredGrid.innerHTML = matched.map(renderCard).join('');
+      filteredCount.textContent = `${labels.join(' · ')} 기사 ${articles.length}건`;
+      filteredGrid.innerHTML = articles.map(renderCard).join('');
       // Initialize AddToPlaylist buttons for dynamically rendered cards
       if ((window as any).__initAddToPlaylistContainers) {
         (window as any).__initAddToPlaylistContainers(filteredGrid);
       }
     }
+
+    // Show/hide empty state
+    if (emptyState) {
+      emptyState.style.display = articles.length === 0 ? '' : 'none';
+    }
   }
-  // Update URL param
+
+  // Update URL params
   const url = new URL(window.location.href);
   if (tag === 'all') {
     url.searchParams.delete('tag');
@@ -178,6 +205,10 @@ function filterByTag(tag: string) {
     url.searchParams.set('tag', tag);
   }
   window.history.pushState({}, '', url.toString());
+}
+
+function filterByTag(tag: string) {
+  applyFilters(tag);
 }
 
 function initTagFilter() {
@@ -190,20 +221,24 @@ function initTagFilter() {
     });
   });
 
+  // Listen for source filter changes
+  document.addEventListener('source-filter-changed', ((e: CustomEvent<{ origin: string }>) => {
+    const currentTag = getActiveTag();
+    applyFilters(currentTag, e.detail.origin);
+  }) as EventListener);
+
+  // Apply initial filters from URL
   const tagParam = new URLSearchParams(window.location.search).get('tag');
-  if (tagParam && validTags.has(tagParam)) {
-    filterByTag(tagParam);
-  } else if (tagParam) {
-    // Unknown tag param — fall back to showing all
-    filterByTag('all');
+  const originParam = new URLSearchParams(window.location.search).get('origin');
+  const initialTag = tagParam && validTags.has(tagParam) ? tagParam : 'all';
+  const initialOrigin = originParam || 'all';
+
+  if (initialTag !== 'all' || initialOrigin !== 'all') {
+    applyFilters(initialTag, initialOrigin);
   }
 }
 
-if (document.readyState === 'loading') {
-  document.addEventListener('astro:page-load', initTagFilter);
-} else {
-  initTagFilter();
-}
+document.addEventListener('astro:page-load', initTagFilter);
 </script>
 
 <style>

--- a/src/lib/article-sort.ts
+++ b/src/lib/article-sort.ts
@@ -6,13 +6,13 @@
  */
 
 export type SortableArticle = {
-  _type: 'curated' | 'feed';
+  _type: 'curated' | 'submitted' | 'feed';
   submitted_at?: Date | string;
   published_at?: Date | string;
 };
 
 function getArticleDate(a: SortableArticle): number {
-  const raw = a._type === 'curated' ? a.submitted_at : a.published_at;
+  const raw = (a._type === 'curated' || a._type === 'submitted') ? a.submitted_at : a.published_at;
   return new Date(raw ?? 0).getTime();
 }
 


### PR DESCRIPTION
## Summary
- **Submitted article invisible**: `article-sort.ts` didn't handle `'submitted'` type — date fell to epoch 1970, sorting article to last page. Source filter only filtered current page DOM cards, not cross-page.
- **Buttons unresponsive on page 2+**: Conditional `astro:page-load` registration pattern failed after ClientRouter navigation.

## Changes
- `article-sort.ts`: Add `'submitted'` to `SortableArticle._type`, use `submitted_at` for date
- `SourceFilter.astro`: Dispatch `source-filter-changed` event instead of DOM-only filtering
- `TagFilter.astro`: Cross-page origin filtering via embedded JSON data, listen for source filter events
- `PersonalizationBar.astro`: Fix `astro:page-load` init pattern
- All 3 components: Replace conditional `if (readyState === 'loading')` with unconditional `document.addEventListener('astro:page-load', ...)`

## Testing
- Verified submitted article appears at `/articles/?origin=submitted` ✓
- Verified page 2 buttons respond after ClientRouter navigation ✓
- Verified cross-page filtering works (page 2 → "제출 기사" → shows 1 article from JSON) ✓
- Build passes ✓