### PR TITLE
fix: playlist article links, YouTube thumbnails, horizontal card layout

### DIFF
--- a/docs/features/playlists.md
+++ b/docs/features/playlists.md
@@ -33,6 +33,13 @@
        → HTML 렌더링 (비공개: noindex)
 ```
 
+#### 상세 페이지 UI
+
+- **레이아웃**: 기사 아이템을 3열 반응형 그리드(`repeat(3, 1fr)`)로 표시한다. `@1024px` 이하에서 2열, `@768px` 이하에서 1열로 전환된다. `/articles/` 페이지의 `grid-3` 레이아웃을 참조한 디자인이다.
+- **YouTube 썸네일**: `url_snapshot`이 YouTube URL인 경우 `img.youtube.com/vi/{videoId}/mqdefault.jpg` 썸네일을 카드 상단에 자동 표시한다. `extractYouTubeVideoId()`가 `youtube.com`, `youtu.be`, `m.youtube.com`, `youtube-nocookie.com`, `/shorts/`, `/live/`, `/embed/`, `/v/` 패턴을 URL 파싱으로 처리한다.
+- **내부 링크**: `source_id`가 있는 curated/feed 아이템은 `/articles/${source_id}`로 내부 페이지에 링크한다. `source_id`가 없는 external 아이템만 외부 URL(`url_snapshot`)로 링크하며 `target="_blank"`를 적용한다.
+- **하위 호환**: DB에 year/month 경로 접두사 없이 저장된 레거시 `source_id`(예: `submission-62-xxx`)를 위해 `[...slug].astro`가 filename-only slug도 추가 생성한다. 이 alias 페이지는 정규 canonical URL과 Giscus term을 `entry.id` 기반으로 설정하여 SEO와 댓글 분리를 방지한다.
+
 ### 기사 추가
 
 ```
@@ -220,6 +227,7 @@
 - 공개 플레이리스트는 관리자 승인 후 `/playlists` 목록에 노출
 - 기사 추가 시 스냅샷(title, url, description) 저장 → 원본 삭제돼도 정보 유지
 - 아이템 타입: `curated` (큐레이션 기사), `feed` (피드 기사), `external` (외부 URL)
+- YouTube 썸네일은 `url_snapshot` URL 기반 클라이언트 측 추출이므로, 삭제/비공개 동영상은 깨진 이미지로 표시될 수 있다
 
 ---
 
@@ -229,6 +237,7 @@
 - [기사 승인 시 플레이리스트 자동 추가](./auto-playlist-add.md)
 - [플레이리스트 데이터 미스매치 트러블슈팅](../troubleshooting/playlist-data-mismatch.md)
 - [플레이리스트 검색 렌더링·순서 변경 트러블슈팅](../troubleshooting/playlist-detail-search-and-reorder.md)
+- [플레이리스트 기사 링크 홈 리다이렉트 트러블슈팅](../troubleshooting/playlist-article-links-redirect-to-home.md)
 
 ## 변경 이력
 
@@ -246,3 +255,4 @@
 | 2026-04-13 | 검색 결과 HTML `\n` 이스케이프 수정, 기사 수 동적 갱신(`updateItemCount`), 순서 변경 실패 시 reload 동기화 반영 |
 | 2026-04-13 | 승인 기사 auto-playlist webhook, auto-created playlist 생성 규칙, deferred submissions 흐름 문서화 |
 | 2026-04-13 | GitHub Actions 승인 감지와 OAuth catch-up 기반 auto-playlist 동기화 반영 |
+| 2026-04-17 | YouTube 썸네일 표시, 3열 그리드 레이아웃, 기사 내부 링크 수정(source_id 기반), alias 페이지 canonical/Giscus 정규화 |

--- a/docs/features/playlists.md
+++ b/docs/features/playlists.md
@@ -35,8 +35,8 @@
 
 #### 상세 페이지 UI
 
