### PR TITLE
fix: update Must-read document title to Korean

### DIFF
--- a/docs/decisions/0004-page-title-standardization.md
+++ b/docs/decisions/0004-page-title-standardization.md
@@ -75,3 +75,4 @@
 | 2026-04-16 | 이모지 규칙 추가: Articles(📰), Community(💬), Must-read(📌) 이모지 통일 |
 | 2026-04-16 | 이모지 누락 보완: articles 페이지네이션, must-read SSR fallback 통일 |
 | 2026-04-16 | Must-read 페이지 제목 한국어화: `📌 Must-read` → `📌 꼭 읽어야 할 기사` (메뉴는 영문 유지) |
+| 2026-04-16 | Must-read 문서 제목(브라우저 탭) 한국어화: `Must-read — HoneyCombo` → `꼭 읽어야 할 기사 — HoneyCombo` |

--- a/functions/must-read.ts
+++ b/functions/must-read.ts
@@ -90,8 +90,8 @@ export const onRequest: AppPagesFunction = async (context: { env: Env; request: 
   const canonicalUrl = getCanonicalUrl(request.url);
 
   const html = renderDocument({
-    pageTitle: 'Must-read — HoneyCombo',
-    metaTitle: 'Must-read — HoneyCombo',
+    pageTitle: '꼭 읽어야 할 기사 — HoneyCombo',
+    metaTitle: '꼭 읽어야 할 기사 — HoneyCombo',
     description: '오늘 꼭 읽어야 할 기술 기사',
     canonicalUrl,
     currentPath: '/must-read',

--- a/src/pages/must-read.astro
+++ b/src/pages/must-read.astro
@@ -3,7 +3,7 @@
 import BaseLayout from '../layouts/BaseLayout.astro';
 ---
 
-<BaseLayout title="Must-read — HoneyCombo" description="오늘 꼭 읽어야 할 기술 기사">
+<BaseLayout title="꼭 읽어야 할 기사 — HoneyCombo" description="오늘 꼭 읽어야 할 기술 기사">
   <section class="page-shell must-read-page" data-must-read-page>
     <header class="page-header">
       <h1 class="page-title">📌 꼭 읽어야 할 기사</h1>


### PR DESCRIPTION
브라우저 탭 제목도 한국어로 통일: Must-read → 꼭 읽어야 할 기사