### PR TITLE
fix: 기사 상세페이지 개선 및 커뮤니티 기능 추가

### DIFF
--- a/docs/features/article-detail-community.md
+++ b/docs/features/article-detail-community.md
@@ -1,0 +1,73 @@
+# 기사 상세페이지 커뮤니티 기능
+
+> 기사 상세페이지에 공유, 북마크, 개선된 관련 기사, 댓글 수 표시 등 커뮤니티 참여 기능 추가
+
+## 개요
+
+커뮤니티 성격 프로젝트에 어울리는 상호작용 기능을 기사 상세페이지와 목록 카드에 추가했다.
+
+## 기능 목록
+
+### 1. 공유 버튼 (ShareButtons)
+
+- **X(Twitter) 공유**: `twitter.com/intent/tweet` URL 기반, API 불필요
+- **링크 복사**: `navigator.clipboard` API, 복사 완료 시 "복사됨!" 피드백
+- **Web Share API**: 모바일에서만 표시, 카카오톡/라인 등 네이티브 공유 지원
+- 위치: 상세페이지 액션 바 (헤더 아래)
+
+### 2. 북마크 (BookmarkButton)
+
+- **localStorage 기반**: `honeycombo:bookmarks` 키에 기사 ID 배열 저장
+- **하트 아이콘 토글**: outline ↔ filled, 핑크 컬러 (#e74c6f)
+- **동기화**: 같은 페이지 내 동일 기사의 북마크 버튼 자동 동기화
+- 상세페이지: `size="md"` (액션 바), 목록 카드: `size="sm"` (아이콘만)
+
+### 3. 관련 기사 개선 (RelatedArticles)
+
+- **Before**: curated만 대상, 태그 1개 매칭, 정렬 없음
+- **After**: curated + feeds 모두 대상, 매칭 태그 수 기반 스코어링, score desc → date desc 정렬
+- 최대 3개 표시, 날짜 표시 추가
+
+### 4. 댓글 수 표시
+
+- 기사 카드에 💬 아이콘 + 댓글 수 표시
+- **Giscus API** 기반 클라이언트 사이드 fetching
+- **IntersectionObserver**: 뷰포트 진입 시에만 fetch (rootMargin: 200px)
+- **sessionStorage 캐시**: 세션 내 중복 요청 방지
+- 댓글 아이콘 클릭 시 상세페이지 `#comments` 앵커로 이동
+
+## 관련 파일
+
+| 파일 | 역할 |
+|------|------|
+| `src/components/ShareButtons.astro` | 공유 버튼 컴포넌트 |
+| `src/components/BookmarkButton.astro` | 북마크 토글 컴포넌트 |
+| `src/components/RelatedArticles.astro` | 관련 기사 (개선된 알고리즘) |
+| `src/components/ArticleCard.astro` | 기사 카드 (북마크 + 댓글 수 통합) |
+| `src/pages/articles/[...slug].astro` | 상세페이지 (액션 바 레이아웃) |
+| `src/components/Comments.astro` | Giscus 댓글 (View Transitions 호환) |
+| `public/_headers` | CSP 헤더 (giscus.app 허용) |
+
+## 설계 결정
+
+- **북마크를 localStorage로 구현**: 서버 비용 없이 즉시 동작. 크로스 디바이스는 기존 플레이리스트 기능으로 대체 가능.
+- **댓글 수를 클라이언트에서 fetch**: SSG 빌드 시점에 GitHub API 토큰 불필요. IntersectionObserver + sessionStorage로 성능 최적화.
+- **Giscus를 `astro:page-load`로 초기화**: View Transitions(ClientRouter) 호환. 기존 `is:inline` + 외부 스크립트 방식은 페이지 전환 시 재초기화 실패.
+
+## 제약 사항
+
+- 북마크는 디바이스별 저장 (localStorage). 로그인 연동 미구현.
+- 댓글 수는 Giscus API 응답 속도에 의존 (보통 100~300ms).
+- Giscus Discussion이 아직 생성되지 않은 기사는 댓글 수 0 표시.
+
+---
+
+## 관련 문서
+
+- [아키텍처 개요](../architecture/overview.md)
+
+## 변경 이력
+
+| 날짜 | 변경 내용 |
+|------|----------|
+| 2026-04-14 | 최초 작성 |

--- a/docs/features/article-detail-community.md
+++ b/docs/features/article-detail-community.md
@@ -6,6 +6,21 @@
 
 커뮤니티 성격 프로젝트에 어울리는 상호작용 기능을 기사 상세페이지와 목록 카드에 추가했다.
 
+## 동작 흐름
+
+```
+기사 상세페이지 로드
+  → astro:page-load 이벤트 발생
+  → BookmarkButton: localStorage에서 북마크 상태 복원
+  → Giscus: 동적으로 script 요소 생성 → iframe 렌더링
+  → ShareButtons: 클릭 시 clipboard/window.open/navigator.share
+
+기사 목록 페이지 로드
+  → BookmarkButton: localStorage에서 전체 북마크 상태 복원
+  → IntersectionObserver: 뷰포트 진입 카드에 대해 Giscus API fetch
+  → sessionStorage 캐시 확인 → 없으면 API 호출 → 댓글 수 표시
+```
+
 ## 기능 목록
 
 ### 1. 공유 버튼 (ShareButtons)
@@ -49,6 +64,15 @@
 | `public/_headers` | CSP 헤더 (giscus.app 허용) |
 
 ## 설계 결정
+
+## 설정값
+
+| 이름 | 위치 | 기본값 | 설명 |
+|------|------|--------|------|
+| `honeycombo:bookmarks` | localStorage | `[]` | 북마크된 기사 ID 배열 |
+| `honeycombo:comment-counts` | sessionStorage | `{}` | 댓글 수 캐시 (path → count) |
+| `REPO_ID` | `Comments.astro` | `R_kgDOR_fpgQ` | GitHub repo ID (Giscus) |
+| `CATEGORY_ID` | `Comments.astro` | `DIC_kwDOR_fpgc4C6lgR` | GitHub Discussions category ID |
 
 - **북마크를 localStorage로 구현**: 서버 비용 없이 즉시 동작. 크로스 디바이스는 기존 플레이리스트 기능으로 대체 가능.
 - **댓글 수를 클라이언트에서 fetch**: SSG 빌드 시점에 GitHub API 토큰 불필요. IntersectionObserver + sessionStorage로 성능 최적화.

--- a/src/components/ArticleCard.astro
+++ b/src/components/ArticleCard.astro
@@ -17,7 +17,7 @@ interface Props {
   articleOrigin?: 'curated' | 'submitted' | 'feed';  // curated=editor pick, submitted=community submission, feed=RSS
 }
 
-const { id, title, url, source, type, description, tags, date, thumbnail_url, isExternal = true, slug, articleOrigin = 'feed' } = Astro.props;
+const { id, title, url, source, type, description, tags, date, thumbnail_url, isExternal = false, slug, articleOrigin = 'feed' } = Astro.props;
 const sourceType = articleOrigin === 'feed' ? 'feed' : 'curated';
 const articleUrl = isExternal ? url : `/articles/${slug || id}`;
 const articlePath = `/articles/${slug || id}/`;

--- a/src/lib/serialize-articles.ts
+++ b/src/lib/serialize-articles.ts
@@ -49,8 +49,8 @@ export function serializeArticles(
       date: new Date(date as string | Date).toISOString(),
       ...(a.thumbnail_url ? { thumbnail_url: a.thumbnail_url } : {}),
       articleOrigin: a._type === 'curated' ? 'curated' : a._type === 'submitted' ? 'submitted' : 'feed',
-      ...(a._type === 'curated' ? { slug: a._id } : {}),
-      isExternal: a._type === 'feed' || a._type === 'submitted',
+      slug: a._id,
+      isExternal: false,
     };
   });
 

