### PR TITLE
feat: enlarge hero image 1.5x (380px -> 560px)

### DIFF
--- a/docs/troubleshooting/playlist-article-links-redirect-to-home.md
+++ b/docs/troubleshooting/playlist-article-links-redirect-to-home.md
@@ -1,0 +1,79 @@
+# 플레이리스트 기사 링크가 홈으로 리다이렉트되는 버그
+
+> 플레이리스트 상세 페이지에서 큐레이션 기사 클릭 시 기사 상세 페이지 대신 홈으로 이동하는 문제
+
+## 증상
+
+`/p/{playlistId}` 플레이리스트 상세 페이지에서 "HoneyCombo 큐레이션" 기사를 클릭하면 해당 기사의 상세 페이지(`/articles/{slug}`)로 이동하지 않고 홈(`/`)으로 리다이렉트됨.
+
+**재현 조건**: DB에 `source_id`가 year/month 디렉토리 접두사 없이 저장된 플레이리스트 아이템 (예: `submission-62-0e8bf03f`)
+
+**재현 환경**: Production (Cloudflare Pages + D1)
+
+## 원인
+
+두 가지 근본 원인이 결합:
+
+1. **`source_id` 형식 불일치**: `playlist_items` 테이블의 `source_id`가 `submission-62-0e8bf03f` (파일명만)로 저장되었으나, Astro content collection의 `entry.id`는 `2026/04/submission-62-0e8bf03f` (디렉토리 경로 포함). `functions/p/[id].ts`의 `getItemHref()`가 `/articles/${source_id}`로 URL을 구성하므로 `/articles/submission-62-0e8bf03f`라는 존재하지 않는 페이지로 링크됨.
+
+2. **Feed 아이템 처리 오류**: `getItemHref()`가 `item_type === 'feed'`일 때 무조건 `url_snapshot`(외부 URL)을 반환했으나, feed 아이템도 `source_id`가 있으면 내부 기사 페이지가 존재함.
+
+## 해결 방법
+
+### 1. `[...slug].astro`에 하위 호환 slug 추가
+
+```diff
+- ...curatedEntries.map((entry) => ({
+-   params: { slug: entry.id },
+-   props: { entry, collection: 'curated' },
+- })),
++ ...curatedEntries.flatMap((entry) => {
++   const paths = [{ params: { slug: entry.id }, props: { entry, collection: 'curated' } }];
++   const parts = entry.id.split('/');
++   if (parts.length > 1) {
++     const filename = parts[parts.length - 1];
++     paths.push({ params: { slug: filename }, props: { entry, collection: 'curated' } });
++   }
++   return paths;
++ }),
+```
+
+이로써 `/articles/submission-62-0e8bf03f`와 `/articles/2026/04/submission-62-0e8bf03f` 모두 동일 기사를 렌더링함.
+
+### 2. `getItemHref()` 로직 수정
+
+```diff
+- if (item.item_type === 'external') return item.url_snapshot;
+- if (item.item_type === 'feed') return item.url_snapshot;
+- return `/articles/${item.source_id ?? ''}`;
++ if (item.item_type === 'external') return item.url_snapshot;
++ if (item.source_id) return `/articles/${item.source_id}`;
++ return item.url_snapshot;
+```
+
+`source_id`가 있는 모든 아이템(curated, feed)은 내부 기사 페이지로 링크.
+
+## 관련 파일
+
+| 파일 | 변경 내용 |
+|------|----------|
+| `src/pages/articles/[...slug].astro` | `getStaticPaths`에서 filename-only slug 추가 생성 |
+| `functions/p/[id].ts` | `getItemHref()` 수정: feed 아이템도 내부 링크 지원 |
+
+## 예방 조치
+
+- 플레이리스트에 기사 추가 시 `source_id`는 반드시 Astro content collection의 `entry.id` (디렉토리 경로 포함 형식)를 사용해야 함.
+- `search-index.json.ts`가 이미 `e.id`를 사용하므로 신규 추가 시 올바른 형식이 저장됨.
+- `AddToPlaylist.astro` 컴포넌트도 `entry.id` 기반 `articleId`를 전달하므로 신규 데이터는 정상.
+
+---
+
+## 관련 문서
+
+- [플레이리스트 기능](../features/playlists.md)
+
+## 변경 이력
+
+| 날짜 | 변경 내용 |
+|------|----------|
+| 2026-04-16 | 최초 작성 |