-- **레이아웃**: 기사 아이템을 3열 반응형 그리드(`repeat(3, 1fr)`)로 표시한다. `@1024px` 이하에서 2열, `@768px` 이하에서 1열로 전환된다. `/articles/` 페이지의 `grid-3` 레이아웃을 참조한 디자인이다.
-- **YouTube 썸네일**: `url_snapshot`이 YouTube URL인 경우 `img.youtube.com/vi/{videoId}/mqdefault.jpg` 썸네일을 카드 상단에 자동 표시한다. `extractYouTubeVideoId()`가 `youtube.com`, `youtu.be`, `m.youtube.com`, `youtube-nocookie.com`, `/shorts/`, `/live/`, `/embed/`, `/v/` 패턴을 URL 파싱으로 처리한다.
+- **레이아웃**: 기사 아이템을 2열 반응형 그리드(`repeat(2, 1fr)`)로 표시한다. `@768px` 이하에서 1열로 전환된다. 각 카드는 가로형(`flex-direction: row`)이며, YouTube 썸네일이 있는 경우 좌측에 140px 고정폭 썸네일을 표시하고 우측에 제목/배지/컨트롤을 배치한다.
+- **YouTube 썸네일**: `url_snapshot`이 YouTube URL인 경우 `img.youtube.com/vi/{videoId}/mqdefault.jpg` 썸네일을 카드 좌측에 자동 표시한다. `extractYouTubeVideoId()`가 `youtube.com`, `youtu.be`, `m.youtube.com`, `youtube-nocookie.com`, `/shorts/`, `/live/`, `/embed/`, `/v/` 패턴을 URL 파싱으로 처리한다.
 - **내부 링크**: `source_id`가 있는 curated/feed 아이템은 `/articles/${source_id}`로 내부 페이지에 링크한다. `source_id`가 없는 external 아이템만 외부 URL(`url_snapshot`)로 링크하며 `target="_blank"`를 적용한다.
 - **하위 호환**: DB에 year/month 경로 접두사 없이 저장된 레거시 `source_id`(예: `submission-62-xxx`)를 위해 `[...slug].astro`가 filename-only slug도 추가 생성한다. 이 alias 페이지는 정규 canonical URL과 Giscus term을 `entry.id` 기반으로 설정하여 SEO와 댓글 분리를 방지한다.
 
@@ -255,4 +255,4 @@
 | 2026-04-13 | 검색 결과 HTML `\n` 이스케이프 수정, 기사 수 동적 갱신(`updateItemCount`), 순서 변경 실패 시 reload 동기화 반영 |
 | 2026-04-13 | 승인 기사 auto-playlist webhook, auto-created playlist 생성 규칙, deferred submissions 흐름 문서화 |
 | 2026-04-13 | GitHub Actions 승인 감지와 OAuth catch-up 기반 auto-playlist 동기화 반영 |
-| 2026-04-17 | YouTube 썸네일 표시, 3열 그리드 레이아웃, 기사 내부 링크 수정(source_id 기반), alias 페이지 canonical/Giscus 정규화 |
+| 2026-04-17 | YouTube 썸네일 표시, 2열 가로형 카드 레이아웃(좌측 썸네일), 기사 내부 링크 수정(source_id 기반), alias 페이지 canonical/Giscus 정규화, BaseLayout canonicalPath 프롭 추가, Comments 컨포넌트 data-giscus-term 지원 |

--- a/docs/troubleshooting/playlist-article-links-redirect-to-home.md
+++ b/docs/troubleshooting/playlist-article-links-redirect-to-home.md
@@ -57,8 +57,10 @@
 
 | 파일 | 변경 내용 |
 |------|----------|
-| `src/pages/articles/[...slug].astro` | `getStaticPaths`에서 filename-only slug 추가 생성 |
+| `src/pages/articles/[...slug].astro` | `getStaticPaths`에서 filename-only slug 추가 생성, `canonicalPath`를 `entry.id` 기반으로 계산하여 BaseLayout/Comments에 전달 |
 | `functions/p/[id].ts` | `getItemHref()` 수정: feed 아이템도 내부 링크 지원 |
+| `src/layouts/BaseLayout.astro` | `canonicalPath` 프롭 추가: alias 페이지에서 정규 canonical URL 및 `og:url` 사용 |
+| `src/components/Comments.astro` | `term` 프롭 + `data-giscus-term` 속성 추가: alias 페이지에서 Giscus가 정규 경로로 댓글 스레드 통합 |
 
 ## 예방 조치
 
@@ -77,3 +79,4 @@
 | 날짜 | 변경 내용 |
 |------|----------|
 | 2026-04-16 | 최초 작성 |
+| 2026-04-17 | canonical URL/Giscus 통합 파일(`BaseLayout.astro`, `Comments.astro`) 추가 |

