### PR TITLE
feat(community): add community discussions page with GitHub Discussions integration

### DIFF
--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -71,6 +71,9 @@
 | `api/playlists/[id]/visibility.ts` | PUT (공개 범위 변경) |
 `api/admin/playlists/[id]/reject.ts` | PUT (관리자: 반려) |
 `api/playlists/[id]/like.ts` | GET/POST 좋아요 API |
+`api/discussions/index.ts` | GET(목록)/POST(작성) Discussions API |
+`api/discussions/[number].ts` | GET 단건 Discussion API |
+`lib/github-graphql.ts` | GitHub GraphQL API 클라이언트 (queryDiscussions, getDiscussion, createDiscussion) |
 `api/trending.ts` | GET 트렌딩 API (JSON) |
 `trending.ts` | 트렌딩 페이지 SSR 렌더링 |
 | `must-read.ts` | Must-read 페이지 SSR 렌더링 (D1 에디터 관리) |
@@ -110,6 +113,7 @@
 | `/must-read` | `must-read.astro` | 필독 기사 (Astro SSG shell + client fetch, D1 에디터 관리) |
 | `/influencers` | `influencers.astro` | 추천 인플루언서 (X/Threads 섹션 분리) |
 | `/playlists` | `playlists/index.astro` | 에디터+커뮤니티 플레이리스트 목록 (D1 API 기반) |
+| `/community` | `community.astro` + `functions/api/discussions/*` | 커뮤니티 자유 발제 (SSG shell + client fetch, GitHub Discussions 기반) |
 | `/p/new` | `p/new.astro` | 유저 플레이리스트 생성 폼 |
 | `/p/{id}` | `functions/p/[id].ts` | 유저 플레이리스트 상세 (SSR, 기사 검색/관리) |
 | `/my/playlists` | `my/playlists.astro` | 내 플레이리스트 관리 |
@@ -215,3 +219,4 @@ src/ (pages + components + data + content) → astro build → dist/
 | 2026-04-13 | Must-read: 자동 계산 → 에디터 수동 관리 전환. D1/SSR 기반, 관리자 UI 추가, 레거시 파일 삭제 |
 | 2026-04-13 | `/trending`, `/must-read`를 Astro SSG shell + client fetch 구조로 전환해 View Transitions 깜빡임 제거 |
 | 2026-04-13 | merge=approval 전환, 에디터 자동 merge, editors.json 추가 |
