### PR TITLE
feat: replace submit page CLI section with agent-paste one-liner

### DIFF
--- a/src/pages/submit.astro
+++ b/src/pages/submit.astro
@@ -38,13 +38,10 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 
     <section class="submit-section">
       <h2>터미널 / AI 에이전트로 제출</h2>
-      <p><code>gh</code> CLI로도 제출할 수 있습니다. AI 에이전트 자동화에 적합합니다.</p>
+      <p>이 문서 읽는 시대는 지났습니다. 그냥 이 텍스트를 에이전트한테 붙여넣으세요:</p>
       <div class="code-block">
-        <code>gh issue create --repo orientpine/honeycombo \<br/>
-          &nbsp;&nbsp;--title "📎 Submit Link" \<br/>
-          &nbsp;&nbsp;--body "### URL&#10;&#10;https://...&#10;&#10;### Type&#10;&#10;Article&#10;&#10;### Tags (comma-separated, max 5)&#10;&#10;AI, LLM&#10;&#10;### Short Description&#10;&#10;A deep dive into practical AI agent usage in production"</code>
+        <code>Read this guide and submit my link to HoneyCombo: https://raw.githubusercontent.com/orientpine/honeycombo/refs/heads/master/docs/guides/agent-submission.md</code>
       </div>
-      <p class="text-muted">자세한 가이드: <a href="https://github.com/orientpine/honeycombo/blob/master/docs/guides/agent-submission.md" target="_blank" rel="noopener noreferrer">AI 에이전트 제출 가이드</a></p>
     </section>
 
     <section class="submit-section">


### PR DESCRIPTION
## Summary

- /submit/ 페이지의 "터미널 / AI 에이전트로 제출" 섹션을 oh-my-openagent 스타일의 원라이너로 교체
- 기존: gh CLI 명령어 전체를 코드 블록으로 표시 + "자세한 가이드" 링크
- 변경: "이 문서 읽는 시대는 지났습니다. 그냥 이 텍스트를 에이전트한테 붙여넣으세요:" + agent-submission.md 가이드를 가리키는 원라이너