--- a/functions/p/[id].ts
+++ b/functions/p/[id].ts
@@ -158,15 +158,15 @@ function renderItems(items: PlaylistItemRow[], isOwner: boolean, playlistId: str
 
       return `
         <article class="item-card card" data-item-id="${escapeAttr(item.id)}" data-position="${item.position}">
-          ${thumbnail ? `<div class="item-thumbnail"><img src="${escapeAttr(thumbnail)}" alt="" loading="lazy" width="320" height="180" /></div>` : ''}
+          ${thumbnail ? `<div class="item-thumbnail"><img src="${escapeAttr(thumbnail)}" alt="" loading="lazy" width="160" height="90" /></div>` : ''}
           <div class="item-body">
-            <div class="item-card-header">
-              <span class="badge">${escapeHtml(sourceLabel)}</span>
-              ${isExternal ? `<span class="item-domain">${escapeHtml(domain)}</span>` : '<span class="item-domain">HoneyCombo 기사</span>'}
-            </div>
             <h2 class="item-title">
               <a href="${escapeAttr(href)}" ${isExternal ? 'target="_blank" rel="noopener noreferrer"' : ''}>${escapeHtml(title)}</a>
             </h2>
+            <div class="item-card-footer">
+              <span class="badge badge-sm">${escapeHtml(sourceLabel)}</span>
+              ${isExternal ? `<span class="item-domain">${escapeHtml(domain)}</span>` : ''}
+            </div>
             ${note ? `<p class="item-note">💬 ${escapeHtml(note)}</p>` : ''}
             ${ownerControls}
           </div>
@@ -362,33 +362,35 @@ const PAGE_STYLES = `
 
       .items {
         display: grid;
-        grid-template-columns: repeat(3, 1fr);
+        grid-template-columns: repeat(2, 1fr);
         gap: var(--space-md);
         margin-top: var(--space-lg);
       }
 
       .item-card {
         display: flex;
-        flex-direction: column;
-        gap: 0;
+        flex-direction: row;
+        gap: var(--space-md);
         overflow: hidden;
       }
 
       .item-thumbnail {
-        margin: calc(-1 * var(--space-md)) calc(-1 * var(--space-md)) 0;
+        flex-shrink: 0;
+        width: 140px;
+        margin: calc(-1 * var(--space-md)) 0 calc(-1 * var(--space-md)) calc(-1 * var(--space-md));
         overflow: hidden;
       }
 
       .item-thumbnail img {
         width: 100%;
-        height: 140px;
+        height: 100%;
         object-fit: cover;
         display: block;
         transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
       }
 
       .item-card:hover .item-thumbnail img {
-        transform: scale(1.03);
+        transform: scale(1.05);
       }
 
       .item-body {
@@ -396,14 +398,20 @@ const PAGE_STYLES = `
         flex-direction: column;
         gap: var(--space-xs);
         flex: 1;
-        padding-top: var(--space-sm);
+        min-width: 0;
       }
 
-      .item-card-header {
+      .item-card-footer {
         display: flex;
-        justify-content: space-between;
         align-items: center;
         gap: var(--space-sm);
+        flex-wrap: wrap;
+      }
+
+      .badge-sm {
+        font-size: 0.7rem;
+        padding: 1px 6px;
+        white-space: nowrap;
       }
 
       .item-title {
@@ -427,7 +435,7 @@ const PAGE_STYLES = `
 
       .item-domain, .meta-text, .updated-at {
         color: var(--color-text-muted);
-        font-size: 0.8rem;
+        font-size: 0.75rem;
       }
 
       .item-note {
@@ -654,21 +662,18 @@ const PAGE_STYLES = `
         margin-bottom: var(--space-lg);
       }
 
-      @media (max-width: 1024px) {
-        .items {
-          grid-template-columns: repeat(2, 1fr);
-        }
-      }
-
       @media (max-width: 768px) {
         .items {
           grid-template-columns: 1fr;
         }
 
+        .item-thumbnail {
+          width: 100px;
+        }
+
         .playlist-meta,
         .owner-controls,
-        .visibility-section,
-        .item-card-header {
+        .visibility-section {
           flex-direction: column;
           align-items: flex-start;
         }


### PR DESCRIPTION
## Summary
- Fix article links in playlist detail page redirecting to home (getItemHref + backward-compatible alias slugs)
- Add YouTube thumbnail display with left-side horizontal card layout (2-column grid)
- Add canonical URL/Giscus unification for alias pages (BaseLayout + Comments)
- Update playlists feature doc and troubleshooting doc