### PR TITLE
refactor: 전 페이지 제목 구조를 통일된 2단 구성으로 표준화

### DIFF
--- a/docs/decisions/0004-page-title-standardization.md
+++ b/docs/decisions/0004-page-title-standardization.md
@@ -1,0 +1,72 @@
+# 0004: 전 페이지 제목 구조 표준화 (2단 구성)
+
+> 상태: **승인**
+
+## 맥락
+
+사이트 내 페이지별 제목 구조가 일관되지 않았다.
+
+- **패턴 A** (trending, community, must-read): `page-eyebrow` + `page-title` (h1) + `page-description` — 3단 구성
+- **패턴 B** (articles, playlists, influencers 등): 일반 `h1` + `page-subtitle` — 2단 구성, 작은 폰트
+- 각 페이지가 인라인 `<style>`에 동일한 `.page-header`, `.page-subtitle` 스타일을 중복 정의
+
+이로 인해 페이지 간 시각적 통일감이 부족하고, 스타일 변경 시 모든 파일을 개별 수정해야 하는 유지보수 문제가 있었다.
+
+## 결정
+
+1. **2단 구성으로 통일**: 모든 페이지(home 제외)의 제목을 `h1.page-title` + `p.page-description` 2단 구조로 표준화
+2. **page-eyebrow 제거**: trending, community, must-read에서 작은 글씨 부제목(eyebrow) 삭제
+3. **공통 스타일을 global.css로 통합**: `.page-shell`, `.page-header`, `.page-title`, `.page-description` 스타일을 `src/styles/global.css`에 정의하고, 각 페이지의 중복 인라인 스타일 제거
+4. **반응형 폰트**: `clamp(2rem, 4vw, 2.75rem)`로 모든 페이지의 제목 크기 통일
+5. **max-width: 720px**: 모든 `.page-header`에 적용하여 제목 영역의 가독성 확보 (flex-between 레이아웃은 예외)
+
+## 고려한 대안
+
+### 대안 1: page-eyebrow를 모든 페이지에 추가 (3단 구성)
+
+- 장점: 카테고리 라벨로 사용 가능
+- 단점: 정보 중복 (eyebrow와 h1이 같은 텍스트), 시각적 노이즈 증가
+- 탈락 사유: 유저가 eyebrow 제거를 명시적으로 요청
+
+### 대안 2: 공유 컴포넌트(PageHeader.astro) 생성
+
+- 장점: HTML 구조도 중앙 관리 가능
+- 단점: props 인터페이스 설계 필요, submit의 notice-box 등 특수 케이스 처리 복잡
+- 탈락 사유: CSS 클래스 통일만으로 충분하며, 과도한 추상화 방지
+
+## 결과
+
+- **시각적 통일**: 모든 페이지가 동일한 2단 제목 구조 사용
+- **코드 간소화**: 13개 파일에서 총 130줄의 중복 인라인 스타일 제거, 64줄의 공통 스타일 추가 (순 66줄 감소)
+- **유지보수 개선**: 제목 스타일 변경 시 global.css 한 곳만 수정하면 됨
+
+## 관련 파일
+
+- `src/styles/global.css` — 공통 page-header 스타일 정의
+- `src/pages/trending.astro` — eyebrow 제거, 인라인 스타일 정리
+- `src/pages/community.astro` — eyebrow 제거
+- `src/pages/must-read.astro` — eyebrow 제거, 인라인 스타일 정리
+- `src/pages/articles/index.astro` — 구조 통일
+- `src/pages/articles/page/[...page].astro` — 구조 통일
+- `src/pages/playlists/index.astro` — 구조 통일
+- `src/pages/influencers.astro` — 구조 통일
+- `src/pages/submit.astro` — 구조 통일
+- `src/pages/my/playlists.astro` — 구조 통일 (flex-between 유지)
+- `src/pages/p/new.astro` — 구조 통일
+- `src/pages/admin/must-read.astro` — 구조 통일
+- `src/pages/admin/playlists.astro` — 구조 통일
+- `functions/trending.ts` — SSR 폴백의 eyebrow 제거
+- `functions/must-read.ts` — SSR 폴백의 eyebrow 제거
+
+---
+
+## 관련 문서
+
+- [트렌딩 플레이리스트](../features/trending-playlists.md)
+- [Must-read 관리](../features/must-read-management.md)
+
+## 변경 이력
+
+| 날짜 | 변경 내용 |
+|------|----------|
+| 2026-04-16 | 최초 작성 |