--- a/src/pages/articles/index.astro
+++ b/src/pages/articles/index.astro
@@ -73,8 +73,8 @@ const allArticlesJson = serializeArticles(allArticles);
           tags={article.tags}
           date={'submitted_at' in article ? article.submitted_at : article.published_at}
           thumbnail_url={article.thumbnail_url}
-          isExternal={article._type === 'feed' || article._type === 'submitted'}
-          slug={article._type === 'curated' ? article._id : undefined}
+          isExternal={false}
+          slug={article._id}
           articleOrigin={article._type}
         />
       ))}

--- a/src/pages/articles/page/[...page].astro
+++ b/src/pages/articles/page/[...page].astro
@@ -74,8 +74,8 @@ const { articles, currentPage, totalPages, allTags, allArticlesJson, curatedCoun
         tags={article.tags}
         date={'submitted_at' in article ? article.submitted_at : article.published_at}
         thumbnail_url={article.thumbnail_url}
-        isExternal={article._type === 'feed' || article._type === 'submitted'}
-        slug={article._type === 'curated' ? article._id : undefined}
+        isExternal={false}
+        slug={article._id}
         articleOrigin={article._type}
       />
     ))}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -64,8 +64,8 @@ const recentArticles = allArticles.slice(0, MAX_RECENT);
             date={'submitted_at' in article ? article.submitted_at : article.published_at}
             thumbnail_url={article.thumbnail_url}
             articleOrigin={article._type}
