### PR TITLE
fix: update stale emoji in must-read client-side empty state

### DIFF
--- a/public/scripts/must-read-page.js
+++ b/public/scripts/must-read-page.js
@@ -36,7 +36,7 @@ document.addEventListener('astro:page-load', () => {
 
   function renderMustReadItems(items) {
     if (!Array.isArray(items) || items.length === 0) {
-      return '<div class="empty-state">⭐ Must-read 목록을 준비 중입니다.</div>';
+      return '<div class="empty-state">📌 Must-read 목록을 준비 중입니다.</div>';
     }
 
     return items.map((item, index) => {


### PR DESCRIPTION
## Summary
- `public/scripts/must-read-page.js` empty state의 ⭐→📌 통일 (클라이언트 렌더 경로 누락분)