### PR TITLE
chore: 미머지 브랜치 통합 — trending 페이지 개선 + submission #9 추가

### DIFF
--- a/docs/features/article-detail-community.md
+++ b/docs/features/article-detail-community.md
@@ -51,6 +51,18 @@
 - **sessionStorage 캐시**: 세션 내 중복 요청 방지
 - 댓글 아이콘 클릭 시 상세페이지 `#comments` 앵커로 이동
 
+### 5. 에디터 추천 뱃지
+
+- `articleOrigin === 'curated'`인 기사에 "에디터 추천" 뱃지 표시
+- `ArticleCard.astro`: SSR 렌더링 카드에 뱃지 적용
+- `TagFilter.astro`: 태그 필터링 시 동적 렌더링 카드에도 동일 뱃지 적용
+
+### 6. 댓글 UI 개선
+
+- 댓글 섹션에 말풍선 아이콘 + "GitHub Discussions" powered-by 라벨 추가
+- `giscus-container` 래퍼로 전환하여 View Transitions 호환성 개선
+- 반응형 헤더 레이아웃 (모바일에서 세로 정렬)
+
 ## 관련 파일
 
 | 파일 | 역할 |
@@ -95,3 +107,4 @@
 | 날짜 | 변경 내용 |
 |------|----------|
 | 2026-04-14 | 최초 작성 |
+| 2026-04-14 | 에디터 추천 뱃지 추가 (ArticleCard, TagFilter), 댓글 UI 개선 (Comments) |

--- a/src/components/ArticleCard.astro
+++ b/src/components/ArticleCard.astro
@@ -32,6 +32,7 @@ const formattedDate = new Date(date).toLocaleDateString('ko-KR', { year: 'numeri
   )}
   <div class="article-body">
     <div class="article-meta">
+      {articleOrigin === 'curated' && <span class="badge badge-curated">에디터 추천</span>}
       <span class="badge">{source}</span>
       {type === 'youtube' && <span class="badge badge-primary">YouTube</span>}
       <time class="article-date" datetime={new Date(date).toISOString()}>{formattedDate}</time>

--- a/src/components/Comments.astro
+++ b/src/components/Comments.astro
@@ -10,12 +10,22 @@ const isConfigured = Boolean(REPO_ID && CATEGORY_ID);
 
 {isConfigured ? (
   <section class="comments-section" data-testid="comments">
-    <h2 class="comments-title">댓글</h2>
-    <div class="giscus"></div>
+    <div class="comments-header">
+      <h2 class="comments-title">
+        <svg class="comments-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="20" height="20" aria-hidden="true">
+          <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"></path>
+        </svg>
+        댓글
+      </h2>
+      <span class="comments-powered">GitHub Discussions</span>
+    </div>
+    <div class="giscus-container"></div>
   </section>
 ) : (
   <section class="comments-section" data-testid="comments">
-    <h2 class="comments-title">댓글</h2>
+    <div class="comments-header">
+      <h2 class="comments-title">댓글</h2>
+    </div>
     <div class="comments-setup-note">
       <p>GitHub Discussions 설정 후 댓글 기능이 활성화됩니다.</p>
       <a href="https://giscus.app" target="_blank" rel="noopener noreferrer">Giscus 설정 →</a>
@@ -24,39 +34,109 @@ const isConfigured = Boolean(REPO_ID && CATEGORY_ID);
 )}
 
 <script>
