### PR TITLE
feat: rename Must-read page title to Korean (꼭 읽어야 할 기사)

### DIFF
--- a/docs/decisions/0004-page-title-standardization.md
+++ b/docs/decisions/0004-page-title-standardization.md
@@ -74,3 +74,4 @@
 | 2026-04-16 | 최초 작성 |
 | 2026-04-16 | 이모지 규칙 추가: Articles(📰), Community(💬), Must-read(📌) 이모지 통일 |
 | 2026-04-16 | 이모지 누락 보완: articles 페이지네이션, must-read SSR fallback 통일 |
+| 2026-04-16 | Must-read 페이지 제목 한국어화: `📌 Must-read` → `📌 꼭 읽어야 할 기사` (메뉴는 영문 유지) |

--- a/functions/must-read.ts
+++ b/functions/must-read.ts
@@ -10,7 +10,7 @@ function getCanonicalUrl(requestUrl: string): string {
 
 function renderMustReadItems(items: MustReadItemRow[]): string {
   if (items.length === 0) {
-    return '<div class="empty-state">📌 Must-read 목록을 준비 중입니다.</div>';
+    return '<div class="empty-state">📌 꼭 읽어야 할 기사 목록을 준비 중입니다.</div>';
   }
 
   return items
@@ -98,7 +98,7 @@ export const onRequest: AppPagesFunction = async (context: { env: Env; request: 
     body: `
       <section class="page-shell">
         <header class="page-header">
-          <h1 class="page-title">📌 Must-read</h1>
+          <h1 class="page-title">📌 꼭 읽어야 할 기사</h1>
           <p class="page-description">오늘 꼭 읽어야 할 기술 기사</p>
         </header>
 

--- a/public/scripts/must-read-page.js
+++ b/public/scripts/must-read-page.js
@@ -36,7 +36,7 @@ document.addEventListener('astro:page-load', () => {
 
   function renderMustReadItems(items) {
     if (!Array.isArray(items) || items.length === 0) {
-      return '<div class="empty-state">📌 Must-read 목록을 준비 중입니다.</div>';
+      return '<div class="empty-state">📌 꼭 읽어야 할 기사 목록을 준비 중입니다.</div>';
     }
 
     return items.map((item, index) => {

--- a/src/pages/must-read.astro
+++ b/src/pages/must-read.astro
@@ -6,7 +6,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 <BaseLayout title="Must-read — HoneyCombo" description="오늘 꼭 읽어야 할 기술 기사">
   <section class="page-shell must-read-page" data-must-read-page>
     <header class="page-header">
-      <h1 class="page-title">📌 Must-read</h1>
+      <h1 class="page-title">📌 꼭 읽어야 할 기사</h1>
       <p class="page-description">오늘 꼭 읽어야 할 기술 기사</p>
     </header>
 


### PR DESCRIPTION
## Summary
- Must-read 페이지 h1을 한국어로 변경: `📌 Must-read` → `📌 꼭 읽어야 할 기사`
- 메뉴(Navigation)는 영문 `Must-read` 유지
- 적용 범위: Astro 페이지, SSR fallback, 클라이언트 JS (3개 파일, 4곳)