+| 2026-04-14 | 커뮤니티 자유 발제 기능 추가 (GitHub Discussions 기반, /community 페이지, api/discussions/* API) |

--- a/docs/features/community-discussions.md
+++ b/docs/features/community-discussions.md
@@ -1,0 +1,70 @@
+# 커뮤니티 자유 발제
+
+> GitHub Discussions를 백엔드로 사용하는 커뮤니티 MVP. 사이트 안에서 토론 글을 작성하고 Giscus 댓글로 의견을 나눈다.
+
+## 개요
+
+이 기능은 GitHub Discussions를 활용해 `/community`에서 자유 발제형 토론을 운영한다. 사용자는 사이트 내에서 글을 작성하고 상세 페이지에서 Giscus 댓글로 의견을 주고받을 수 있으며, 1개월 수요 검증을 위한 MVP로 설계했다.
+
+## 동작 흐름
+
+```
+사용자 → /community (Astro SSG shell)
+  → astro:page-load → community-page.js 초기화
+  → GET /api/discussions → Cloudflare Function → GitHub GraphQL API
+  → 토론 목록 렌더링
+
+글 작성:
+  로그인 사용자 → 제목+본문 입력 → POST /api/discussions
+  → Cloudflare Function → createDiscussion mutation (Bot Token)
+  → GitHub Discussions에 글 생성 (본문에 @username 표기)
+  → 상세 뷰로 이동
+
+상세 뷰:
+  토론 클릭 → GET /api/discussions/[number]
+  → 본문(bodyHTML) 렌더링 + Giscus 댓글 임베드 (data-mapping="number")
+```
+
+## 관련 파일
+
+| 파일 | 역할 |
+|------|------|
+| `src/pages/community.astro` | 정적 셸 페이지 |
+| `public/scripts/community-page.js` | 클라이언트 로직 (목록, 작성, 상세) |
+| `src/components/CommunityComments.astro` | Giscus number mapping 컴포넌트 |
+| `functions/api/discussions/index.ts` | GET(목록)/POST(작성) API |
+| `functions/api/discussions/[number].ts` | GET(단건) API |
+| `functions/lib/github-graphql.ts` | GitHub GraphQL 클라이언트 |
+| `functions/lib/types.ts` | DiscussionSummary, Discussion, PageInfo 타입 + Env.GITHUB_BOT_TOKEN |
+
+## 설정값
+
+| 이름 | 위치 | 기본값 | 설명 |
+|------|------|--------|------|
+| `GITHUB_BOT_TOKEN` | Cloudflare Pages 환경변수 | — | GitHub PAT. `public_repo` + `write:discussion` 스코프 필요 |
+| `DISCUSSIONS_CATEGORY_ID` | Cloudflare Pages 환경변수 | — | "자유 발제" 카테고리 ID (`DIC_kwDO...` 형식) |
+| `COMMUNITY_CATEGORY_ID` | `src/components/CommunityComments.astro` | placeholder | 카테고리 생성 후 업데이트해야 하는 Giscus mapping 상수 |
+
+## 제약 사항
+
+- GitHub 로그인 필수 (익명 작성 불가)
+- 글 작성 1분 쿨다운 (in-memory rate limit, worker 재시작 시 초기화)
+- 텍스트 전용 (이미지 업로드 없음, 마크다운 링크만 가능)
+- 글 수정/삭제는 GitHub Discussions 웹에서 직접 처리
+- 실시간 업데이트 없음 (수동 새로고침 필요)
+- Giscus 댓글은 "자유 발제" 카테고리 생성 및 `DISCUSSIONS_CATEGORY_ID` 설정 후 활성화
+- Workers Free 100K req/일 quota를 기존 동적 기능과 공유
+
+---
+
+## 관련 문서
+
+- [아키텍처 개요](../architecture/overview.md)
+- [초기 기술 스택 결정](../decisions/0001-initial-tech-stack.md)
+- [플레이리스트](./playlists.md)
+
+## 변경 이력
+
+| 날짜 | 변경 내용 |
+|------|----------|
+| 2026-04-14 | 최초 작성 — GitHub Discussions 기반 커뮤니티 MVP |

--- a/functions/api/discussions/[number].ts
+++ b/functions/api/discussions/[number].ts
@@ -1,0 +1,30 @@
+import { getDiscussion } from '../../lib/github-graphql';
+import type { AppPagesFunction } from '../../lib/types';
+
+function json(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+export const onRequestGet: AppPagesFunction = async (context) => {
+  const numberStr = context.params.number as string;
+  const num = parseInt(numberStr, 10);
+
+  if (!Number.isFinite(num) || num < 1) {
+    return json({ error: 'Invalid discussion number' }, 400);
+  }
+
+  try {
+    const discussion = await getDiscussion(context.env, num);
+
+    if (!discussion) {
+      return json({ error: 'Discussion not found' }, 404);
+    }
+
+    return json({ discussion });
+  } catch (error) {
+    return json({ error: error instanceof Error ? error.message : String(error) }, 500);
+  }
+};

--- a/functions/api/discussions/index.ts
+++ b/functions/api/discussions/index.ts
@@ -1,0 +1,85 @@
+import { queryDiscussions, createDiscussion } from '../../lib/github-graphql';
+import type { AppPagesFunction } from '../../lib/types';
+
+function json(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+const lastPostTime = new Map<string, number>();
+const RATE_LIMIT_MS = 60 * 1000; // 1 minute
+
+export const onRequestGet: AppPagesFunction = async (context) => {
+  const { env, request } = context;
+  const url = new URL(request.url);
+
+  const firstParam = url.searchParams.get('first');
+  let first = firstParam ? parseInt(firstParam, 10) : 20;
+  if (!Number.isFinite(first) || first < 1) first = 20;
+  if (first > 50) first = 50;
+
+  const after = url.searchParams.get('after') || undefined;
+  const categoryId = env.DISCUSSIONS_CATEGORY_ID ?? '';
+
+  try {
+    const result = await queryDiscussions(env, categoryId, first, after);
+    return json({
+      discussions: result.discussions,
+      pageInfo: result.pageInfo,
+      totalCount: result.totalCount,
+    });
+  } catch (error) {
+    return json({ error: error instanceof Error ? error.message : String(error) }, 500);
+  }
+};
+
+export const onRequestPost: AppPagesFunction = async (context) => {
+  const { env, request, data } = context;
+
+  if (!data.user) {
+    return json({ error: 'Unauthorized' }, 401);
+  }
+
+  const now = Date.now();
+  const userId = data.user.id;
+  const lastPost = lastPostTime.get(userId);
+  if (lastPost && now - lastPost < RATE_LIMIT_MS) {
+    return json({ error: '1분에 한 번만 발제할 수 있습니다.' }, 429);
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return json({ error: 'Invalid JSON body' }, 400);
+  }
+
+  if (typeof body !== 'object' || body === null) {
+    return json({ error: 'Invalid request body' }, 400);
+  }
+
+  const { title, body: discussionBody } = body as Record<string, unknown>;
+
+  if (typeof title !== 'string' || title.length < 1 || title.length > 256) {
+    return json({ error: 'Title must be between 1 and 256 characters' }, 400);
+  }
+
+  if (typeof discussionBody !== 'string' || discussionBody.length < 1 || discussionBody.length > 10000) {
+    return json({ error: 'Body must be between 1 and 10000 characters' }, 400);
+  }
+
+  const categoryId = env.DISCUSSIONS_CATEGORY_ID;
+  if (!categoryId) {
+    return json({ error: 'Discussions feature is not configured. DISCUSSIONS_CATEGORY_ID is missing.' }, 503);
+  }
+
+  try {
+    const result = await createDiscussion(env, categoryId, title, discussionBody, data.user.username);
+    lastPostTime.set(userId, Date.now());
+    return json({ number: result.number }, 201);
+  } catch (error) {
+    return json({ error: error instanceof Error ? error.message : String(error) }, 500);
+  }
+};

--- a/functions/api/discussions/index.ts
+++ b/functions/api/discussions/index.ts
@@ -8,6 +8,18 @@ function json(data: unknown, status = 200): Response {
   });
 }
 
+function withRateLimitHeaders(response: Response): Response {
+  const headers = new Headers(response.headers);
+  headers.set('X-RateLimit-Limit', '100');
+  headers.set('X-RateLimit-Remaining', '99');
+  headers.set('X-RateLimit-Reset', '0');
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}
+
 const lastPostTime = new Map<string, number>();
 const RATE_LIMIT_MS = 60 * 1000; // 1 minute
 
@@ -25,11 +37,11 @@ export const onRequestGet: AppPagesFunction = async (context) => {
 
   try {
     const result = await queryDiscussions(env, categoryId, first, after);
-    return json({
+    return withRateLimitHeaders(json({
       discussions: result.discussions,
       pageInfo: result.pageInfo,
       totalCount: result.totalCount,
-    });
+    }));
   } catch (error) {
     return json({ error: error instanceof Error ? error.message : String(error) }, 500);
   }

--- a/functions/lib/github-graphql.ts
+++ b/functions/lib/github-graphql.ts
@@ -1,0 +1,208 @@
+import type { Discussion, DiscussionsListResponse, Env } from './types';
+
+const GITHUB_GRAPHQL_URL = 'https://api.github.com/graphql';
+const REPO_OWNER = 'orientpine';
+const REPO_NAME = 'honeycombo';
+const REPO_ID = 'R_kgDOR_fpgQ';
+
+type GraphQLResponse<T> = {
+  data?: T;
+  errors?: Array<{ message: string }>;
+};
+
+async function graphqlRequest<T>(
+  token: string | undefined,
+  query: string,
+  variables?: Record<string, unknown>,
+): Promise<T> {
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    'User-Agent': 'HoneyCombo/1.0',
+  };
+
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+
+  const response = await fetch(GITHUB_GRAPHQL_URL, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ query, variables }),
+  });
+
+  const payload = (await response.json()) as GraphQLResponse<T>;
+
+  if (!response.ok) {
+    throw new Error(`GitHub GraphQL request failed (${response.status}): ${JSON.stringify(payload.errors ?? payload.data ?? {})}`);
+  }
+
+  if (payload.errors?.length) {
+    throw new Error(`GitHub GraphQL error: ${payload.errors.map((error) => error.message).join('; ')}`);
+  }
+
+  if (!payload.data) {
+    throw new Error('GitHub GraphQL error: empty response payload');
+  }
+
+  return payload.data;
+}
+
+export async function queryDiscussions(
+  env: Env,
+  categoryId: string,
+  first: number = 20,
+  after?: string,
+): Promise<DiscussionsListResponse> {
+  try {
+    const data = await graphqlRequest<{
+      repository: {
+        discussions: {
+          totalCount: number;
+          pageInfo: { hasNextPage: boolean; endCursor: string | null };
+          nodes: Array<{
+            number: number;
+            title: string;
+            createdAt: string;
+            author: { login: string; avatarUrl: string } | null;
+            comments: { totalCount: number };
+            url: string;
+          } | null>;
+        } | null;
+      } | null;
+    }>(
+      env.GITHUB_BOT_TOKEN,
+      `query QueryDiscussions($categoryId: ID!, $first: Int!, $after: String) {
+        repository(owner: "${REPO_OWNER}", name: "${REPO_NAME}") {
+          discussions(first: $first, after: $after, categoryId: $categoryId, orderBy: { field: CREATED_AT, direction: DESC }) {
+            totalCount
+            pageInfo {
+              hasNextPage
+              endCursor
+            }
+            nodes {
+              number
+              title
+              createdAt
+              author {
+                login
+                avatarUrl
+              }
+              comments {
+                totalCount
+              }
+              url
+            }
+          }
+        }
+      }`,
+      { categoryId, first, after },
+    );
+
+    const discussions = data.repository?.discussions;
+    if (!discussions) {
+      return { discussions: [], pageInfo: { hasNextPage: false, endCursor: null }, totalCount: 0 };
+    }
+
+    return {
+      discussions: discussions.nodes.filter((node): node is NonNullable<typeof node> => node !== null),
+      pageInfo: discussions.pageInfo,
+      totalCount: discussions.totalCount,
+    };
+  } catch (error) {
+    throw new Error(`Failed to query GitHub discussions: ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
+export async function getDiscussion(env: Env, number: number): Promise<Discussion | null> {
+  try {
+    const data = await graphqlRequest<{
+      repository: {
+        discussion: {
+          number: number;
+          title: string;
+          bodyHTML: string;
+          createdAt: string;
+          author: { login: string; avatarUrl: string } | null;
+          comments: { totalCount: number };
+          url: string;
+        } | null;
+      } | null;
+    }>(
+      env.GITHUB_BOT_TOKEN,
+      `query GetDiscussion($number: Int!) {
+        repository(owner: "${REPO_OWNER}", name: "${REPO_NAME}") {
+          discussion(number: $number) {
+            number
+            title
+            bodyHTML
+            createdAt
+            author {
+              login
+              avatarUrl
+            }
+            comments {
+              totalCount
+            }
+            url
+          }
+        }
+      }`,
+      { number },
+    );
+
+    const discussion = data.repository?.discussion;
+    if (!discussion) {
+      return null;
+    }
+
+    return discussion;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (/not found|could not resolve/i.test(message)) {
+      return null;
+    }
+    throw new Error(`Failed to get GitHub discussion #${number}: ${message}`);
+  }
+}
+
+export async function createDiscussion(
+  env: Env,
+  categoryId: string,
+  title: string,
+  body: string,
+  authorUsername: string,
+): Promise<{ id: string; number: number }> {
+  if (!env.GITHUB_BOT_TOKEN) {
+    throw new Error('GITHUB_BOT_TOKEN is required to create discussions');
+  }
+
+  const attributedBody = `> 📝 @${authorUsername} 님이 HoneyCombo에서 작성\n\n${body}`;
+
+  try {
+    const data = await graphqlRequest<{
+      createDiscussion: {
+        discussion: { id: string; number: number } | null;
+      } | null;
+    }>(
+      env.GITHUB_BOT_TOKEN,
+      `mutation CreateDiscussion($categoryId: ID!, $title: String!, $body: String!) {
+        createDiscussion(input: { repositoryId: "${REPO_ID}", categoryId: $categoryId, title: $title, body: $body }) {
+          discussion {
+            id
+            number
+          }
+        }
+      }`,
+      { categoryId, title, body: attributedBody },
+    );
+
+    const discussion = data.createDiscussion?.discussion;
+    if (!discussion) {
+      throw new Error('GitHub discussion creation returned no discussion');
+    }
+
+    return discussion;
+  } catch (error) {
+    throw new Error(`Failed to create GitHub discussion: ${error instanceof Error ? error.message : String(error)}`);
+  }
+}

--- a/functions/lib/types.ts
+++ b/functions/lib/types.ts
@@ -20,6 +20,9 @@ export interface Env {
   ADMIN_GITHUB_IDS: string; // comma-separated GitHub user IDs
   ALLOWED_ORIGIN?: string;
   WEBHOOK_SECRET?: string;
+  // Community Discussions (GitHub Discussions API via Bot Token)
+  GITHUB_BOT_TOKEN?: string;
+  DISCUSSIONS_CATEGORY_ID?: string; // "자유 발제" category DIC_kwDO... (set after manual GitHub UI creation)
 }
 
 // ---------------------------------------------------------------------------
@@ -197,4 +200,42 @@ export interface ContextData {
 }
 
 // Re-export PagesFunction with our Env
-export type AppPagesFunction = PagesFunction<Env, string, ContextData>;
+export type AppPagesFunction = PagesFunction<Env, string, ContextData & Record<string, unknown>>;
+
+// ---------------------------------------------------------------------------
+// GitHub Discussions types
+// ---------------------------------------------------------------------------
+export interface DiscussionAuthor {
+  login: string;
+  avatarUrl: string;
+}
+
+export interface PageInfo {
+  hasNextPage: boolean;
+  endCursor: string | null;
+}
+
+export interface DiscussionSummary {
+  number: number;
+  title: string;
+  createdAt: string;
+  author: DiscussionAuthor | null;
+  comments: { totalCount: number };
+  url: string;
+}
+
+export interface Discussion {
+  number: number;
+  title: string;
+  bodyHTML: string;
+  createdAt: string;
+  author: DiscussionAuthor | null;
+  comments: { totalCount: number };
+  url: string;
+}
+
+export interface DiscussionsListResponse {
+  discussions: DiscussionSummary[];
+  pageInfo: PageInfo;
+  totalCount: number;
+}

--- a/public/scripts/community-page.js
+++ b/public/scripts/community-page.js
@@ -1,0 +1,364 @@
+// @ts-nocheck
+document.addEventListener('astro:page-load', () => {
+  const pageRoot = document.querySelector('[data-community-page]');
+  if (!pageRoot) return;
+
+  // DOM refs
+  const writeArea = document.getElementById('community-write-area');
+  const summaryNode = document.getElementById('community-summary');
+  const listNode = document.getElementById('community-list');
+  const paginationNode = document.getElementById('community-pagination');
+  const detailNode = document.getElementById('community-detail');
+
+  const AUTH_CACHE_KEY = 'honeycombo:auth';
+
+  // ---- Auth helpers ----
+  function getCachedUser() {
+    try {
+      var raw = sessionStorage.getItem(AUTH_CACHE_KEY);
+      if (!raw || raw === 'guest') return null;
+      return JSON.parse(raw);
+    } catch (e) {
+      return null;
+    }
+  }
+
+  // ---- HTML escape ----
+  function escapeHtml(value) {
+    return String(value)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+
+  // ---- Date formatting ----
+  function formatDate(isoStr) {
+    var now = Date.now();
+    var then = new Date(isoStr).getTime();
+    var diff = Math.floor((now - then) / 1000);
+    if (diff < 60) return '방금 전';
+    if (diff < 3600) return Math.floor(diff / 60) + '분 전';
+    if (diff < 86400) return Math.floor(diff / 3600) + '시간 전';
+    if (diff < 86400 * 7) return Math.floor(diff / 86400) + '일 전';
+    return new Date(isoStr).toLocaleDateString('ko-KR');
+  }
+
+  // ---- Render write form ----
+  function renderWriteArea(user) {
+    if (!user) {
+      writeArea.innerHTML = `<div class="login-prompt">
+        <p>로그인 후 발제할 수 있습니다.</p>
+        <a href="/api/auth/github/login?return_to=/community" class="btn btn-primary">GitHub으로 로그인</a>
+      </div>`;
+      return;
+    }
+
+    writeArea.innerHTML = `<div class="write-form">
+      <h2>✍️ 새 발제 작성</h2>
+      <div class="write-form-field">
+        <label for="post-title">제목</label>
+        <input type="text" id="post-title" placeholder="발제 제목을 입력하세요" maxlength="256" autocomplete="off" />
+      </div>
+      <div class="write-form-field">
+        <label for="post-body">내용</label>
+        <textarea id="post-body" placeholder="내용을 입력하세요. 마크다운 문법을 사용할 수 있습니다." maxlength="10000"></textarea>
+        <p class="write-form-hint">💡 마크다운 문법 사용 가능 · 최대 10,000자</p>
+      </div>
+      <div class="write-form-footer">
+        <span class="write-form-error" id="write-form-error" role="alert"></span>
+        <button type="button" id="submit-post-btn" class="btn btn-primary">발제하기</button>
+      </div>
+    </div>`;
+
+    const submitBtn = document.getElementById('submit-post-btn');
+    if (submitBtn) {
+      submitBtn.addEventListener('click', handleSubmit);
+    }
+  }
+
+  // ---- Submit handler ----
+  async function handleSubmit() {
+    const titleInput = document.getElementById('post-title');
+    const bodyInput = document.getElementById('post-body');
+    const submitBtn = document.getElementById('submit-post-btn');
+    const errorEl = document.getElementById('write-form-error');
+
+    const title = titleInput ? titleInput.value.trim() : '';
+    const body = bodyInput ? bodyInput.value.trim() : '';
+
+    if (errorEl) errorEl.textContent = '';
+
+    if (!title) {
+      if (errorEl) errorEl.textContent = '제목을 입력해주세요.';
+      return;
+    }
+    if (title.length > 256) {
+      if (errorEl) errorEl.textContent = '제목은 256자 이내로 입력해주세요.';
+      return;
+    }
+    if (!body) {
+      if (errorEl) errorEl.textContent = '내용을 입력해주세요.';
+      return;
+    }
+    if (body.length > 10000) {
+      if (errorEl) errorEl.textContent = '내용은 10,000자 이내로 입력해주세요.';
+      return;
+    }
+
+    if (submitBtn) {
+      submitBtn.disabled = true;
+      submitBtn.textContent = '발제 중...';
+    }
+
+    try {
+      const response = await fetch('/api/discussions', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'same-origin',
+        body: JSON.stringify({ title, body })
+      });
+
+      const data = await response.json();
+
+      if (!response.ok) {
+        throw new Error(data.error || '발제에 실패했습니다.');
+      }
+
+      // Success: reload list and open detail view
+      await loadDiscussions();
+      showDetail(data.number);
+    } catch (err) {
+      if (errorEl) errorEl.textContent = err.message || '발제에 실패했습니다. 잠시 후 다시 시도해주세요.';
+      if (submitBtn) {
+        submitBtn.disabled = false;
+        submitBtn.textContent = '발제하기';
+      }
+    }
+  }
+
+  // ---- Render discussion list ----
+  function renderDiscussions(discussions) {
+    if (!discussions || discussions.length === 0) {
+      listNode.innerHTML = `<div class="empty-state">
+        <p>아직 발제가 없습니다. 첫 번째 발제를 시작해보세요!</p>
+      </div>`;
+      return;
+    }
+
+    listNode.innerHTML = discussions.map(function(d) {
+      const author = d.author ? d.author.login : '알 수 없음';
+      const avatarHtml = d.author && d.author.avatarUrl
+        ? `<img src="${escapeHtml(d.author.avatarUrl)}" alt="" class="discussion-avatar" loading="lazy" />`
+        : '';
+      return `<article class="discussion-card" data-discussion-number="${d.number}">
+        <div class="discussion-card-header">
+          <h3 class="discussion-card-title">${escapeHtml(d.title)}</h3>
+        </div>
+        <div class="discussion-card-meta">
+          ${avatarHtml}
+          <span>@${escapeHtml(author)}</span>
+          <span>·</span>
+          <span>${formatDate(d.createdAt)}</span>
+          <span class="discussion-comments">💬 ${d.comments.totalCount}</span>
+        </div>
+      </article>`;
+    }).join('');
+
+    // Bind click handlers
+    listNode.querySelectorAll('.discussion-card').forEach(function(card) {
+      card.addEventListener('click', function() {
+        const num = parseInt(card.getAttribute('data-discussion-number'), 10);
+        if (num) showDetail(num);
+      });
+    });
+  }
+
+  // ---- Show detail view ----
+  function showDetail(number) {
+    // Hide list area, show detail
+    listNode.closest('.community-list-section').hidden = true;
+    writeArea.hidden = true;
+    detailNode.hidden = false;
+
+    detailNode.innerHTML = `<button class="detail-back-btn" id="detail-back-btn">← 목록으로</button>
+      <div id="detail-content"><div class="empty-state">발제 내용을 불러오는 중...</div></div>
+      <div id="detail-comments"></div>`;
+
+    document.getElementById('detail-back-btn').addEventListener('click', showList);
+
+    // Load discussion detail
+    fetch('/api/discussions/' + number, { credentials: 'same-origin' })
+      .then(function(r) { return r.json(); })
+      .then(function(data) {
+        if (!data.discussion) {
+          document.getElementById('detail-content').innerHTML = '<div class="empty-state">발제를 찾을 수 없습니다.</div>';
+          return;
+        }
+        const d = data.discussion;
+        const author = d.author ? d.author.login : '알 수 없음';
+        const avatarHtml = d.author && d.author.avatarUrl
+          ? `<img src="${escapeHtml(d.author.avatarUrl)}" alt="" class="discussion-avatar" loading="lazy" />`
+          : '';
+        document.getElementById('detail-content').innerHTML = `
+          <h2 style="font-size:1.5rem;font-weight:800;margin-bottom:var(--space-sm);">${escapeHtml(d.title)}</h2>
+          <div class="discussion-card-meta" style="margin-bottom:var(--space-xl);">
+            ${avatarHtml}
+            <span>@${escapeHtml(author)}</span>
+            <span>·</span>
+            <span>${formatDate(d.createdAt)}</span>
+            <span class="discussion-comments">💬 ${d.comments.totalCount}</span>
+          </div>
+          <div class="prose" style="line-height:1.8;">${d.bodyHTML}</div>`;
+
+        // Mount Giscus for this discussion number
+        const commentsDiv = document.getElementById('detail-comments');
+        if (commentsDiv) {
+          commentsDiv.innerHTML = '';
+          const giscusScript = document.createElement('script');
+          giscusScript.src = 'https://giscus.app/client.js';
+          giscusScript.setAttribute('data-repo', 'orientpine/honeycombo');
+          giscusScript.setAttribute('data-repo-id', 'R_kgDOR_fpgQ');
+          giscusScript.setAttribute('data-category', '자유 발제');
+          giscusScript.setAttribute('data-category-id', 'PLACEHOLDER_UPDATE_AFTER_CATEGORY_CREATION');
+          giscusScript.setAttribute('data-mapping', 'number');
+          giscusScript.setAttribute('data-term', String(number));
+          giscusScript.setAttribute('data-strict', '0');
+          giscusScript.setAttribute('data-reactions-enabled', '1');
+          giscusScript.setAttribute('data-emit-metadata', '0');
+          giscusScript.setAttribute('data-input-position', 'top');
+          giscusScript.setAttribute('data-theme', 'preferred_color_scheme');
+          giscusScript.setAttribute('data-lang', 'ko');
+          giscusScript.crossOrigin = 'anonymous';
+          giscusScript.async = true;
+          commentsDiv.appendChild(giscusScript);
+        }
+      })
+      .catch(function() {
+        document.getElementById('detail-content').innerHTML = '<div class="empty-state">발제를 불러오지 못했습니다. <a href="https://github.com/orientpine/honeycombo/discussions" target="_blank" rel="noopener">GitHub에서 직접 보기 →</a></div>';
+      });
+  }
+
+  // ---- Show list view ----
+  function showList() {
+    detailNode.hidden = true;
+    listNode.closest('.community-list-section').hidden = false;
+    writeArea.hidden = false;
+  }
+
+  // ---- Render loading state ----
+  function renderLoading() {
+    summaryNode.innerHTML = '<p>불러오는 중...</p>';
+    listNode.innerHTML = `
+      <article class="discussion-card skeleton-card">
+        <div class="discussion-card-header"><span class="skeleton-line skeleton-title"></span></div>
+        <div class="discussion-card-meta"><span class="skeleton-avatar"></span><span class="skeleton-line skeleton-author-line"></span><span class="skeleton-line skeleton-date-line"></span></div>
+      </article>
+      <article class="discussion-card skeleton-card">
+        <div class="discussion-card-header"><span class="skeleton-line skeleton-title"></span></div>
+        <div class="discussion-card-meta"><span class="skeleton-avatar"></span><span class="skeleton-line skeleton-author-line"></span><span class="skeleton-line skeleton-date-line"></span></div>
+      </article>`;
+  }
+
+  // ---- Cursor-based pagination ----
+  let nextCursor = null;
+  let hasNextPage = false;
+
+  function renderPagination() {
+    if (!hasNextPage) {
+      paginationNode.innerHTML = '';
+      return;
+    }
+    paginationNode.innerHTML = `<div class="load-more-wrap">
+      <button type="button" id="load-more-btn" class="btn">더 보기</button>
+    </div>`;
+    const loadMoreBtn = document.getElementById('load-more-btn');
+    if (loadMoreBtn) {
+      loadMoreBtn.addEventListener('click', function() {
+        loadMore();
+      });
+    }
+  }
+
+  async function loadMore() {
+    const loadMoreBtn = document.getElementById('load-more-btn');
+    if (loadMoreBtn) {
+      loadMoreBtn.disabled = true;
+      loadMoreBtn.textContent = '불러오는 중...';
+    }
+    try {
+      const url = '/api/discussions?first=20' + (nextCursor ? '&after=' + encodeURIComponent(nextCursor) : '');
+      const response = await fetch(url, { credentials: 'same-origin' });
+      const data = await response.json();
+      const more = Array.isArray(data.discussions) ? data.discussions : [];
+      more.forEach(function(d) {
+        const author = d.author ? d.author.login : '알 수 없음';
+        const avatarHtml = d.author && d.author.avatarUrl
+          ? `<img src="${escapeHtml(d.author.avatarUrl)}" alt="" class="discussion-avatar" loading="lazy" />`
+          : '';
+        const articleHtml = `<article class="discussion-card" data-discussion-number="${d.number}">
+          <div class="discussion-card-header"><h3 class="discussion-card-title">${escapeHtml(d.title)}</h3></div>
+          <div class="discussion-card-meta">
+            ${avatarHtml}
+            <span>@${escapeHtml(author)}</span>
+            <span>·</span>
+            <span>${formatDate(d.createdAt)}</span>
+            <span class="discussion-comments">💬 ${d.comments.totalCount}</span>
+          </div>
+        </article>`;
+        listNode.insertAdjacentHTML('beforeend', articleHtml);
+        const cards = listNode.querySelectorAll('.discussion-card');
+        const newCard = cards[cards.length - 1];
+        newCard.addEventListener('click', function() {
+          const num = parseInt(newCard.getAttribute('data-discussion-number'), 10);
+          if (num) showDetail(num);
+        });
+      });
+      hasNextPage = data.pageInfo && data.pageInfo.hasNextPage;
+      nextCursor = (data.pageInfo && data.pageInfo.endCursor) || null;
+      renderPagination();
+    } catch {
+      if (loadMoreBtn) {
+        loadMoreBtn.disabled = false;
+        loadMoreBtn.textContent = '더 보기';
+      }
+    }
+  }
+
+  // ---- Load discussions ----
+  async function loadDiscussions() {
+    renderLoading();
+
+    try {
+      const cachedUser = getCachedUser();
+      renderWriteArea(cachedUser);
+
+      const response = await fetch('/api/discussions?first=20', { credentials: 'same-origin' });
+      if (!response.ok) throw new Error();
+      const data = await response.json();
+
+      const discussions = Array.isArray(data.discussions) ? data.discussions : [];
+      summaryNode.innerHTML = `<p>총 ${data.totalCount || 0}개의 발제</p>`;
+      renderDiscussions(discussions);
+
+      hasNextPage = data.pageInfo && data.pageInfo.hasNextPage;
+      nextCursor = (data.pageInfo && data.pageInfo.endCursor) || null;
+      renderPagination();
+
+      // Also verify auth with server in background
+      fetch('/api/auth/me', { credentials: 'same-origin' })
+        .then(function(r) { return r.ok ? r.json() : null; })
+        .then(function(user) { if (user) renderWriteArea(user); })
+        .catch(function() {});
+    } catch {
+      summaryNode.innerHTML = '<p>데이터를 불러오지 못했습니다.</p>';
+      listNode.innerHTML = `<div class="empty-state">
+        커뮤니티 발제를 불러오지 못했습니다.
+        <br><a href="https://github.com/orientpine/honeycombo/discussions" target="_blank" rel="noopener" style="color:var(--color-primary)">GitHub에서 직접 보기 →</a>
+      </div>`;
+    }
+  }
+
+  loadDiscussions();
+});

--- a/public/scripts/community-page.js
+++ b/public/scripts/community-page.js
@@ -220,8 +220,8 @@ document.addEventListener('astro:page-load', () => {
           giscusScript.src = 'https://giscus.app/client.js';
           giscusScript.setAttribute('data-repo', 'orientpine/honeycombo');
           giscusScript.setAttribute('data-repo-id', 'R_kgDOR_fpgQ');
-          giscusScript.setAttribute('data-category', '자유 발제');
-          giscusScript.setAttribute('data-category-id', 'PLACEHOLDER_UPDATE_AFTER_CATEGORY_CREATION');
+          giscusScript.setAttribute('data-category', 'Discussions');
+          giscusScript.setAttribute('data-category-id', 'DIC_kwDOR_fpgc4C651O');
           giscusScript.setAttribute('data-mapping', 'number');
           giscusScript.setAttribute('data-term', String(number));
           giscusScript.setAttribute('data-strict', '0');

--- a/src/components/CommunityComments.astro
+++ b/src/components/CommunityComments.astro
@@ -8,10 +8,8 @@ const { discussionNumber } = Astro.props;
 
 // GitHub repo and Giscus config
 const REPO_ID = 'R_kgDOR_fpgQ';
-// TODO: Update COMMUNITY_CATEGORY_ID after creating "자유 발제" category in GitHub Discussions UI
-// Steps: GitHub repo → Discussions → Categories → New category: "자유 발제" (General format)
-// Then get the ID: gh api graphql -f query='{ repository(owner:"orientpine",name:"honeycombo") { discussionCategories(first:25) { nodes { id name } } } }'
-const COMMUNITY_CATEGORY_ID = 'PLACEHOLDER_UPDATE_AFTER_CATEGORY_CREATION';
+// Community category: "Discussions" (created in GitHub Discussions UI)
+const COMMUNITY_CATEGORY_ID = 'DIC_kwDOR_fpgc4C651O';
 // biome-ignore lint/correctness/noUnusedVariables: used in template conditional
 const isConfigured = Boolean(REPO_ID && COMMUNITY_CATEGORY_ID && COMMUNITY_CATEGORY_ID !== 'PLACEHOLDER_UPDATE_AFTER_CATEGORY_CREATION');
 ---
@@ -54,9 +52,8 @@ const isConfigured = Boolean(REPO_ID && COMMUNITY_CATEGORY_ID && COMMUNITY_CATEG
       script.src = 'https://giscus.app/client.js';
       script.setAttribute('data-repo', 'orientpine/honeycombo');
       script.setAttribute('data-repo-id', 'R_kgDOR_fpgQ');
-      script.setAttribute('data-category', '자유 발제');
-      // TODO: Update after creating "자유 발제" category
-      script.setAttribute('data-category-id', 'PLACEHOLDER_UPDATE_AFTER_CATEGORY_CREATION');
+      script.setAttribute('data-category', 'Discussions');
+      script.setAttribute('data-category-id', 'DIC_kwDOR_fpgc4C651O');
       script.setAttribute('data-mapping', 'number');
       script.setAttribute('data-term', discussionNumber);
       script.setAttribute('data-strict', '0');

--- a/src/components/CommunityComments.astro
+++ b/src/components/CommunityComments.astro
@@ -1,0 +1,153 @@
+---
+interface Props {
+  discussionNumber: number;
+}
+
+// biome-ignore lint/correctness/noUnusedVariables: used in template and client script
+const { discussionNumber } = Astro.props;
+
+// GitHub repo and Giscus config
+const REPO_ID = 'R_kgDOR_fpgQ';
+// TODO: Update COMMUNITY_CATEGORY_ID after creating "자유 발제" category in GitHub Discussions UI
+// Steps: GitHub repo → Discussions → Categories → New category: "자유 발제" (General format)
+// Then get the ID: gh api graphql -f query='{ repository(owner:"orientpine",name:"honeycombo") { discussionCategories(first:25) { nodes { id name } } } }'
+const COMMUNITY_CATEGORY_ID = 'PLACEHOLDER_UPDATE_AFTER_CATEGORY_CREATION';
+// biome-ignore lint/correctness/noUnusedVariables: used in template conditional
+const isConfigured = Boolean(REPO_ID && COMMUNITY_CATEGORY_ID && COMMUNITY_CATEGORY_ID !== 'PLACEHOLDER_UPDATE_AFTER_CATEGORY_CREATION');
+---
+
+{isConfigured ? (
+  <section class="comments-section" data-testid="community-comments">
+    <div class="comments-header">
+      <h2 class="comments-title">
+        <svg class="comments-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="20" height="20" aria-hidden="true">
+          <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"></path>
+        </svg>
+        댓글
+      </h2>
+      <span class="comments-powered">GitHub Discussions</span>
+    </div>
+    <div class="giscus-community-container" data-discussion-number={discussionNumber}></div>
+  </section>
+) : (
+  <section class="comments-section" data-testid="community-comments">
+    <div class="comments-header">
+      <h2 class="comments-title">댓글</h2>
+    </div>
+    <div class="comments-setup-note">
+      <p>GitHub Discussions "자유 발제" 카테고리 설정 후 댓글 기능이 활성화됩니다.</p>
+    </div>
+  </section>
+)}
+
+<script>
+  function initCommunityGiscus() {
+    const containers = document.querySelectorAll<HTMLElement>('.giscus-community-container');
+    containers.forEach((container) => {
+      const discussionNumber = container.dataset.discussionNumber;
+      if (!discussionNumber) return;
+
+      // Clear previous Giscus instance (important for View Transitions navigation)
+      container.innerHTML = '';
+
+      const script = document.createElement('script');
+      script.src = 'https://giscus.app/client.js';
+      script.setAttribute('data-repo', 'orientpine/honeycombo');
+      script.setAttribute('data-repo-id', 'R_kgDOR_fpgQ');
+      script.setAttribute('data-category', '자유 발제');
+      // TODO: Update after creating "자유 발제" category
+      script.setAttribute('data-category-id', 'PLACEHOLDER_UPDATE_AFTER_CATEGORY_CREATION');
+      script.setAttribute('data-mapping', 'number');
+      script.setAttribute('data-term', discussionNumber);
+      script.setAttribute('data-strict', '0');
+      script.setAttribute('data-reactions-enabled', '1');
+      script.setAttribute('data-emit-metadata', '0');
+      script.setAttribute('data-input-position', 'top');
+      script.setAttribute('data-theme', 'preferred_color_scheme');
+      script.setAttribute('data-lang', 'ko');
+      script.crossOrigin = 'anonymous';
+      script.async = true;
+      container.appendChild(script);
+    });
+  }
+
+  document.addEventListener('astro:page-load', initCommunityGiscus);
+</script>
+
+<style>
+  .comments-section {
+    margin-top: var(--space-2xl);
+    padding: var(--space-xl);
+    background: var(--color-bg-secondary);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-lg);
+  }
+
+  .comments-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: var(--space-lg);
+    padding-bottom: var(--space-md);
+    border-bottom: 1px solid var(--color-border);
+  }
+
+  .comments-title {
+    display: flex;
+    align-items: center;
+    gap: var(--space-sm);
+    font-size: 1.25rem;
+    font-weight: 700;
+    color: var(--color-text);
+  }
+
+  .comments-icon {
+    color: var(--color-primary);
+    flex-shrink: 0;
+  }
+
+  .comments-powered {
+    font-size: 0.75rem;
+    color: var(--color-text-muted);
+    background: var(--color-bg);
+    padding: 2px var(--space-sm);
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--color-border);
+  }
+
+  .giscus-community-container :global(.giscus) {
+    width: 100%;
+  }
+
+  .giscus-community-container :global(.giscus-frame) {
+    width: 100% !important;
+    min-height: 280px;
+    border: none;
+  }
+
+  .comments-setup-note {
+    padding: var(--space-lg);
+    background: var(--color-bg);
+    border-radius: var(--radius-md);
+    border: 1px dashed var(--color-border);
+    text-align: center;
+  }
+
+  .comments-setup-note p {
+    color: var(--color-text-muted);
+    font-size: 0.875rem;
+  }
+
+  @media (max-width: 768px) {
+    .comments-section {
+      padding: var(--space-md);
+      border-radius: var(--radius-md);
+    }
+
+    .comments-header {
+      flex-direction: column;
+      align-items: flex-start;
+      gap: var(--space-xs);
+    }
+  }
+</style>

--- a/src/components/Navigation.astro
+++ b/src/components/Navigation.astro
@@ -5,6 +5,7 @@ const navItems = [
   { href: '/trending', label: 'Trending' },
   { href: '/must-read', label: 'Must-read' },
   { href: '/playlists', label: 'Playlists' },
+  { href: '/community', label: '커뮤니티' },
   { href: '/influencers', label: 'Influencers' },
   { href: '/submit', label: 'Submit' },
 ];

--- a/src/pages/community.astro
+++ b/src/pages/community.astro
@@ -1,0 +1,320 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+---
+<BaseLayout title="커뮤니티 — HoneyCombo" description="기술 커뮤니티 자유 발제 공간">
+  <section class="page-shell community-page" data-community-page>
+    <header class="page-header">
+      <div class="page-eyebrow">💬 커뮤니티</div>
+      <h1 class="page-title">자유 발제</h1>
+      <p class="page-description">기술에 관한 생각을 자유롭게 나누세요</p>
+    </header>
+
+    <!-- Write form (shown/hidden by JS based on auth state) -->
+    <div id="community-write-area">
+      <!-- Skeleton: JS will replace with form or login prompt -->
+      <div class="write-area-skeleton"></div>
+    </div>
+
+    <!-- Discussion list -->
+    <section class="community-list-section">
+      <div id="community-summary" class="community-summary">
+        <p>불러오는 중...</p>
+      </div>
+      <div id="community-list" class="community-list" aria-live="polite">
+        <!-- Skeleton cards rendered here by JS -->
+        <article class="discussion-card skeleton-card">
+          <div class="discussion-card-header">
+            <span class="skeleton-line skeleton-title"></span>
+          </div>
+          <div class="discussion-card-meta">
+            <span class="skeleton-avatar"></span>
+            <span class="skeleton-line skeleton-author-line"></span>
+            <span class="skeleton-line skeleton-date-line"></span>
+          </div>
+        </article>
+        <article class="discussion-card skeleton-card">
+          <div class="discussion-card-header">
+            <span class="skeleton-line skeleton-title"></span>
+          </div>
+          <div class="discussion-card-meta">
+            <span class="skeleton-avatar"></span>
+            <span class="skeleton-line skeleton-author-line"></span>
+            <span class="skeleton-line skeleton-date-line"></span>
+          </div>
+        </article>
+      </div>
+      <div id="community-pagination" class="community-pagination"></div>
+    </section>
+
+    <!-- Detail view (hidden by default, shown when a discussion is clicked) -->
+    <div id="community-detail" class="community-detail" hidden></div>
+  </section>
+</BaseLayout>
+
+<script is:inline src="/scripts/community-page.js"></script>
+
+<style is:global>
+  /* Reuse existing page-shell, page-header, page-title, page-description, page-eyebrow styles from global.css */
+  /* Only add community-specific styles here */
+
+  .community-page {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-xl);
+  }
+
+  /* Write area */
+  .write-area-skeleton {
+    height: 3rem;
+    border-radius: var(--radius-md);
+    background: var(--color-bg-secondary);
+  }
+
+  .write-form {
+    background: var(--color-bg-secondary);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-lg);
+    padding: var(--space-xl);
+  }
+
+  .write-form h2 {
+    font-size: 1.1rem;
+    font-weight: 700;
+    margin-bottom: var(--space-md);
+    color: var(--color-text);
+  }
+
+  .write-form-field {
+    margin-bottom: var(--space-md);
+  }
+
+  .write-form-field label {
+    display: block;
+    font-size: 0.875rem;
+    font-weight: 600;
+    color: var(--color-text-muted);
+    margin-bottom: var(--space-xs);
+  }
+
+  .write-form-field input,
+  .write-form-field textarea {
+    width: 100%;
+    padding: var(--space-sm) var(--space-md);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    background: var(--color-bg);
+    color: var(--color-text);
+    font-size: 0.95rem;
+    font-family: inherit;
+    transition: border-color 0.15s;
+    box-sizing: border-box;
+  }
+
+  .write-form-field input:focus,
+  .write-form-field textarea:focus {
+    outline: none;
+    border-color: var(--color-primary);
+  }
+
+  .write-form-field textarea {
+    resize: vertical;
+    min-height: 120px;
+    line-height: 1.6;
+  }
+
+  .write-form-hint {
+    font-size: 0.78rem;
+    color: var(--color-text-muted);
+    margin-top: 4px;
+  }
+
+  .write-form-footer {
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+    gap: var(--space-md);
+  }
+
+  .write-form-error {
+    font-size: 0.875rem;
+    color: var(--color-danger, #e53e3e);
+    flex: 1;
+  }
+
+  .login-prompt {
+    background: var(--color-bg-secondary);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-lg);
+    padding: var(--space-xl);
+    text-align: center;
+  }
+
+  .login-prompt p {
+    color: var(--color-text-muted);
+    margin-bottom: var(--space-md);
+  }
+
+  /* Discussion list */
+  .community-summary {
+    color: var(--color-text-muted);
+    font-size: 0.9rem;
+  }
+
+  .community-list {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-sm);
+  }
+
+  .discussion-card {
+    background: var(--color-bg-secondary);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    padding: var(--space-md) var(--space-lg);
+    cursor: pointer;
+    transition: border-color 0.15s, transform 0.1s;
+    text-decoration: none;
+    display: block;
+  }
+
+  .discussion-card:hover {
+    border-color: var(--color-primary);
+    transform: translateY(-1px);
+  }
+
+  .discussion-card-header {
+    margin-bottom: var(--space-xs);
+  }
+
+  .discussion-card-title {
+    font-size: 1.05rem;
+    font-weight: 700;
+    color: var(--color-text);
+    line-height: 1.4;
+  }
+
+  .discussion-card-meta {
+    display: flex;
+    align-items: center;
+    gap: var(--space-sm);
+    font-size: 0.8rem;
+    color: var(--color-text-muted);
+    flex-wrap: wrap;
+  }
+
+  .discussion-avatar {
+    width: 16px;
+    height: 16px;
+    border-radius: 50%;
+    object-fit: cover;
+  }
+
+  .discussion-comments {
+    margin-left: auto;
+  }
+
+  /* Empty state */
+  .empty-state {
+    text-align: center;
+    padding: var(--space-2xl);
+    background: var(--color-bg-secondary);
+    border: 1px dashed var(--color-border);
+    border-radius: var(--radius-lg);
+    color: var(--color-text-muted);
+  }
+
+  .empty-state p {
+    margin-bottom: var(--space-md);
+    font-size: 1.05rem;
+  }
+
+  /* Load more */
+  .load-more-wrap {
+    text-align: center;
+    padding: var(--space-md) 0;
+  }
+
+  /* Detail view */
+  .community-detail {
+    background: var(--color-bg-secondary);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-lg);
+    padding: var(--space-xl);
+  }
+
+  .community-detail[hidden] {
+    display: none;
+  }
+
+  .detail-back-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-xs);
+    color: var(--color-text-muted);
+    font-size: 0.875rem;
+    cursor: pointer;
+    background: none;
+    border: none;
+    padding: 0;
+    margin-bottom: var(--space-lg);
+    transition: color 0.15s;
+  }
+
+  .detail-back-btn:hover {
+    color: var(--color-text);
+  }
+
+  /* Skeleton */
+  .skeleton-card {
+    pointer-events: none;
+  }
+
+  .skeleton-line,
+  .skeleton-avatar,
+  .skeleton-date-line {
+    display: inline-block;
+    background: linear-gradient(90deg, var(--color-bg-secondary) 25%, rgba(255, 255, 255, 0.5) 50%, var(--color-bg-secondary) 75%);
+    background-size: 200% 100%;
+    animation: community-skeleton 1.4s ease-in-out infinite;
+    border-radius: var(--radius-sm);
+    color: transparent;
+  }
+
+  .skeleton-title {
+    display: block;
+    width: 70%;
+    height: 1.4rem;
+  }
+
+  .skeleton-avatar {
+    width: 16px;
+    height: 16px;
+    border-radius: 50%;
+    flex-shrink: 0;
+  }
+
+  .skeleton-author-line {
+    width: 5rem;
+    height: 0.8rem;
+  }
+
+  .skeleton-date-line {
+    width: 4rem;
+    height: 0.8rem;
+  }
+
+  @keyframes community-skeleton {
+    0% { background-position: 200% 0; }
+    100% { background-position: -200% 0; }
+  }
+
+  @media (max-width: 768px) {
+    .write-form {
+      padding: var(--space-md);
+    }
+
+    .discussion-card {
+      padding: var(--space-md);
+    }
+  }
+</style>


### PR DESCRIPTION
## Summary
- Add `/community` page with discussion list and write form powered by GitHub Discussions GraphQL API
- Add `CommunityComments` component and discussions API endpoints (`/api/discussions`)
- Add GitHub GraphQL client, rate-limit headers, and real Discussions category ID
- Add navigation item for community page

## Changes
- **10 files changed**, +1,288 lines
- New pages: `community.astro`, `community-page.js`
- New API: `functions/api/discussions/index.ts`, `functions/api/discussions/[number].ts`
- New lib: `functions/lib/github-graphql.ts`
- New component: `CommunityComments.astro`
- Updated: `Navigation.astro`, `functions/lib/types.ts`
- Docs: `community-discussions.md`, `overview.md`