-            isExternal={article._type === 'feed'}
-            slug={article._type === 'curated' ? article._id : undefined}
+            isExternal={false}
+            slug={article._id}
           />
         ))}
       </div>

--- a/src/pages/submit.astro
+++ b/src/pages/submit.astro
@@ -38,9 +38,13 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 
     <section class="submit-section">
       <h2>터미널 / AI 에이전트로 제출</h2>
-      <p>이 문서 읽는 시대는 지났습니다. 그냥 이 텍스트를 에이전트한테 붙여넣으세요:</p>
-      <div class="code-block">
-        <code>Read this guide and submit my link to HoneyCombo: https://raw.githubusercontent.com/orientpine/honeycombo/refs/heads/master/docs/guides/agent-submission.md</code>
+      <div class="agent-card">
+        <p class="agent-intro">AI 에이전트에게 자료 등록을 시키세요.</p>
+        <p class="agent-desc">아래 텍스트를 에이전트에 붙여넣으면, 가이드를 읽고 자동으로 제출합니다.</p>
+        <div class="agent-prompt">
+          <code>Read this guide and submit my link to HoneyCombo: https://raw.githubusercontent.com/orientpine/honeycombo/refs/heads/master/docs/guides/agent-submission.md</code>
+        </div>
+        <a class="agent-guide-link" href="https://github.com/orientpine/honeycombo/blob/master/docs/guides/agent-submission.md" target="_blank" rel="noopener noreferrer">자세한 가이드 보기 →</a>
       </div>
     </section>
 
@@ -83,38 +87,95 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 </BaseLayout>
 
 <style>
-.page-header { margin-bottom: var(--space-xl); }
-.page-header h1 { font-size: 2rem; font-weight: 800; }
-.page-subtitle { color: var(--color-text-muted); margin-top: var(--space-xs); }
-.submit-content { max-width: 800px; }
+.page-header { margin-bottom: var(--space-2xl); }
+.page-header h1 { font-size: 2rem; font-weight: 800; letter-spacing: -0.02em; }
+.page-subtitle { color: var(--color-text-muted); margin-top: var(--space-xs); font-size: 1.05rem; }
+
+.notice-box {
+  background: color-mix(in srgb, var(--color-accent) 15%, transparent);
+  border-left: 4px solid var(--color-accent);
+  padding: var(--space-md) var(--space-lg);
+  border-radius: var(--radius-md);
+  margin-top: var(--space-lg);
+}
+.notice-box > strong { display: block; margin-bottom: var(--space-xs); font-size: 0.95rem; }
+.notice-box p { font-size: 0.875rem; color: var(--color-text-muted); margin: 0; line-height: 1.6; }
+
+.submit-content { max-width: 720px; }
+
 .submit-section { margin-bottom: var(--space-2xl); }
-.submit-section h2 { font-size: 1.25rem; font-weight: 700; margin-bottom: var(--space-md); }
+.submit-section h2 {
+  font-size: 1.15rem;
+  font-weight: 700;
+  margin-bottom: var(--space-md);
+  letter-spacing: -0.01em;
+}
+
 .btn {
   display: inline-flex;
   align-items: center;
-  padding: var(--space-sm) var(--space-lg);
+  padding: 0.625rem 1.25rem;
   border-radius: var(--radius-md);
   font-weight: 600;
-  font-size: 0.95rem;
-  transition: all 0.15s;
+  font-size: 0.9rem;
+  transition: all 0.15s ease;
   text-decoration: none;
 }
 .btn-primary { background: var(--color-primary); color: white; }
