### PR TITLE
fix: add missing emoji to articles pagination and must-read SSR fallback

### DIFF
--- a/docs/decisions/0004-page-title-standardization.md
+++ b/docs/decisions/0004-page-title-standardization.md
@@ -73,3 +73,4 @@
 |------|----------|
 | 2026-04-16 | 최초 작성 |
 | 2026-04-16 | 이모지 규칙 추가: Articles(📰), Community(💬), Must-read(📌) 이모지 통일 |
+| 2026-04-16 | 이모지 누락 보완: articles 페이지네이션, must-read SSR fallback 통일 |

--- a/functions/must-read.ts
+++ b/functions/must-read.ts
@@ -10,7 +10,7 @@ function getCanonicalUrl(requestUrl: string): string {
 
 function renderMustReadItems(items: MustReadItemRow[]): string {
   if (items.length === 0) {
-    return '<div class="empty-state">⭐ Must-read 목록을 준비 중입니다.</div>';
+    return '<div class="empty-state">📌 Must-read 목록을 준비 중입니다.</div>';
   }
 
   return items
@@ -98,7 +98,7 @@ export const onRequest: AppPagesFunction = async (context: { env: Env; request: 
     body: `
       <section class="page-shell">
         <header class="page-header">
-          <h1 class="page-title">⭐ Must-read</h1>
+          <h1 class="page-title">📌 Must-read</h1>
           <p class="page-description">오늘 꼭 읽어야 할 기술 기사</p>
         </header>
 

--- a/src/pages/articles/page/[...page].astro
+++ b/src/pages/articles/page/[...page].astro
@@ -53,7 +53,7 @@ const { articles, currentPage, totalPages, allTags, allArticlesJson, curatedCoun
 
 <BaseLayout title={`기사 ${currentPage}페이지 — HoneyCombo`}>
   <header class="page-header">
-    <h1 class="page-title">기사</h1>
+    <h1 class="page-title">📰 기사</h1>
     <p class="page-description">최신 기술 뉴스와 에디터 큐레이션</p>
   </header>
   


### PR DESCRIPTION
## Summary
- 📰 Articles 페이지네이션(`/articles/page/2/` 등) h1에 누락된 📰 이모지 추가
- 📌 Must-read SSR fallback(`functions/must-read.ts`) h1 및 empty state의 ⭐→📌 통일

PR #54의 누락분 보완.