--- a/docs/decisions/0004-page-title-standardization.md
+++ b/docs/decisions/0004-page-title-standardization.md
@@ -14,7 +14,7 @@
 
 ## 결정
 
-1. **2단 구성으로 통일**: 모든 페이지(home 제외)의 제목을 `h1.page-title` + `p.page-description` 2단 구조로 표준화
+1. **2단 구성으로 통일**: 모든 섹션 페이지(home, 콘텐츠 상세 페이지 제외)의 제목을 `h1.page-title` + `p.page-description` 2단 구조로 표준화
 2. **page-eyebrow 제거**: trending, community, must-read에서 작은 글씨 부제목(eyebrow) 삭제
 3. **공통 스타일을 global.css로 통합**: `.page-shell`, `.page-header`, `.page-title`, `.page-description` 스타일을 `src/styles/global.css`에 정의하고, 각 페이지의 중복 인라인 스타일 제거
 4. **반응형 폰트**: `clamp(2rem, 4vw, 2.75rem)`로 모든 페이지의 제목 크기 통일
@@ -36,9 +36,10 @@
 
 ## 결과
 
-- **시각적 통일**: 모든 페이지가 동일한 2단 제목 구조 사용
+- **시각적 통일**: 모든 섹션 페이지가 동일한 2단 제목 구조 사용
 - **코드 간소화**: 13개 파일에서 총 130줄의 중복 인라인 스타일 제거, 64줄의 공통 스타일 추가 (순 66줄 감소)
 - **유지보수 개선**: 제목 스타일 변경 시 global.css 한 곳만 수정하면 됨
+- **적용 범위**: 섹션/목록 페이지에 적용. 콘텐츠 상세 페이지(`articles/[...slug].astro`)는 개별 기사 제목과 메타데이터를 표시하는 별도 구조(`article-detail-title` + `ArticleMeta`)를 유지
 
 ## 관련 파일
 

--- a/functions/must-read.ts
+++ b/functions/must-read.ts
@@ -46,14 +46,6 @@ const PAGE_STYLES = `
         max-width: 720px;
       }
 
-      .page-eyebrow {
-        display: inline-flex;
-        align-items: center;
-        gap: var(--space-xs);
-        margin-bottom: var(--space-sm);
-        color: var(--color-primary);
-        font-weight: 700;
-      }
 
       .page-title {
         font-size: clamp(2rem, 4vw, 2.75rem);
@@ -106,7 +98,6 @@ export const onRequest: AppPagesFunction = async (context: { env: Env; request: 
     body: `
       <section class="page-shell">
         <header class="page-header">
-          <div class="page-eyebrow">⭐ Must-read</div>
           <h1 class="page-title">⭐ Must-read</h1>
           <p class="page-description">오늘 꼭 읽어야 할 기술 기사</p>
         </header>

--- a/functions/trending.ts
+++ b/functions/trending.ts
@@ -132,14 +132,6 @@ const PAGE_STYLES = `
         max-width: 720px;
       }
 
-      .page-eyebrow {
-        display: inline-flex;
-        align-items: center;
-        gap: var(--space-xs);
-        margin-bottom: var(--space-sm);
-        color: var(--color-primary);
-        font-weight: 700;
-      }
 
       .page-title {
         font-size: clamp(2rem, 4vw, 2.75rem);
@@ -316,7 +308,6 @@ export const onRequest: AppPagesFunction = async (context: { env: Env; request: 
     body: `
       <section class="page-shell">
         <header class="page-header">
-          <div class="page-eyebrow">🔥 트렌딩 플레이리스트</div>
           <h1 class="page-title">🔥 트렌딩 플레이리스트</h1>
           <p class="page-description">커뮤니티가 좋아하는 플레이리스트</p>
         </header>

--- a/src/pages/admin/must-read.astro
+++ b/src/pages/admin/must-read.astro
@@ -4,10 +4,10 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
 ---
 
 <BaseLayout title="Must-read 관리 — HoneyCombo">
-  <div class="page-header">
-    <h1>⭐ Must-read 관리</h1>
-    <p class="page-subtitle">필독 기사를 직접 선정하고 관리합니다</p>
-  </div>
+  <header class="page-header">
+    <h1 class="page-title">⭐ Must-read 관리</h1>
+    <p class="page-description">필독 기사를 직접 선정하고 관리합니다</p>
+  </header>
 
   <div class="admin-content">
     <div id="loading" class="state-message">