-.btn-primary:hover { background: var(--color-primary-hover); color: white; text-decoration: none; }
-.btn-secondary { background: var(--color-bg-alt, #f0f0f0); color: var(--color-text); border: 1px solid var(--color-border, #ddd); }
-.btn-secondary:hover { background: var(--color-bg-alt-hover, #e0e0e0); text-decoration: none; }
+.btn-primary:hover { background: var(--color-primary-hover); color: white; text-decoration: none; transform: translateY(-1px); box-shadow: var(--shadow-sm); }
+.btn-secondary { background: transparent; color: var(--color-text); border: 1px solid var(--color-border); }
+.btn-secondary:hover { border-color: var(--color-primary); color: var(--color-primary); text-decoration: none; }
 .submit-methods { display: flex; gap: var(--space-sm); flex-wrap: wrap; }
-.code-block { background: var(--color-bg-alt, #f5f5f5); padding: var(--space-md); border-radius: var(--radius-md); overflow-x: auto; margin: var(--space-sm) 0; }
-.code-block code { font-size: 0.85rem; line-height: 1.6; white-space: pre-wrap; word-break: break-all; }
-.text-muted { color: var(--color-text-muted); font-size: 0.9rem; margin-top: var(--space-sm); }
-.guide-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); gap: var(--space-md); }
-.guide-card h3 { font-size: 1rem; font-weight: 600; margin-bottom: var(--space-sm); }
-.guide-card ul { list-style: none; display: flex; flex-direction: column; gap: var(--space-xs); }
-.guide-card ul li { font-size: 0.9rem; color: var(--color-text-muted); }
-.process-list { display: flex; flex-direction: column; gap: var(--space-md); padding-left: var(--space-lg); }
-.process-list li { font-size: 0.95rem; line-height: 1.6; }
-.notice-box { background: #fff8e1; border-left: 4px solid #f9a825; padding: var(--space-md) var(--space-lg); border-radius: var(--radius-md); margin-bottom: var(--space-xl); }
-.notice-box > strong { display: block; margin-bottom: var(--space-xs); font-size: 1rem; }
-.notice-box p { font-size: 0.9rem; color: var(--color-text-muted); margin: 0; line-height: 1.6; }
+
+/* Agent card */
+.agent-card {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  padding: var(--space-lg) var(--space-xl);
+  background: var(--color-bg);
+}
+.agent-intro {
+  font-size: 1.05rem;
+  font-weight: 600;
+  margin-bottom: var(--space-xs);
+}
+.agent-desc {
+  font-size: 0.875rem;
+  color: var(--color-text-muted);
+  margin-bottom: var(--space-md);
+}
+.agent-prompt {
+  background: #1c1c1e;
+  padding: var(--space-md) var(--space-lg);
+  border-radius: var(--radius-md);
+  margin-bottom: var(--space-md);
+}
+.agent-prompt code {
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  line-height: 1.7;
+  color: #e0e0e0;
+  white-space: pre-wrap;
+  word-break: break-all;
+  user-select: all;
+}
+.agent-guide-link {
+  font-size: 0.85rem;
+  font-weight: 500;
+}
+
+/* Guide grid */
+.guide-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: var(--space-md); }
+.guide-card { padding: var(--space-lg); }
+.guide-card h3 { font-size: 0.95rem; font-weight: 700; margin-bottom: var(--space-sm); }
+.guide-card ul { list-style: none; display: flex; flex-direction: column; gap: 0.375rem; }
+.guide-card ul li { font-size: 0.875rem; color: var(--color-text-muted); }
 .note-inline { font-size: 0.8rem; color: var(--color-primary); margin-top: var(--space-sm); font-weight: 600; }
+
+/* Process list */
+.process-list { display: flex; flex-direction: column; gap: var(--space-md); padding-left: var(--space-lg); }
+.process-list li { font-size: 0.9rem; line-height: 1.7; }
+.process-list li strong { color: var(--color-primary); }
+
+.text-muted { color: var(--color-text-muted); font-size: 0.875rem; margin-top: var(--space-sm); }
 </style>


### PR DESCRIPTION
## Summary
- 기사 상세페이지 내부 링크 네비게이션 복구 (isExternal=false 통일)
- 커뮤니티 기능: 공유 버튼(X/복사/Web Share), 북마크(localStorage), 댓글 수 표시(Giscus API)
- 관련 기사 알고리즘 개선: feeds 포함, 태그 매칭 수 기반 정렬
- 중복 원문보기 버튼 제거, 댓글 CSP 수정, View Transitions 호환