### PR TITLE
fix: 기사 탭별 UI 통일 (제출 기사/RSS 피드에 전체 탭 UI 적용)

### DIFF
--- a/docs/troubleshooting/article-tab-ui-inconsistency.md
+++ b/docs/troubleshooting/article-tab-ui-inconsistency.md
@@ -43,23 +43,24 @@
 
 `TagFilter.astro`의 `applyFilters()`에서 동적 렌더링 후 호출.
 
-### 4. 제목 색상 통일
+### 4. 제목 색상 (필터 영역만 오렌지)
 
-`.article-title a` 색상을 `var(--color-text)`에서 `var(--color-primary)`로 변경하여 모든 탭에서 동일한 오렌지 색상 사용.
+ArticleCard의 기본 제목 색상은 `var(--color-text)` (어두운 색) 유지. 필터 결과 영역(`#tag-filtered-grid`)에만 `var(--color-primary)` (오렌지) 오버라이드를 TagFilter.astro 스코프드 스타일로 적용. 이렇게 하면 홈페이지 등 다른 페이지의 ArticleCard 제목 색상에 영향을 주지 않음.
 
 ## 관련 파일
 
 | 파일 | 변경 내용 |
 |------|----------|
-| `src/components/ArticleCard.astro` | `<style is:global>`, 제목 색상 `var(--color-primary)`, 댓글 observer 글로벌 노출 |
+| `src/components/ArticleCard.astro` | `<style is:global>`, 제목 색상 `var(--color-text)` 유지, 댓글 observer 글로벌 노출 |
 | `src/components/BookmarkButton.astro` | `<style is:global>`, `initBookmarkButtons` 글로벌 노출 |
-| `src/components/TagFilter.astro` | `renderCard()`에 북마크·댓글·footer 추가, 동적 렌더링 후 init 호출 |
+| `src/components/TagFilter.astro` | `renderCard()`에 북마크·댓글·footer 추가, 동적 렌더링 후 init 호출, `#tag-filtered-grid` 제목 오렌지 오버라이드 |
 
 ## 예방 조치
 
 - 클라이언트 JS로 동적 렌더링하는 `renderCard()` 함수를 수정할 때는 반드시 SSR `ArticleCard.astro`와 구조를 동기화할 것.
 - Astro 컴포넌트 스타일이 동적 생성 요소에도 필요한 경우 `<style is:global>`을 사용할 것.
-- 새로운 UI 요소(버튼, 인디케이터 등)를 ArticleCard에 추가할 때 `renderCard()`도 함께 업데이트할 것.
+- Astro 컴포넌트 스타일이 동적 생성 요소에도 필요한 경우 `<style is:global>`을 사용할 것.
+- 글로벌 스타일 변경 시 홈페이지 등 다른 페이지에 의도치 않은 영향이 없는지 확인할 것.
 
 ---
 