--- a/functions/p/[id].ts
+++ b/functions/p/[id].ts
@@ -53,8 +53,27 @@ function getVisibilityLabel(playlist: PlaylistDetail): string {
 
 function getItemHref(item: PlaylistItemRow): string {
   if (item.item_type === 'external') return item.url_snapshot;
-  if (item.item_type === 'feed') return item.url_snapshot;
-  return `/articles/${item.source_id ?? ''}`;
+  // Both curated and feed items with source_id link to internal article pages
+  if (item.source_id) return `/articles/${item.source_id}`;
+  // Fallback to external URL when no source_id
+  return item.url_snapshot;
+}
+
+function extractYouTubeVideoId(url: string): string | null {
+  const patterns = [
+    /(?:youtube\.com\/watch\?v=|youtu\.be\/|youtube\.com\/embed\/)([a-zA-Z0-9_-]{11})/,
+    /youtube\.com\/shorts\/([a-zA-Z0-9_-]{11})/,
+  ];
+  for (const pattern of patterns) {
+    const match = url.match(pattern);
+    if (match) return match[1];
+  }
+  return null;
+}
+
+function getYouTubeThumbnailUrl(url: string): string | null {
+  const videoId = extractYouTubeVideoId(url);
+  return videoId ? `https://img.youtube.com/vi/${videoId}/mqdefault.jpg` : null;
 }
 
 function getItemDomain(url: string): string {
@@ -112,7 +131,8 @@ function renderItems(items: PlaylistItemRow[], isOwner: boolean, playlistId: str
       const note = item.note?.trim();
       const sourceLabel = getItemMetaLabel(item);
       const domain = getItemDomain(item.url_snapshot);
-      const isExternal = item.item_type === 'external' || item.item_type === 'feed';
+      const isExternal = item.item_type === 'external' || !item.source_id;
+      const thumbnail = getYouTubeThumbnailUrl(item.url_snapshot);
       const ownerControls = isOwner
         ? `
           <div class="item-controls">
@@ -131,16 +151,18 @@ function renderItems(items: PlaylistItemRow[], isOwner: boolean, playlistId: str
 
       return `
         <article class="item-card card" data-item-id="${escapeAttr(item.id)}" data-position="${item.position}">
-          <div class="item-card-header">
-            <span class="badge">${escapeHtml(sourceLabel)}</span>
-            ${isExternal ? `<span class="item-domain">${escapeHtml(domain)}</span>` : '<span class="item-domain">HoneyCombo 기사</span>'}
+          ${thumbnail ? `<div class="item-thumbnail"><img src="${escapeAttr(thumbnail)}" alt="" loading="lazy" width="320" height="180" /></div>` : ''}
+          <div class="item-body">
+            <div class="item-card-header">
+              <span class="badge">${escapeHtml(sourceLabel)}</span>
+              ${isExternal ? `<span class="item-domain">${escapeHtml(domain)}</span>` : '<span class="item-domain">HoneyCombo 기사</span>'}
+            </div>
+            <h2 class="item-title">
+              <a href="${escapeAttr(href)}" ${isExternal ? 'target="_blank" rel="noopener noreferrer"' : ''}>${escapeHtml(title)}</a>
+            </h2>
+            ${note ? `<p class="item-note">💬 ${escapeHtml(note)}</p>` : ''}
+            ${ownerControls}
           </div>
-          <h2 class="item-title">
-            <a href="${escapeAttr(href)}" ${isExternal ? 'target="_blank" rel="noopener noreferrer"' : ''}>${escapeHtml(title)}</a>
-          </h2>
-          <p class="item-url">${escapeHtml(item.url_snapshot)}</p>
-          ${note ? `<p class="item-note">💬 ${escapeHtml(note)}</p>` : ''}
-          ${ownerControls}
         </article>`;
     })
     .join('');
@@ -333,8 +355,41 @@ const PAGE_STYLES = `
 
       .items {
         display: grid;
+        grid-template-columns: repeat(2, 1fr);
         gap: var(--space-md);
         margin-top: var(--space-lg);
+      }
+
+      .item-card {
+        display: flex;
+        flex-direction: column;
+        gap: 0;
+        overflow: hidden;
+      }
+
+      .item-thumbnail {
+        margin: calc(-1 * var(--space-md)) calc(-1 * var(--space-md)) 0;
+        overflow: hidden;
+      }
+
+      .item-thumbnail img {
+        width: 100%;
+        height: 140px;
+        object-fit: cover;
+        display: block;
+        transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+      }
+
+      .item-card:hover .item-thumbnail img {
+        transform: scale(1.03);
+      }
+
+      .item-body {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-xs);
+        flex: 1;
+        padding-top: var(--space-sm);
       }
 
       .item-card-header {
@@ -342,13 +397,16 @@ const PAGE_STYLES = `
         justify-content: space-between;
         align-items: center;
         gap: var(--space-sm);
-        margin-bottom: var(--space-sm);
       }
 
       .item-title {
-        font-size: 1.125rem;
+        font-size: 0.95rem;
+        font-weight: 600;
         line-height: 1.4;
-        margin-bottom: var(--space-xs);
+        display: -webkit-box;
+        -webkit-line-clamp: 2;
+        -webkit-box-orient: vertical;
+        overflow: hidden;
       }
 
       .item-title a {
@@ -357,23 +415,20 @@ const PAGE_STYLES = `
 
       .item-title a:hover {
         color: var(--color-primary);
+        text-decoration: none;
       }
 
-      .item-domain, .item-url, .meta-text, .updated-at {
+      .item-domain, .meta-text, .updated-at {
         color: var(--color-text-muted);
-        font-size: 0.9rem;
-      }
-
-      .item-url {
-        word-break: break-all;
+        font-size: 0.8rem;
       }
 
       .item-note {
-        margin-top: var(--space-sm);
-        padding: var(--space-sm);
+        padding: var(--space-xs) var(--space-sm);
         background: var(--color-bg-secondary);
         border-radius: var(--radius-sm);
         color: var(--color-text-muted);
+        font-size: 0.85rem;
       }
 
       .item-controls {
@@ -593,6 +648,10 @@ const PAGE_STYLES = `
       }
 
       @media (max-width: 768px) {
+        .items {
+          grid-template-columns: 1fr;
+        }
+
         .playlist-meta,
         .owner-controls,
         .visibility-section,
@@ -608,7 +667,7 @@ const PAGE_STYLES = `
         .owner-actions .btn {
           width: 100%;
         }
-      }`;
+      }
 
 function renderStatusPage(status: number, title: string, message: string, canonicalUrl: string): Response {
   const html = renderDocument({

--- a/src/pages/articles/[...slug].astro
+++ b/src/pages/articles/[...slug].astro
@@ -26,14 +26,25 @@ export async function getStaticPaths() {
     return [];
   });
   return [
-    ...curatedEntries.map((entry: any) => ({
-      params: { slug: entry.id },
-      props: { entry, collection: 'curated' as const },
-    })),
-    ...feedEntries.map((entry: any) => ({
-      params: { slug: entry.id },
-      props: { entry, collection: 'feeds' as const },
-    })),
+    ...curatedEntries.flatMap((entry: any) => {
+      const paths = [{ params: { slug: entry.id }, props: { entry, collection: 'curated' as const } }];
+      // Backward compatibility: also generate filename-only path for source_ids stored without year/month prefix
+      const parts = entry.id.split('/');
+      if (parts.length > 1) {
+        const filename = parts[parts.length - 1];
+        paths.push({ params: { slug: filename }, props: { entry, collection: 'curated' as const } });
+      }
+      return paths;
+    }),
+    ...feedEntries.flatMap((entry: any) => {
+      const paths = [{ params: { slug: entry.id }, props: { entry, collection: 'feeds' as const } }];
+      const parts = entry.id.split('/');
+      if (parts.length > 1) {
+        const filename = parts[parts.length - 1];
+        paths.push({ params: { slug: filename }, props: { entry, collection: 'feeds' as const } });
+      }
+      return paths;
+    }),
   ];
 }
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -125,7 +125,7 @@ const recentArticles = allArticles.slice(0, MAX_RECENT);
 }
 .hero-logo {
   width: 100%;
-  max-height: 380px;
+  max-height: 560px;
   object-fit: contain;
   border-radius: 16px;
   box-shadow: 0 8px 32px rgba(0, 0, 0, 0.1);


### PR DESCRIPTION
## Summary
- 히어로 이미지 max-height 380px -> 560px (1.5배 확대)
- 데스크탑에서 더 임팩트 있는 비주얼 + 기사 섹션 fold 내 유지