### PR TITLE
fix(ci): use PAT for enablePullRequestAutoMerge

### DIFF
--- a/.github/workflows/admin-pr-auto-merge.yml
+++ b/.github/workflows/admin-pr-auto-merge.yml
@@ -67,7 +67,10 @@ jobs:
       - name: Enable auto-merge (squash)
         if: steps.check_editor.outputs.is_editor == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # GITHUB_TOKEN은 enablePullRequestAutoMerge GraphQL mutation에 대해
+          # "Resource not accessible by integration" 오류를 반환한다.
+          # process-submission.yml도 동일한 이유로 secrets.PAT를 사용한다.
+          GH_TOKEN: ${{ secrets.PAT }}
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |


### PR DESCRIPTION
## Context

PR #78 introduced \`.github/workflows/admin-pr-auto-merge.yml\` using \`secrets.GITHUB_TOKEN\`. The first run on PR #78 itself failed with:

\`\`\`
GraphQL: Resource not accessible by integration (enablePullRequestAutoMerge)
\`\`\`

The default \`GITHUB_TOKEN\` does not grant permission for the \`enablePullRequestAutoMerge\` GraphQL mutation regardless of \`permissions:\` block settings. \`process-submission.yml\` already hit the exact same issue on its \`Auto-merge if editor\` step and uses \`secrets.PAT\`.

## Fix

Switch the \`Enable auto-merge (squash)\` step's \`GH_TOKEN\` to \`secrets.PAT\`, matching the existing convention in \`process-submission.yml\`. Reading \`editors.json\` in the previous step still works with \`GITHUB_TOKEN\` (read-only API), so only the merge-enabling step needs the PAT.

Inline comment added to document WHY PAT is used, preventing future regressions.

## Self-demonstration

This PR itself is the verification: if the fix works, the workflow (now running the fixed code from the PR branch) will enable auto-merge and this PR will merge when \`ci\` passes. If not, manual fallback (\`gh pr merge 79 --auto --squash --delete-branch\`) will be run per AGENTS.md.