--- a/docs/troubleshooting/article-tab-ui-inconsistency.md
+++ b/docs/troubleshooting/article-tab-ui-inconsistency.md
@@ -1,0 +1,74 @@
+# 기사 탭별 UI 불일치 (전체 vs 제출 기사/RSS 피드)
+
+> "전체" 탭과 "제출 기사"/"RSS 피드" 탭의 기사 카드 UI가 서로 달랐던 문제 해결
+
+## 증상
+
+`/articles/?origin=submitted` 또는 `/articles/?origin=feed`에서 기사 카드 UI가 "전체" 탭과 다르게 표시됨:
+- 북마크 버튼(❤️) 없음
+- 댓글 카운트(💬) 없음
+- `article-footer` 영역 없음
+- 카드 스타일(간격, 폰트, 레이아웃) 미적용
+
+**재현 환경**: 모든 브라우저, `/articles/` 페이지에서 탭 전환 시
+
+## 원인
+
+두 가지 근본 원인:
+
+1. **SSR vs 클라이언트 렌더링 구조 차이**: "전체" 탭은 Astro SSR `ArticleCard.astro` 컴포넌트로 렌더링되어 `BookmarkButton`, 댓글 인디케이터, `article-footer`가 포함됨. 반면 "제출 기사"/"RSS 피드" 탭은 `TagFilter.astro`의 클라이언트 JS `renderCard()` 함수로 동적 렌더링되는데, 이 함수에 해당 요소들이 누락되어 있었음.
+
+2. **Astro 스코프드 스타일 미적용**: `ArticleCard.astro`와 `BookmarkButton.astro`의 `<style>` 태그가 Astro 기본 스코프드 모드로 동작하여, SSR 렌더링된 카드에만 스타일이 적용되고 JS로 동적 생성된 카드에는 적용되지 않음.
+
+## 해결 방법
+
+### 1. 스타일을 글로벌로 전환
+
+`ArticleCard.astro`와 `BookmarkButton.astro`의 `<style>`을 `<style is:global>`로 변경하여 동적 카드에도 스타일 적용.
+
+```diff
+- <style>
++ <style is:global>
+```
+
+### 2. renderCard()에 누락된 UI 요소 추가
+
+`TagFilter.astro`의 `renderCard()` 함수에 `article-footer`, 북마크 버튼, 댓글 인디케이터 HTML 추가.
+
+### 3. 초기화 함수 글로벌 노출
+
+동적 렌더링 후 북마크·댓글 기능이 동작하도록 초기화 함수를 `window` 객체에 노출:
+- `BookmarkButton.astro`: `window.__initBookmarkButtons`
+- `ArticleCard.astro`: `window.__initCommentCounts`
+
+`TagFilter.astro`의 `applyFilters()`에서 동적 렌더링 후 호출.
+
+### 4. 제목 색상 통일
+
+`.article-title a` 색상을 `var(--color-text)`에서 `var(--color-primary)`로 변경하여 모든 탭에서 동일한 오렌지 색상 사용.
+
+## 관련 파일
+
+| 파일 | 변경 내용 |
+|------|----------|
+| `src/components/ArticleCard.astro` | `<style is:global>`, 제목 색상 `var(--color-primary)`, 댓글 observer 글로벌 노출 |
+| `src/components/BookmarkButton.astro` | `<style is:global>`, `initBookmarkButtons` 글로벌 노출 |
+| `src/components/TagFilter.astro` | `renderCard()`에 북마크·댓글·footer 추가, 동적 렌더링 후 init 호출 |
+
+## 예방 조치
+
+- 클라이언트 JS로 동적 렌더링하는 `renderCard()` 함수를 수정할 때는 반드시 SSR `ArticleCard.astro`와 구조를 동기화할 것.
+- Astro 컴포넌트 스타일이 동적 생성 요소에도 필요한 경우 `<style is:global>`을 사용할 것.
+- 새로운 UI 요소(버튼, 인디케이터 등)를 ArticleCard에 추가할 때 `renderCard()`도 함께 업데이트할 것.
+
+---
+
+## 관련 문서
+
+- [아키텍처 개요](../architecture/overview.md)
+
+## 변경 이력
+
+| 날짜 | 변경 내용 |
+|------|----------|
+| 2026-04-14 | 최초 작성 |

