### PR TITLE
fix: add English Link List pattern to submission workflow trigger

### DIFF
--- a/.github/workflows/process-submission.yml
+++ b/.github/workflows/process-submission.yml
@@ -21,6 +21,7 @@ jobs:
       contains(github.event.issue.labels.*.name, 'submission')
       || (github.event.action == 'opened'
           && (contains(github.event.issue.body, '### URL')
+              || contains(github.event.issue.body, '### Link List')
               || contains(github.event.issue.body, '### 링크 목록')))
       || github.event_name == 'workflow_dispatch'
     permissions:
@@ -34,7 +35,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           ISSUE_NUM: ${{ github.event.issue.number }}
-          IS_BULK: ${{ contains(github.event.issue.body, '### 링크 목록') }}
+          IS_BULK: ${{ contains(github.event.issue.body, '### Link List') || contains(github.event.issue.body, '### 링크 목록') }}
         run: |
           if [ "$IS_BULK" = "true" ]; then
             gh issue edit "$ISSUE_NUM" --add-label "submission,bulk" --repo "$REPO"


### PR DESCRIPTION
## Summary

- Bulk submission workflow의 `if` 조건에 `### Link List` (영문) 패턴을 추가
- `IS_BULK` 환경변수 판별에도 `### Link List` 패턴을 추가

## 원인

제출 가이드(`docs/guides/agent-submission.md`)는 `### Link List`(영문)를 사용하도록 안내하고, 처리 스크립트(`scripts/process-submission.ts`)도 이를 정상 파싱하지만, 워크플로우 `if` 조건은 `### 링크 목록`(한글)만 인식하여 영문 bulk 제출 시 워크플로우가 skip됨.

Issue #62가 이 버그로 인해 처리되지 않음.

## 변경 내용

`.github/workflows/process-submission.yml`:
1. Job `if` 조건: `### Link List` 패턴 추가
2. `IS_BULK` 환경변수: `### Link List || ### 링크 목록` 으로 확장

머지 후 workflow_dispatch로 Issue #62 재처리 필요.