-document.addEventListener('astro:page-load', () => {
-  const container = document.querySelector('.giscus');
-  if (!container) return;
+  document.addEventListener('astro:page-load', () => {
+    const container = document.querySelector('.giscus-container');
+    if (!container) return;
 
-  // Clear previous Giscus instance
-  container.innerHTML = '';
+    // Clear previous Giscus instance (important for View Transitions navigation)
+    container.innerHTML = '';
 
-  const script = document.createElement('script');
-  script.src = 'https://giscus.app/client.js';
-  script.setAttribute('data-repo', 'orientpine/honeycombo');
-  script.setAttribute('data-repo-id', 'R_kgDOR_fpgQ');
-  script.setAttribute('data-category', 'General');
-  script.setAttribute('data-category-id', 'DIC_kwDOR_fpgc4C6lgR');
-  script.setAttribute('data-mapping', 'pathname');
-  script.setAttribute('data-strict', '0');
-  script.setAttribute('data-reactions-enabled', '1');
-  script.setAttribute('data-emit-metadata', '0');
-  script.setAttribute('data-input-position', 'bottom');
-  script.setAttribute('data-theme', 'preferred_color_scheme');
-  script.setAttribute('data-lang', 'ko');
-  script.crossOrigin = 'anonymous';
-  script.async = true;
-
-  container.appendChild(script);
-});
+    const script = document.createElement('script');
+    script.src = 'https://giscus.app/client.js';
+    script.setAttribute('data-repo', 'orientpine/honeycombo');
+    script.setAttribute('data-repo-id', 'R_kgDOR_fpgQ');
+    script.setAttribute('data-category', 'General');
+    script.setAttribute('data-category-id', 'DIC_kwDOR_fpgc4C6lgR');
+    script.setAttribute('data-mapping', 'pathname');
+    script.setAttribute('data-strict', '0');
+    script.setAttribute('data-reactions-enabled', '1');
+    script.setAttribute('data-emit-metadata', '0');
+    script.setAttribute('data-input-position', 'top');
+    script.setAttribute('data-theme', 'preferred_color_scheme');
+    script.setAttribute('data-lang', 'ko');
+    script.crossOrigin = 'anonymous';
+    script.async = true;
+    container.appendChild(script);
+  });
 </script>
 
 <style>
-.comments-section { margin-top: var(--space-2xl); padding-top: var(--space-xl); border-top: 1px solid var(--color-border); }
-.comments-title { font-size: 1.25rem; font-weight: 700; margin-bottom: var(--space-lg); }
-.comments-section :global(.giscus) { width: 100%; }
-.comments-section :global(.giscus-frame) { width: 100% !important; min-height: 300px; }
-.comments-setup-note { padding: var(--space-md); background: var(--color-bg-secondary); border-radius: var(--radius-md); border: 1px dashed var(--color-border); text-align: center; }
+  .comments-section {
+    margin-top: var(--space-2xl);
+    padding: var(--space-xl);
+    background: var(--color-bg-secondary);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-lg);
+  }
+
+  .comments-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: var(--space-lg);
+    padding-bottom: var(--space-md);
+    border-bottom: 1px solid var(--color-border);
+  }
+
+  .comments-title {
+    display: flex;
+    align-items: center;
+    gap: var(--space-sm);
+    font-size: 1.25rem;
+    font-weight: 700;
+    color: var(--color-text);
+  }
+
+  .comments-icon {
+    color: var(--color-primary);
+    flex-shrink: 0;
+  }
+
+  .comments-powered {
+    font-size: 0.75rem;
+    color: var(--color-text-muted);
+    background: var(--color-bg);
+    padding: 2px var(--space-sm);
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--color-border);
+  }
+
+  .giscus-container :global(.giscus) {
+    width: 100%;
+  }
+
+  .giscus-container :global(.giscus-frame) {
+    width: 100% !important;
+    min-height: 280px;
+    border: none;
+  }
+
+  .comments-setup-note {
+    padding: var(--space-lg);
+    background: var(--color-bg);
+    border-radius: var(--radius-md);
+    border: 1px dashed var(--color-border);
+    text-align: center;
+  }
+
 .comments-setup-note p { color: var(--color-text-muted); font-size: 0.875rem; margin-bottom: var(--space-sm); }