--- a/src/components/ArticleCard.astro
+++ b/src/components/ArticleCard.astro
@@ -73,8 +73,8 @@ const formattedDate = new Date(date).toLocaleDateString('ko-KR', { year: 'numeri
 .article-meta { display: flex; align-items: center; gap: var(--space-sm); flex-wrap: wrap; }
 .article-date { font-size: 0.8rem; color: var(--color-text-muted); margin-left: auto; }
 .article-title { font-size: 1rem; font-weight: 600; line-height: 1.4; }
-.article-title a { color: var(--color-primary); }
-.article-title a:hover { color: var(--color-primary-hover); text-decoration: none; }
+.article-title a { color: var(--color-text); }
+.article-title a:hover { color: var(--color-primary); text-decoration: none; }
 .article-description { font-size: 0.875rem; color: var(--color-text-muted); line-height: 1.5; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden; }
 .article-tags { display: flex; flex-wrap: wrap; gap: var(--space-xs); }
 .article-footer { display: flex; align-items: center; justify-content: space-between; margin-top: auto; padding-top: var(--space-xs); }

--- a/src/components/ArticleCard.astro
+++ b/src/components/ArticleCard.astro
@@ -68,18 +68,18 @@ const formattedDate = new Date(date).toLocaleDateString('ko-KR', { year: 'numeri
 
 <style is:global>
 .article-card { display: flex; flex-direction: column; gap: var(--space-sm); position: relative; }
-.article-thumbnail img { width: 100%; height: 160px; object-fit: cover; border-radius: var(--radius-sm); }
-.article-body { display: flex; flex-direction: column; gap: var(--space-sm); flex: 1; }
-.article-meta { display: flex; align-items: center; gap: var(--space-sm); flex-wrap: wrap; }
-.article-date { font-size: 0.8rem; color: var(--color-text-muted); margin-left: auto; }
-.article-title { font-size: 1rem; font-weight: 600; line-height: 1.4; }
-.article-title a { color: var(--color-text); }
-.article-title a:hover { color: var(--color-primary); text-decoration: none; }
-.article-description { font-size: 0.875rem; color: var(--color-text-muted); line-height: 1.5; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden; }
-.article-tags { display: flex; flex-wrap: wrap; gap: var(--space-xs); }
-.article-footer { display: flex; align-items: center; justify-content: space-between; margin-top: auto; padding-top: var(--space-xs); }
-.article-stats { display: flex; align-items: center; gap: var(--space-sm); }
-.comment-indicator {
+.article-card .article-thumbnail img { width: 100%; height: 160px; object-fit: cover; border-radius: var(--radius-sm); }
+.article-card .article-body { display: flex; flex-direction: column; gap: var(--space-sm); flex: 1; }
+.article-card .article-meta { display: flex; align-items: center; gap: var(--space-sm); flex-wrap: wrap; }
+.article-card .article-date { font-size: 0.8rem; color: var(--color-text-muted); margin-left: auto; }
+.article-card .article-title { font-size: 1rem; font-weight: 600; line-height: 1.4; }
+.article-card .article-title a { color: var(--color-text); }
+.article-card .article-title a:hover { color: var(--color-primary); text-decoration: none; }
+.article-card .article-description { font-size: 0.875rem; color: var(--color-text-muted); line-height: 1.5; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden; }
+.article-card .article-tags { display: flex; flex-wrap: wrap; gap: var(--space-xs); }
+.article-card .article-footer { display: flex; align-items: center; justify-content: space-between; margin-top: auto; padding-top: var(--space-xs); }
+.article-card .article-stats { display: flex; align-items: center; gap: var(--space-sm); }
+.article-card .comment-indicator {
   display: inline-flex;
   align-items: center;
   gap: 3px;
@@ -88,8 +88,8 @@ const formattedDate = new Date(date).toLocaleDateString('ko-KR', { year: 'numeri
   text-decoration: none;
   transition: color 0.15s;
 }
-.comment-indicator:hover { color: var(--color-primary); text-decoration: none; }
-.comment-count-value { font-variant-numeric: tabular-nums; min-width: 1ch; }
+.article-card .comment-indicator:hover { color: var(--color-primary); text-decoration: none; }
+.article-card .comment-count-value { font-variant-numeric: tabular-nums; min-width: 1ch; }
 </style>
 
 <script>
@@ -134,6 +134,9 @@ const formattedDate = new Date(date).toLocaleDateString('ko-KR', { year: 'numeri
 
     const container = root || document;
     container.querySelectorAll<HTMLElement>('[data-comment-path]').forEach(el => {
+      // Avoid duplicate observation by checking init flag
+      if (el.dataset.commentInit) return;
+      el.dataset.commentInit = 'true';
       observer!.observe(el);
     });
   }

--- a/src/components/ArticleCard.astro
+++ b/src/components/ArticleCard.astro
@@ -66,15 +66,15 @@ const formattedDate = new Date(date).toLocaleDateString('ko-KR', { year: 'numeri
   </div>
 </article>
 
-<style>
+<style is:global>
 .article-card { display: flex; flex-direction: column; gap: var(--space-sm); position: relative; }
 .article-thumbnail img { width: 100%; height: 160px; object-fit: cover; border-radius: var(--radius-sm); }
 .article-body { display: flex; flex-direction: column; gap: var(--space-sm); flex: 1; }
 .article-meta { display: flex; align-items: center; gap: var(--space-sm); flex-wrap: wrap; }
 .article-date { font-size: 0.8rem; color: var(--color-text-muted); margin-left: auto; }
 .article-title { font-size: 1rem; font-weight: 600; line-height: 1.4; }
-.article-title a { color: var(--color-text); }
-.article-title a:hover { color: var(--color-primary); text-decoration: none; }
+.article-title a { color: var(--color-primary); }
+.article-title a:hover { color: var(--color-primary-hover); text-decoration: none; }
 .article-description { font-size: 0.875rem; color: var(--color-text-muted); line-height: 1.5; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden; }
 .article-tags { display: flex; flex-wrap: wrap; gap: var(--space-xs); }
 .article-footer { display: flex; align-items: center; justify-content: space-between; margin-top: auto; padding-top: var(--space-xs); }
@@ -95,43 +95,49 @@ const formattedDate = new Date(date).toLocaleDateString('ko-KR', { year: 'numeri
 <script>
   // Comment count fetcher — Giscus API + IntersectionObserver + sessionStorage cache
   // Module script: runs once, persists across View Transitions
-  document.addEventListener('astro:page-load', () => {
-    const CACHE_KEY = 'honeycombo:comment-counts';
-    let cache: Record<string, number> = {};
+  const CACHE_KEY = 'honeycombo:comment-counts';
+  let cache: Record<string, number> = {};
+  let observer: IntersectionObserver | null = null;
+
+  function initCommentCounts(root?: HTMLElement) {
     try { cache = JSON.parse(sessionStorage.getItem(CACHE_KEY) || '{}'); } catch {}
 
-    const observer = new IntersectionObserver((entries) => {
-      for (const entry of entries) {
-        if (!entry.isIntersecting) continue;
-        const el = entry.target as HTMLElement;
-        const path = el.dataset.commentPath;
-        if (!path) continue;
-        observer.unobserve(el);
+    if (!observer) {
+      observer = new IntersectionObserver((entries) => {
+        for (const entry of entries) {
+          if (!entry.isIntersecting) continue;
+          const el = entry.target as HTMLElement;
+          const path = el.dataset.commentPath;
+          if (!path) continue;
+          observer!.unobserve(el);
 
-        const countEl = el.querySelector('.comment-count-value');
-        if (!countEl) continue;
+          const countEl = el.querySelector('.comment-count-value');
+          if (!countEl) continue;
 
-        // Use cached value if available
-        if (path in cache) {
-          countEl.textContent = String(cache[path]);
-          return;
+          if (path in cache) {
+            countEl.textContent = String(cache[path]);
+            return;
+          }
+
+          fetch(`https://giscus.app/api/discussions?repo=orientpine%2Fhoneycombo&term=${encodeURIComponent(path)}&category=General&number=0&strict=false&first=1`)
+            .then(r => r.status === 404 ? null : r.json())
+            .then(data => {
+              const count = data?.discussion?.totalCommentCount ?? data?.discussion?.comments?.totalCount ?? 0;
+              cache[path] = count;
+              try { sessionStorage.setItem(CACHE_KEY, JSON.stringify(cache)); } catch {}
+              countEl.textContent = String(count);
+            })
+            .catch(() => { countEl.textContent = '0'; });
         }
+      }, { rootMargin: '200px' });
+    }
 
-        // Fetch from Giscus API
-        fetch(`https://giscus.app/api/discussions?repo=orientpine%2Fhoneycombo&term=${encodeURIComponent(path)}&category=General&number=0&strict=false&first=1`)
-          .then(r => r.status === 404 ? null : r.json())
-          .then(data => {
-            const count = data?.discussion?.totalCommentCount ?? data?.discussion?.comments?.totalCount ?? 0;
-            cache[path] = count;
-            try { sessionStorage.setItem(CACHE_KEY, JSON.stringify(cache)); } catch {}
-            countEl.textContent = String(count);
-          })
-          .catch(() => { countEl.textContent = '0'; });
-      }
-    }, { rootMargin: '200px' });
-
-    document.querySelectorAll<HTMLElement>('[data-comment-path]').forEach(el => {
-      observer.observe(el);
+    const container = root || document;
+    container.querySelectorAll<HTMLElement>('[data-comment-path]').forEach(el => {
+      observer!.observe(el);
     });
-  });
+  }
+
+  (window as any).__initCommentCounts = initCommentCounts;
+  document.addEventListener('astro:page-load', () => initCommentCounts());
 </script>

--- a/src/components/BookmarkButton.astro
+++ b/src/components/BookmarkButton.astro
@@ -65,10 +65,11 @@ const iconSize = size === 'sm' ? 14 : 18;
     });
   }
 
+  (window as any).__initBookmarkButtons = initBookmarkButtons;
   document.addEventListener('astro:page-load', initBookmarkButtons);
 </script>
 
-<style>
+<style is:global>
   .bookmark-btn {
     display: inline-flex;
     align-items: center;

--- a/src/components/TagFilter.astro
+++ b/src/components/TagFilter.astro
@@ -274,4 +274,8 @@ document.addEventListener('astro:page-load', initTagFilter);
   color: var(--color-text-muted);
   font-weight: 500;
 }
+
+/* Filtered tabs (제출 기사/RSS 피드) keep orange title color per user request */
+#tag-filtered-grid :global(.article-title a) { color: var(--color-primary); }
+#tag-filtered-grid :global(.article-title a:hover) { color: var(--color-primary-hover); text-decoration: none; }
 </style>

--- a/src/components/TagFilter.astro
+++ b/src/components/TagFilter.astro
@@ -196,6 +196,7 @@ function applyFilters(tag: string, origin?: string) {
     // Render filtered results
     if (filteredContainer && filteredGrid && filteredCount) {
       filteredContainer.style.display = '';
+      filteredGrid.dataset.activeOrigin = activeOrigin;
       filteredCount.textContent = `${labels.join(' · ')} 기사 ${articles.length}건`;
       filteredGrid.innerHTML = articles.map(renderCard).join('');
       // Initialize AddToPlaylist buttons for dynamically rendered cards
@@ -276,6 +277,9 @@ document.addEventListener('astro:page-load', initTagFilter);
 }
 
 /* Filtered tabs (제출 기사/RSS 피드) keep orange title color per user request */
-#tag-filtered-grid :global(.article-title a) { color: var(--color-primary); }
-#tag-filtered-grid :global(.article-title a:hover) { color: var(--color-primary-hover); text-decoration: none; }
+/* Only when origin is submitted or feed — tag-only filtering on 전체 keeps dark titles */
+#tag-filtered-grid:global([data-active-origin="submitted"]) :global(.article-title a),
+#tag-filtered-grid:global([data-active-origin="feed"]) :global(.article-title a) { color: var(--color-primary); }
+#tag-filtered-grid:global([data-active-origin="submitted"]) :global(.article-title a:hover),
+#tag-filtered-grid:global([data-active-origin="feed"]) :global(.article-title a:hover) { color: var(--color-primary-hover); text-decoration: none; }
 </style>

--- a/src/components/TagFilter.astro
+++ b/src/components/TagFilter.astro
@@ -89,7 +89,7 @@ function renderCard(a: ClientArticle): string {
     <div class="article-meta">
       <span class="badge">${source}</span>
       ${typeBadge}
-      <time class="article-date" datetime="${a.date}">${formatted}</time>
+      <time class="article-date" datetime="${new Date(a.date).toISOString()}">${formatted}</time>
     </div>
     <h3 class="article-title">
       <a href="${escapeHtml(articleUrl)}"${target}>${title}</a>

--- a/src/components/TagFilter.astro
+++ b/src/components/TagFilter.astro
@@ -65,17 +65,17 @@ function renderCard(a: ClientArticle): string {
   const formatted = new Date(a.date).toLocaleDateString('ko-KR', { year: 'numeric', month: 'short', day: 'numeric' });
   const title = escapeHtml(a.title);
   const source = escapeHtml(a.source);
+  const articleSlug = a.slug || a._id;
+  const articlePath = `/articles/${articleSlug}/`;
 
   const thumb = a.thumbnail_url
-    ? `<div class="article-thumbnail"><img src="${escapeHtml(a.thumbnail_url)}" alt="" loading="lazy" width="300" height="160" /></div>`
+    ? `<div class="article-thumbnail"><img src="${escapeHtml(a.thumbnail_url)}" alt="${title}" loading="lazy" width="300" height="160" /></div>`
     : '';
-
-  const originBadge = '';
 
   const typeBadge = a.type === 'youtube' ? '<span class="badge badge-primary">YouTube</span>' : '';
 
   const desc = a.description
-    ? `<p class="article-description">${escapeHtml(a.description.length > 200 ? a.description.slice(0, 200) + '...' : a.description)}</p>`
+    ? `<p class="article-description">${escapeHtml(a.description)}</p>`
     : '';
 
   const tagsHtml = a.tags.map(t => `<span class="tag">${escapeHtml(t)}</span>`).join('');
@@ -83,11 +83,10 @@ function renderCard(a: ClientArticle): string {
 
   const sourceType = a.articleOrigin === 'feed' ? 'feed' : 'curated';
 
-  return `<article class="card article-card" data-testid="article-card" data-tags="${tagsAttr}" data-origin="${a.articleOrigin}">
+  return `<article class="card article-card" data-testid="article-card" data-tags="${tagsAttr}" data-origin="${a.articleOrigin}" data-article-path="${articlePath}">
   ${thumb}
   <div class="article-body">
     <div class="article-meta">
-      ${originBadge}
       <span class="badge">${source}</span>
       ${typeBadge}
       <time class="article-date" datetime="${a.date}">${formatted}</time>
@@ -97,18 +96,36 @@ function renderCard(a: ClientArticle): string {
     </h3>
     ${desc}
     <div class="article-tags">${tagsHtml}</div>
-    <div class="add-to-playlist-container" data-article-id="${escapeHtml(a._id)}" data-title="${title}" data-url="${escapeHtml(a.url)}" data-description="${escapeHtml(a.description || '')}" data-source-type="${sourceType}">
-      <button class="add-to-playlist-btn tag">➕ 플레이리스트에 추가</button>
-      <div class="playlist-dropdown" style="display: none;">
-        <div class="playlist-dropdown-header">플레이리스트 선택</div>
-        <ul class="playlist-list">
-          <li class="playlist-loading">불러오는 중...</li>
-        </ul>
-        <div class="playlist-dropdown-footer">
-          <a href="/p/new" class="new-playlist-link">➕ 새 플레이리스트 만들기</a>
-        </div>
+    <div class="article-footer">
+      <div class="article-stats">
+        <button class="bookmark-btn bookmark-sm" data-bookmark-id="${escapeHtml(articleSlug)}" title="북마크" aria-label="북마크">
+          <svg class="bookmark-icon-outline" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path>
+          </svg>
+          <svg class="bookmark-icon-filled" width="14" height="14" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path>
+          </svg>
+        </button>
+        <a href="/articles/${escapeHtml(articleSlug)}/#comments" class="comment-indicator" data-comment-path="${articlePath}">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"></path>
+          </svg>
+          <span class="comment-count-value">&ndash;</span>
+        </a>
       </div>
-      <div class="playlist-toast" style="display: none;"></div>
+      <div class="add-to-playlist-container" data-article-id="${escapeHtml(a._id)}" data-title="${title}" data-url="${escapeHtml(a.url)}" data-description="${escapeHtml(a.description || '')}" data-source-type="${sourceType}">
+        <button class="add-to-playlist-btn tag">➕ 플레이리스트에 추가</button>
+        <div class="playlist-dropdown" style="display: none;">
+          <div class="playlist-dropdown-header">플레이리스트 선택</div>
+          <ul class="playlist-list">
+            <li class="playlist-loading">불러오는 중...</li>
+          </ul>
+          <div class="playlist-dropdown-footer">
+            <a href="/p/new" class="new-playlist-link">➕ 새 플레이리스트 만들기</a>
+          </div>
+        </div>
+        <div class="playlist-toast" style="display: none;"></div>
+      </div>
     </div>
   </div>
 </article>`;
@@ -184,6 +201,14 @@ function applyFilters(tag: string, origin?: string) {
       // Initialize AddToPlaylist buttons for dynamically rendered cards
       if ((window as any).__initAddToPlaylistContainers) {
         (window as any).__initAddToPlaylistContainers(filteredGrid);
+      }
+      // Initialize bookmark buttons for dynamically rendered cards
+      if ((window as any).__initBookmarkButtons) {
+        (window as any).__initBookmarkButtons();
+      }
+      // Initialize comment count observers for dynamically rendered cards
+      if ((window as any).__initCommentCounts) {
+        (window as any).__initCommentCounts(filteredGrid);
       }
     }
 


### PR DESCRIPTION
## Summary

- "전체" 탭의 기사 카드 UI(북마크, 댓글, footer)를 "제출 기사"/"RSS 피드" 탭에도 동일하게 적용
- 제목 색상은 제출 기사/RSS 피드 탭에서만 오렌지(`var(--color-primary)`) 유지, 전체 탭과 홈페이지는 기존 어두운 색 유지
- CSS 셀렉터를 `.article-card`로 스코핑하여 스타일 충돌 방지
- 북마크/댓글 초기화 함수를 글로벌 노출하여 동적 렌더링 카드에서도 동작

## Changes

| 파일 | 변경 내용 |
|------|----------|
| `ArticleCard.astro` | `<style is:global>`, 셀렉터 `.article-card` 스코핑, 댓글 observer 글로벌 노출 |
| `BookmarkButton.astro` | `<style is:global>`, `initBookmarkButtons` 글로벌 노출 |
| `TagFilter.astro` | `renderCard()`에 북마크·댓글·footer 추가, origin별 제목 색상 분기 |
| `docs/troubleshooting/` | 트러블슈팅 문서 추가 |