@@ -457,9 +457,6 @@ document.addEventListener('astro:page-load', () => {
 </script>
 
 <style>
-.page-header { margin-bottom: var(--space-xl); }
-.page-header h1 { font-size: 2rem; font-weight: 800; }
-.page-subtitle { color: var(--color-text-muted); margin-top: var(--space-xs); }
 
 .admin-content {
   display: flex;

--- a/src/pages/admin/playlists.astro
+++ b/src/pages/admin/playlists.astro
@@ -3,10 +3,10 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
 ---
 
 <BaseLayout title="플레이리스트 관리 — HoneyCombo" description="관리자 플레이리스트 승인/반려">
-  <div class="page-header">
-    <h1>🛡️ 플레이리스트 승인 관리</h1>
-    <p class="page-subtitle">커뮤니티 공개 요청된 플레이리스트를 검토합니다</p>
-  </div>
+  <header class="page-header">
+    <h1 class="page-title">🛡️ 플레이리스트 승인 관리</h1>
+    <p class="page-description">커뮤니티 공개 요청된 플레이리스트를 검토합니다</p>
+  </header>
 
   <div class="admin-content">
     <div id="loading" class="state-message">
@@ -205,9 +205,6 @@ document.addEventListener('astro:page-load', () => {
 </script>
 
 <style>
-.page-header { margin-bottom: var(--space-xl); }
-.page-header h1 { font-size: 2rem; font-weight: 800; }
-.page-subtitle { color: var(--color-text-muted); margin-top: var(--space-xs); }
 
 .grid-1 {
   display: grid;

--- a/src/pages/articles/index.astro
+++ b/src/pages/articles/index.astro
@@ -45,10 +45,10 @@ const allArticlesJson = serializeArticles(allArticles);
 ---
 
 <BaseLayout title="기사 목록 — HoneyCombo" description="최신 기술 뉴스와 큐레이션 기사">
-  <div class="page-header">
-    <h1>기사</h1>
-    <p class="page-subtitle">최신 기술 뉴스와 에디터 큐레이션</p>
-  </div>
+  <header class="page-header">
+    <h1 class="page-title">기사</h1>
+    <p class="page-description">최신 기술 뉴스와 에디터 큐레이션</p>
+  </header>
   
   <SourceFilter curatedCount={curatedCount} submittedCount={submittedCount} feedCount={feedCount} />
 
@@ -86,9 +86,6 @@ const allArticlesJson = serializeArticles(allArticles);
 </BaseLayout>
 
 <style>
-.page-header { margin-bottom: var(--space-xl); }
-.page-header h1 { font-size: 2rem; font-weight: 800; }
-.page-subtitle { color: var(--color-text-muted); margin-top: var(--space-xs); }
 .article-grid { margin-top: var(--space-md); }
 .empty-state { text-align: center; padding: var(--space-2xl); color: var(--color-text-muted); }
 </style>

--- a/src/pages/articles/page/[...page].astro
+++ b/src/pages/articles/page/[...page].astro
@@ -52,10 +52,10 @@ const { articles, currentPage, totalPages, allTags, allArticlesJson, curatedCoun
 ---
 
 <BaseLayout title={`기사 ${currentPage}페이지 — HoneyCombo`}>
-  <div class="page-header">
-    <h1>기사</h1>
-    <p class="page-subtitle">최신 기술 뉴스와 에디터 큐레이션</p>
-  </div>
+  <header class="page-header">
+    <h1 class="page-title">기사</h1>
+    <p class="page-description">최신 기술 뉴스와 에디터 큐레이션</p>
+  </header>
   
   <SourceFilter curatedCount={curatedCount} submittedCount={submittedCount} feedCount={feedCount} />
 
@@ -86,8 +86,5 @@ const { articles, currentPage, totalPages, allTags, allArticlesJson, curatedCoun
 </BaseLayout>
 
 <style>
-.page-header { margin-bottom: var(--space-xl); }
-.page-header h1 { font-size: 2rem; font-weight: 800; }
-.page-subtitle { color: var(--color-text-muted); margin-top: var(--space-xs); }
 .article-grid { margin-top: var(--space-md); }
 </style>

--- a/src/pages/community.astro
+++ b/src/pages/community.astro
@@ -4,7 +4,6 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 <BaseLayout title="커뮤니티 — HoneyCombo" description="기술 커뮤니티 자유 발제 공간">
   <section class="page-shell community-page" data-community-page>
     <header class="page-header">
-      <div class="page-eyebrow">💬 커뮤니티</div>
       <h1 class="page-title">자유 발제</h1>
       <p class="page-description">기술에 관한 생각을 자유롭게 나누세요</p>
     </header>
@@ -54,8 +53,6 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 <script is:inline src="/scripts/community-page.js"></script>
 
 <style is:global>
-  /* Reuse existing page-shell, page-header, page-title, page-description, page-eyebrow styles from global.css */
-  /* Only add community-specific styles here */
 
   .community-page {
     display: flex;

--- a/src/pages/influencers.astro
+++ b/src/pages/influencers.astro
@@ -18,10 +18,10 @@ const threadsInfluencers = influencers
 ---
 
 <BaseLayout title="추천 인플루언서 — HoneyCombo" description="기술 분야 주요 인플루언서 모음">
-  <div class="page-header">
-    <h1>⭐ 추천 인플루언서</h1>
-    <p class="page-subtitle">기술 분야 주요 인물들을 팔로우해 보세요</p>
-  </div>
+  <header class="page-header">
+    <h1 class="page-title">⭐ 추천 인플루언서</h1>
+    <p class="page-description">기술 분야 주요 인물들을 팔로우해 보세요</p>
+  </header>
 
   {xInfluencers.length > 0 && (
     <section class="platform-section">
@@ -63,9 +63,6 @@ const threadsInfluencers = influencers
 </BaseLayout>
 
 <style>
-.page-header { margin-bottom: var(--space-xl); }
-.page-header h1 { font-size: 2rem; font-weight: 800; }
-.page-subtitle { color: var(--color-text-muted); margin-top: var(--space-xs); }
 .platform-section { margin-bottom: var(--space-xl); }
 .platform-title { font-size: 1.4rem; font-weight: 700; margin-bottom: var(--space-md); }
 .empty-state { text-align: center; padding: var(--space-2xl); color: var(--color-text-muted); }

--- a/src/pages/must-read.astro
+++ b/src/pages/must-read.astro
@@ -6,7 +6,6 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 <BaseLayout title="Must-read — HoneyCombo" description="오늘 꼭 읽어야 할 기술 기사">
   <section class="page-shell must-read-page" data-must-read-page>
     <header class="page-header">
-      <div class="page-eyebrow">⭐ Must-read</div>
       <h1 class="page-title">⭐ Must-read</h1>
       <p class="page-description">오늘 꼭 읽어야 할 기술 기사</p>
     </header>
@@ -46,37 +45,6 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 <script is:inline src="/scripts/must-read-page.js"></script>
 
 <style is:global>
-  .page-shell {
-    display: flex;
-    flex-direction: column;
-    gap: var(--space-xl);
-  }
-
-  .page-header {
-    max-width: 720px;
-  }
-
-  .page-eyebrow {
-    display: inline-flex;
-    align-items: center;
-    gap: var(--space-xs);
-    margin-bottom: var(--space-sm);
-    color: var(--color-primary);
-    font-weight: 700;
-  }
-
-  .page-title {
-    font-size: clamp(2rem, 4vw, 2.75rem);
-    line-height: 1.2;
-    font-weight: 800;
-    margin-bottom: var(--space-sm);
-  }
-
-  .page-description {
-    color: var(--color-text-muted);
-    font-size: 1.05rem;
-  }
-
   .must-read-grid { display: flex; flex-direction: column; gap: var(--space-md); }
   .must-read-card { display: flex; gap: var(--space-md); align-items: flex-start; padding: var(--space-lg); background: var(--color-bg); border: 1px solid var(--color-border); border-radius: var(--radius-lg); }
   .must-read-rank { font-size: 1.5rem; font-weight: 800; color: var(--color-accent); min-width: 2rem; }

--- a/src/pages/my/playlists.astro
+++ b/src/pages/my/playlists.astro
@@ -3,15 +3,15 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
 ---
 
 <BaseLayout title="내 플레이리스트 — HoneyCombo" description="내가 만든 플레이리스트를 관리하세요">
-  <div class="page-header flex-between">
+  <header class="page-header flex-between">
     <div>
-      <h1>📋 내 플레이리스트</h1>
-      <p class="page-subtitle">내가 만든 플레이리스트를 관리하세요</p>
+      <h1 class="page-title">📋 내 플레이리스트</h1>
+      <p class="page-description">내가 만든 플레이리스트를 관리하세요</p>
     </div>
     <div class="header-actions" id="header-actions">
       <a href="/p/new" class="btn btn-primary">새 플레이리스트 만들기</a>
     </div>
-  </div>
+  </header>
 
   <div class="my-playlists-content">
     <div id="auth-check-loading" class="state-message">
@@ -316,9 +316,6 @@ document.addEventListener('astro:page-load', () => {
 </script>
 
 <style>
-.page-header { margin-bottom: var(--space-xl); }
-.page-header h1 { font-size: 2rem; font-weight: 800; }
-.page-subtitle { color: var(--color-text-muted); margin-top: var(--space-xs); }
 
 .flex-between {
   display: flex;

--- a/src/pages/p/new.astro
+++ b/src/pages/p/new.astro
@@ -3,10 +3,10 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
 ---
 
 <BaseLayout title="새 플레이리스트 만들기 — HoneyCombo" description="새로운 플레이리스트를 만들어보세요">
-  <div class="page-header">
-    <h1>📝 새 플레이리스트 만들기</h1>
-    <p class="page-subtitle">나만의 기술 콘텐츠 모음을 만들어보세요</p>
-  </div>
+  <header class="page-header">
+    <h1 class="page-title">📝 새 플레이리스트 만들기</h1>
+    <p class="page-description">나만의 기술 콘텐츠 모음을 만들어보세요</p>
+  </header>
 
   <div class="submit-content">
     <div id="auth-check-loading" class="auth-message">
@@ -305,9 +305,6 @@ document.addEventListener('astro:page-load', async () => {
 </script>
 
 <style>
-.page-header { margin-bottom: var(--space-xl); }
-.page-header h1 { font-size: 2rem; font-weight: 800; }
-.page-subtitle { color: var(--color-text-muted); margin-top: var(--space-xs); }
 .submit-content { max-width: 600px; }
 
 .auth-message {

--- a/src/pages/playlists/index.astro
+++ b/src/pages/playlists/index.astro
@@ -3,10 +3,10 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
 ---
 
 <BaseLayout title="플레이리스트 — HoneyCombo" description="에디터가 큐레이션한 기사 플레이리스트">
-  <div class="page-header">
-    <h1>🎵 플레이리스트</h1>
-    <p class="page-subtitle">에디터 큐레이션 & 커뮤니티 플레이리스트</p>
-  </div>
+  <header class="page-header">
+    <h1 class="page-title">🎵 플레이리스트</h1>
+    <p class="page-description">에디터 큐레이션 & 커뮤니티 플레이리스트</p>
+  </header>
 
   <section id="editor-playlists" class="editor-section">
     <div id="editor-list" class="playlist-grid grid grid-3">
@@ -176,9 +176,6 @@ document.addEventListener('astro:page-load', () => {
 </script>
 
 <style>
-.page-header { margin-bottom: var(--space-xl); }
-.page-header h1 { font-size: 2rem; font-weight: 800; }
-.page-subtitle { color: var(--color-text-muted); margin-top: var(--space-xs); }
 .empty-state,
 .community-section :global(.empty-state),
 .editor-section :global(.empty-state) { text-align: center; padding: var(--space-2xl); color: var(--color-text-muted); }

--- a/src/pages/submit.astro
+++ b/src/pages/submit.astro
@@ -3,14 +3,14 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 ---
 
 <BaseLayout title="자료등록 — HoneyCombo" description="기술 기사나 YouTube 영상을 제출하세요">
-  <div class="page-header">
-    <h1>📝 자료등록</h1>
-    <p class="page-subtitle">좋은 기술 콘텐츠를 공유해주세요</p>
+  <header class="page-header">
+    <h1 class="page-title">📝 자료등록</h1>
+    <p class="page-description">좋은 기술 콘텐츠를 공유해주세요</p>
     <div class="notice-box">
       <strong>📌 Language Requirement</strong>
       <p>All submissions must be written in <strong>English</strong>.<br/>제출 내용은 모두 <strong>영어</strong>로 작성해주세요.</p>
     </div>
-  </div>
+  </header>
 
   <div class="submit-content">
     <section class="submit-section">
@@ -87,9 +87,6 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 </BaseLayout>
 
 <style>
-.page-header { margin-bottom: var(--space-2xl); }
-.page-header h1 { font-size: 2rem; font-weight: 800; letter-spacing: -0.02em; }
-.page-subtitle { color: var(--color-text-muted); margin-top: var(--space-xs); font-size: 1.05rem; }
 
 .notice-box {
   background: color-mix(in srgb, var(--color-accent) 15%, transparent);

--- a/src/pages/trending.astro
+++ b/src/pages/trending.astro
@@ -6,7 +6,6 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 <BaseLayout title="트렌딩 플레이리스트 — HoneyCombo" description="커뮤니티가 가장 좋아하는 기술 기사 플레이리스트">
   <section class="page-shell trending-page" data-trending-page>
     <header class="page-header">
-      <div class="page-eyebrow">🔥 트렌딩 플레이리스트</div>
       <h1 class="page-title">🔥 트렌딩 플레이리스트</h1>
       <p class="page-description">커뮤니티가 좋아하는 플레이리스트</p>
     </header>
@@ -83,37 +82,6 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 <script is:inline src="/scripts/trending-page.js"></script>
 
 <style is:global>
-  .page-shell {
-    display: flex;
-    flex-direction: column;
-    gap: var(--space-xl);
-  }
-
-  .page-header {
-    max-width: 720px;
-  }
-
-  .page-eyebrow {
-    display: inline-flex;
-    align-items: center;
-    gap: var(--space-xs);
-    margin-bottom: var(--space-sm);
-    color: var(--color-primary);
-    font-weight: 700;
-  }
-
-  .page-title {
-    font-size: clamp(2rem, 4vw, 2.75rem);
-    line-height: 1.2;
-    font-weight: 800;
-    margin-bottom: var(--space-sm);
-  }
-
-  .page-description {
-    color: var(--color-text-muted);
-    font-size: 1.05rem;
-  }
-
   .trending-summary {
     display: flex;
     align-items: center;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -65,6 +65,34 @@ img { max-width: 100%; height: auto; }
 .grid-3 { grid-template-columns: repeat(3, 1fr); }
 .flex { display: flex; gap: var(--space-sm); align-items: center; }
 
+/* Page Shell & Header */
+.page-shell {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xl);
+}
+
+.page-header {
+  margin-bottom: var(--space-xl);
+}
+
+.page-shell > .page-header {
+  max-width: 720px;
+  margin-bottom: 0;
+}
+
+.page-title {
+  font-size: clamp(2rem, 4vw, 2.75rem);
+  line-height: 1.2;
+  font-weight: 800;
+  margin-bottom: var(--space-sm);
+}
+
+.page-description {
+  color: var(--color-text-muted);
+  font-size: 1.05rem;
+}
+
 /* Card */
 .card {
   background: var(--color-bg);

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -73,11 +73,15 @@ img { max-width: 100%; height: auto; }
 }
 
 .page-header {
+  max-width: 720px;
   margin-bottom: var(--space-xl);
 }
 
+.page-header.flex-between {
+  max-width: none;
+}
+
 .page-shell > .page-header {
-  max-width: 720px;
   margin-bottom: 0;
 }
 


### PR DESCRIPTION
## Summary

- home을 제외한 모든 페이지의 제목 구성을 **h1(page-title) + description(page-description)** 2단 구조로 통일
- trending/community/must-read 페이지의 `page-eyebrow` (작은 글씨 부제목) 제거
- 각 페이지에 중복 정의되던 page-header/title/description 스타일을 `global.css`로 통합
- 모든 페이지에 `clamp(2rem, 4vw, 2.75rem)` 반응형 폰트 적용

## 변경 파일 (13개)

| 파일 | 변경 내용 |
|------|----------|
| `src/styles/global.css` | page-shell, page-header, page-title, page-description 공통 스타일 추가 |
| `src/pages/trending.astro` | page-eyebrow 제거, 중복 인라인 스타일 삭제 |
| `src/pages/community.astro` | page-eyebrow 제거, 오래된 주석 정리 |
| `src/pages/must-read.astro` | page-eyebrow 제거, 중복 인라인 스타일 삭제 |
| `src/pages/articles/index.astro` | header 구조 통일 (h1→page-title, page-subtitle→page-description) |
| `src/pages/articles/page/[...page].astro` | 동일 |
| `src/pages/playlists/index.astro` | 동일 |
| `src/pages/influencers.astro` | 동일 |
| `src/pages/submit.astro` | 동일 |
| `src/pages/my/playlists.astro` | 동일 (flex-between 레이아웃 유지) |
| `src/pages/p/new.astro` | 동일 |
| `src/pages/admin/must-read.astro` | 동일 |
| `src/pages/admin/playlists.astro` | 동일 |