### PR TITLE
fix: Giscus 댓글 View Transitions 네비게이션 시 렌더링 안 되는 버그 수정

### DIFF
--- a/docs/troubleshooting/giscus-view-transitions.md
+++ b/docs/troubleshooting/giscus-view-transitions.md
@@ -57,6 +57,11 @@
 
 Astro View Transitions 환경에서 외부 스크립트를 사용할 때는 `<script src="..." is:inline>`을 직접 사용하지 말고, `astro:page-load` 이벤트 핸들러 내에서 동적으로 `document.createElement('script')`로 생성해야 한다. 기존 코드베이스의 `ArticleCard.astro`, `Navigation.astro` 등이 이 패턴을 따르고 있으므로 참고할 것.
 
+## 관련 문서
+
+- [아키텍처 개요](../architecture/overview.md)
+- [Cloudflare Pages 자동 배포 실패](./cloudflare-pages-auto-deploy-failure.md)
+
 ---
 
 ## 변경 이력

--- a/docs/troubleshooting/giscus-view-transitions.md
+++ b/docs/troubleshooting/giscus-view-transitions.md
@@ -1,0 +1,66 @@
+# Giscus 댓글 View Transitions 네비게이션 시 렌더링 안 됨
+
+> 기사 클릭 시 댓글이 표시되지 않고, 새로고침 후에야 렌더링되는 버그
+
+## 증상
+
+기사 목록에서 기사를 클릭하면 댓글 영역이 비어 있다. 브라우저에서 새로고침(F5)하면 정상적으로 Giscus 댓글이 표시된다.
+
+**재현 조건**:
+1. 메인 페이지 또는 기사 목록 페이지 진입
+2. 기사 카드 클릭 → 기사 상세 페이지 이동
+3. 댓글 섹션이 비어 있음 (Giscus iframe 없음)
+4. F5로 새로고침하면 정상 표시
+
+**재현 환경**: 모든 브라우저 (Astro View Transitions 지원 브라우저)
+
+## 원인
+
+`BaseLayout.astro`에서 `<ClientRouter />`(Astro View Transitions)를 사용하고 있어, 페이지 간 이동 시 전체 페이지 리로드가 아닌 DOM swap이 발생한다.
+
+`Comments.astro`에서 Giscus를 `<script src="https://giscus.app/client.js" is:inline>` 형태로 로드하고 있었는데, 외부 스크립트(`src` 속성)는 View Transitions의 DOM swap 시 브라우저가 재실행하지 않는다. 따라서 클라이언트 네비게이션으로 기사 상세 페이지에 진입하면 Giscus가 초기화되지 않는다.
+
+새로고침 시에는 전체 페이지가 로드되므로 스크립트가 정상 실행되어 댓글이 표시된다.
+
+## 해결 방법
+
+정적 `<script src>` 태그를 제거하고, `astro:page-load` 이벤트에서 동적으로 Giscus 스크립트를 생성·삽입하는 방식으로 전환했다. 이 패턴은 `ArticleCard.astro`의 댓글 수 fetch 등 기존 코드베이스에서 이미 사용 중인 패턴이다.
+
+```diff
+- <script src="https://giscus.app/client.js"
+-     data-repo="orientpine/honeycombo"
+-     ...
+-     is:inline
+- ></script>
++ <div class="giscus"></div>
++
++ <script>
++ document.addEventListener('astro:page-load', () => {
++   const container = document.querySelector('.giscus');
++   if (!container) return;
++   container.innerHTML = '';
++   const script = document.createElement('script');
++   script.src = 'https://giscus.app/client.js';
++   // ... setAttribute로 모든 data 속성 설정
++   container.appendChild(script);
++ });
++ </script>
+```
+
+## 관련 파일
+
+| 파일 | 변경 내용 |
+|------|----------|
+| `src/components/Comments.astro` | 정적 스크립트 → `astro:page-load` 동적 초기화로 전환 |
+
+## 예방 조치
+
+Astro View Transitions 환경에서 외부 스크립트를 사용할 때는 `<script src="..." is:inline>`을 직접 사용하지 말고, `astro:page-load` 이벤트 핸들러 내에서 동적으로 `document.createElement('script')`로 생성해야 한다. 기존 코드베이스의 `ArticleCard.astro`, `Navigation.astro` 등이 이 패턴을 따르고 있으므로 참고할 것.
+
+---
+
+## 변경 이력
+
+| 날짜 | 변경 내용 |
+|------|----------|
+| 2026-04-14 | 최초 작성 |

--- a/src/components/Comments.astro
+++ b/src/components/Comments.astro
@@ -11,22 +11,7 @@ const isConfigured = Boolean(REPO_ID && CATEGORY_ID);
 {isConfigured ? (
   <section class="comments-section" data-testid="comments">
     <h2 class="comments-title">댓글</h2>
-  <script src="https://giscus.app/client.js"
-      data-repo="orientpine/honeycombo"
-      data-repo-id={REPO_ID}
-      data-category="General"
-      data-category-id={CATEGORY_ID}
-      data-mapping="pathname"
-      data-strict="0"
-      data-reactions-enabled="1"
-      data-emit-metadata="0"
-      data-input-position="bottom"
-      data-theme="preferred_color_scheme"
-      data-lang="ko"
-      crossorigin="anonymous"
-      async
-      is:inline
-    ></script>
+    <div class="giscus"></div>
   </section>
 ) : (
   <section class="comments-section" data-testid="comments">
@@ -37,6 +22,34 @@ const isConfigured = Boolean(REPO_ID && CATEGORY_ID);
     </div>
   </section>
 )}
+
+<script>
+document.addEventListener('astro:page-load', () => {
+  const container = document.querySelector('.giscus');
+  if (!container) return;
+
+  // Clear previous Giscus instance
+  container.innerHTML = '';
+
+  const script = document.createElement('script');
+  script.src = 'https://giscus.app/client.js';
+  script.setAttribute('data-repo', 'orientpine/honeycombo');
+  script.setAttribute('data-repo-id', 'R_kgDOR_fpgQ');
+  script.setAttribute('data-category', 'General');
+  script.setAttribute('data-category-id', 'DIC_kwDOR_fpgc4C6lgR');
+  script.setAttribute('data-mapping', 'pathname');
+  script.setAttribute('data-strict', '0');
+  script.setAttribute('data-reactions-enabled', '1');
+  script.setAttribute('data-emit-metadata', '0');
+  script.setAttribute('data-input-position', 'bottom');
+  script.setAttribute('data-theme', 'preferred_color_scheme');
+  script.setAttribute('data-lang', 'ko');
+  script.crossOrigin = 'anonymous';
+  script.async = true;
+
+  container.appendChild(script);
+});
+</script>
 
 <style>
 .comments-section { margin-top: var(--space-2xl); padding-top: var(--space-xl); border-top: 1px solid var(--color-border); }


### PR DESCRIPTION
## Summary

- Giscus 댓글이 기사 클릭 시 렌더링되지 않고 새로고침 후에만 표시되는 버그 수정
- 원인: Astro View Transitions(ClientRouter)에서 외부 `<script src>` + `is:inline`이 클라이언트 네비게이션 시 재실행되지 않음
- 수정: `astro:page-load` 이벤트로 동적 스크립트 생성 방식으로 전환 (ArticleCard 등 기존 패턴과 동일)