### PR TITLE
fix: GeekNews Weekly #353 기사 제목·요약을 원문 기반으로 개선

### DIFF
--- a/src/content/curated/2026/04/submission-22-968e6f51.json
+++ b/src/content/curated/2026/04/submission-22-968e6f51.json
@@ -1,10 +1,10 @@
 {
   "id": "submission-22-968e6f51",
-  "title": "GeekNews Weekly #353 covering the shift from prompt engineering to harness engineering, with curated links on agent skills, meta-harness design, and self-improving agents",
+  "title": "GeekNews Weekly #353 — 스킬이 쏟아지는 시대, 내 하네스는 내가 만든다",
   "url": "https://news.hada.io/weekly/202615",
   "source": "User Submission",
   "type": "article",
-  "description": "GeekNews Weekly #353 covering the shift from prompt engineering to harness engineering, with curated links on agent skills, meta-harness design, and self-improving agents",
+  "description": "프롬프트에서 하네스 엔지니어링으로의 패러다임 전환, Addy Osmani의 agent-skills 등 에이전트 스킬 공유 러시, Anthropic Managed Agents 설계와 Meta HyperAgents까지 — 에이전트 시대의 핵심 흐름을 정리한 위클리 뉴스레터",
   "tags": [
     "ai",
     "agents",


### PR DESCRIPTION
## Summary

- GeekNews Weekly #353 기사의 자동 생성된 영문 제목·요약을 원문 뉴스레터 제목 기반의 한국어로 교체
- **title**: `GeekNews Weekly #353 — 스킬이 쏟아지는 시대, 내 하네스는 내가 만든다`
- **description**: 핵심 주제(하네스 엔지니어링 전환, 에이전트 스킬 공유, 메타 하네스)를 요약한 한 줄 설명으로 변경