-.comments-setup-note a { font-size: 0.875rem; color: var(--color-primary); }
+
+  .comments-setup-note a {
+    font-size: 0.875rem;
+    color: var(--color-primary);
+    font-weight: 500;
+  }
+
+  @media (max-width: 768px) {
+    .comments-section {
+      padding: var(--space-md);
+      border-radius: var(--radius-md);
+    }
+
+    .comments-header {
+      flex-direction: column;
+      align-items: flex-start;
+      gap: var(--space-xs);
+    }
+  }
 </style>

--- a/src/components/TagFilter.astro
+++ b/src/components/TagFilter.astro
@@ -70,7 +70,9 @@ function renderCard(a: ClientArticle): string {
     ? `<div class="article-thumbnail"><img src="${escapeHtml(a.thumbnail_url)}" alt="" loading="lazy" width="300" height="160" /></div>`
     : '';
 
-  const originBadge = '';
+  const originBadge = a.articleOrigin === 'curated'
+    ? '<span class="badge badge-curated">에디터 추천</span>'
+    : '';
 
   const typeBadge = a.type === 'youtube' ? '<span class="badge badge-primary">YouTube</span>' : '';
 

--- a/src/content/curated/2026/04/submission-9-968e6f51.json
+++ b/src/content/curated/2026/04/submission-9-968e6f51.json
@@ -1,0 +1,17 @@
+{
+  "id": "submission-9-968e6f51",
+  "title": "GeekNews Weekly #353 - 스킬이 쏟아지는 시대, 내 하네스는 내가 만든다. 프롬프트→컨텍스트→하네스 엔지니어링 패러다임 전환과 에이전트 스킬 공유 트렌드 정리",
+  "url": "https://news.hada.io/weekly/202615",
+  "source": "User Submission",
+  "type": "article",
+  "description": "GeekNews Weekly #353 - 스킬이 쏟아지는 시대, 내 하네스는 내가 만든다. 프롬프트→컨텍스트→하네스 엔지니어링 패러다임 전환과 에이전트 스킬 공유 트렌드 정리",
+  "tags": [
+    "ai",
+    "에이전트",
+    "하네스 엔지니어링"
+  ],
+  "submitted_by": "orientpine",
+  "submitted_by_id": "32758428",
+  "submitted_at": "2026-04-13T11:51:44.655Z",
+  "status": "pending"
+}

--- a/src/content/curated/2026/04/submission-9-968e6f51.json
+++ b/src/content/curated/2026/04/submission-9-968e6f51.json
@@ -13,5 +13,5 @@
   "submitted_by": "orientpine",
   "submitted_by_id": "32758428",
   "submitted_at": "2026-04-13T11:51:44.655Z",
-  "status": "pending"
+  "status": "approved"
 }


### PR DESCRIPTION
## Summary

기능 개발이 완료됐으나 master에 머지되지 않았던 브랜치 2개를 통합합니다.

### 머지된 브랜치
- **`feat/trending-mustread-astro-pages`** — trending 페이지 playlist 카드 스타일, 에디터 추천 뱃지, 기사 상세페이지 UI 개선 (댓글 컴포넌트, 커뮤니티 뱃지 로직 통일)
- **`submission/9`** — GeekNews Weekly #353 기사 콘텐츠 추가

### 충돌 해결 (4파일)
- `ArticleCard.astro` — 에디터 추천 뱃지 추가 (branch 채택)
- `Comments.astro` — 아이콘 + GitHub Discussions 라벨 + 개선된 UI (branch 채택)
- `TagFilter.astro` — 동적 렌더링 카드에도 에디터 추천 뱃지 (branch 채택)
- `[...slug].astro` — ShareButtons, BookmarkButton 등 커뮤니티 기능 유지 (master 채택)

### 정리된 브랜치 (이미 master에 반영 완료)
- `fix/article-detail-community-features` (PR #34)
- `fix/submission-english-field-names` (PR #25)
- `feat/submit-agent-oneliner` (master에 개선 버전 존재)
- `fix/remove-origin-badges` (PR #33)
- `cloudflare/workers-autoconfig` (PR #1)
- `submission/4` (테스트 데이터)

빌드 검증 완료 ✅