### PR TITLE
feat(home): add intro, recent articles, trending and influencer sections

### DIFF
--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -106,7 +106,7 @@
 
 | URL | 페이지 | 설명 |
 |-----|--------|------|
-| `/` | `index.astro` | 메인 (CSS 애니메이션 로고 + CTA) |
+| `/` | `index.astro` | 메인 (히어로 + 소개 + 최근 기사 6 + 트렌딩 플레이리스트 3 + 추천 인플루언서 4) |
 | `/articles` | `articles/index.astro` | 기사 목록 (SourceFilter: 전체/에디터추천/제출기사/RSS) |
 | `/articles/[slug]` | `articles/[...slug].astro` | 개별 기사 (curated만) |
 | `/trending` | `trending.astro` | 트렌딩 플레이리스트 (Astro SSG shell + client fetch, 좋아요 수 순위) |
@@ -221,3 +221,4 @@ src/ (pages + components + data + content) → astro build → dist/
 | 2026-04-13 | merge=approval 전환, 에디터 자동 merge, editors.json 추가 |
 | 2026-04-14 | 커뮤니티 자유 발제 기능 추가 (GitHub Discussions 기반, /community 페이지, api/discussions/* API) |
 | 2026-04-16 | CI 파이프라인에 wrangler 직접 배포 추가 (Cloudflare GitHub App 이벤트 누락 근본 해결) |
+| 2026-04-17 | 메인 페이지 콘텐츠 허브화 — 소개 섹션·최근 기사·트렌딩·추천 인플루언서 추가, `color-scheme: light` 메타/CSS로 라이트 모드 고정 |

--- a/docs/features/main-page-redesign.md
+++ b/docs/features/main-page-redesign.md
@@ -1,61 +1,90 @@
 # 메인 페이지 리디자인
 
-> 메인 페이지를 CSS 애니메이션 로고 + CTA 버튼 2개(기사 보기, 트렌드 랭킹)로 단순화하고, 다크모드를 제거하여 흰색 배경 통일
+> 히어로 로고 + CTA 위에 소개, 최근 기사(6), 트렌딩 플레이리스트(3), 추천 인플루언서(4)를 추가해 공백을 해소한 콘텐츠 허브형 레이아웃. 라이트 모드 고정.
 
 ## 개요
 
-메인 페이지를 브랜드 아이덴티티 중심으로 리디자인했다. 기존의 정적 히어로 이미지와 최근 기사 섹션을 제거하고, 육각형 조각이 순차 등장하는 CSS 애니메이션 로고를 메인 비주얼로 배치했다. 로고 이미지 내에 "HONEY COMBO" 텍스트가 포함되어 있어 별도 헤딩이 불필요하다.
+메인 페이지는 두 단계로 진화했다.
 
-다크모드를 전면 제거하고 배경색을 `#FFFFFF`(흰색)로 통일하여 로고 이미지 배경과 페이지 배경 사이에 경계가 보이지 않도록 했다.
+1. **1단계 (2026-04-17 이전)**: CSS 애니메이션 로고 + CTA 버튼 2개만 있는 브랜드 아이덴티티 중심 구성. 스크롤이 짧고 공백이 많아 첫 방문자가 사이트의 가치 제안(3-pillar 큐레이션 모델)을 인지하기 어려웠다.
+2. **2단계 (현재)**: 기존 히어로는 유지하되 하단 패딩을 줄이고, 그 아래에 4개의 콘텐츠 섹션을 추가했다. 새 컴포넌트를 만들지 않고 기존 `ArticleCard`, `InfluencerCard`, 기존 디자인 토큰만 사용한다.
+
+라이트 모드는 완전히 고정된다. 로고 이미지 조각의 배경이 흰색이라 OS 다크모드 적용 시 로고와 페이지 배경 사이에 경계가 드러나는 문제를 차단하기 위해, CSS(`color-scheme: light`)와 HTML(`<meta name="color-scheme" content="light">`) 양쪽에서 명시한다.
 
 ## 동작 흐름
 
 ```
-페이지 로드 → initHoneyComboLogo() 호출 → 9개 PNG 조각을 컨테이너에 배치 → 순차적 딜레이로 scale/fade 애니메이션 → CTA 버튼 표시
+페이지 로드
+  ↓
+[Hero] initHoneyComboLogo() → 9개 PNG 조각을 순차 scale/fade 애니메이션
+  ↓
+[Intro] 정적 마크업 (README 기반 카피 + 3-pillar 뱃지)
+  ↓
+[최근 기사] 빌드 타임: getCollection('curated', status=approved) + getCollection('feeds')
+         → compareArticles 로 날짜 내림차순 정렬 → 상위 6개 슬라이싱
+         → ArticleCard × 6 (grid-3)
+  ↓
+[트렌딩 플레이리스트] 빌드 타임: 스켈레톤 3개 렌더링
+         런타임: loadHomeTrending() → fetch('/api/trending?page=1&limit=3')
+         → 응답의 data.playlists.slice(0, 3) 을 인라인 카드 HTML 로 치환
+  ↓
+[추천 인플루언서] 빌드 타임: getCollection('influencers').slice(0, 4)
+         → InfluencerCard × 4 (grid-2, 모바일 1열)
 ```
 
-- 8개 육각형 그룹(`group_1.png` ~ `group_8.png`)이 0~900ms 사이에 순차 등장
-- 텍스트(`text_honey_combo.png`)가 1200ms 후 slide-up으로 등장
-- Astro 클라이언트 네비게이션(`astro:page-load`)에서도 애니메이션 재생
+- 기사 날짜 필드는 `submitted_at` 우선, 없으면 `published_at`을 사용한다 (`articles/index.astro`와 동일 로직).
+- 기사 수집·인플루언서 수집 실패 시 빈 배열 fallback + 안내 메시지 표시.
+- 트렌딩 API 실패/빈 응답 시 스켈레톤을 에러 안내로 교체한다.
 
 ## 관련 파일
 
 | 파일 | 역할 |
 |------|------|
-| `src/pages/index.astro` | 메인 페이지 — 애니메이션 로고 + CTA 버튼 |
-| `public/images/logo/group_*.png` | 로고 육각형 조각 이미지 8개 |
-| `public/images/logo/text_honey_combo.png` | 로고 텍스트 이미지 |
-| `src/styles/global.css` | 글로벌 CSS — 다크모드 제거, 배경색 #FFFFFF |
-| `src/layouts/BaseLayout.astro` | 레이아웃 — 다크모드 preload 제거 |
-| `functions/lib/layout.ts` | Functions 레이아웃 — 다크모드 제거 |
-| `src/components/Comments.astro` | Giscus 테마 light 고정 |
-| `src/components/CommunityComments.astro` | Giscus 테마 light 고정 |
-| `public/scripts/community-page.js` | Giscus 테마 light 고정 |
+| `src/pages/index.astro` | 메인 페이지 — 히어로 + Intro + 4개 콘텐츠 섹션, 로고 애니메이션 스크립트, 트렌딩 클라이언트 fetch |
+| `src/components/ArticleCard.astro` | 최근 기사 섹션 카드 (재사용) |
+| `src/components/InfluencerCard.astro` | 추천 인플루언서 섹션 카드 (재사용) |
+| `src/lib/article-sort.ts` | `compareArticles` — 최근 기사 정렬용 공유 비교 함수 |
+| `src/layouts/BaseLayout.astro` | `<meta name="color-scheme" content="light">` 삽입 위치 |
+| `src/styles/global.css` | `:root { color-scheme: light; ... }` 토큰 선언 |
+| `functions/api/trending.ts` | 트렌딩 API 엔드포인트 (`{ page, total, totalPages, playlists: [...] }` 응답) |
+| `public/images/logo/group_*.png` | 로고 육각형 조각 이미지 8개 (히어로) |
+| `public/images/logo/text_honey_combo.png` | 로고 텍스트 이미지 (히어로) |
 
 ## 설정값
 
 | 이름 | 위치 | 기본값 | 설명 |
 |------|------|--------|------|
-| `--hc-duration` | `src/pages/index.astro` | `0.7s` | 각 조각 애니메이션 시간 |
+| `--hc-duration` | `src/pages/index.astro` | `0.7s` | 로고 각 조각 애니메이션 시간 |
 | `maxDelay` | `src/pages/index.astro` | `900` | 마지막 육각형 등장 딜레이(ms) |
 | `textDelay` | `src/pages/index.astro` | `1200` | 텍스트 등장 딜레이(ms) |
 | `startDelay` | `src/pages/index.astro` | `300` | 전체 시작 대기(ms) |
-| `--color-bg` | `src/styles/global.css` | `#FFFFFF` | 페이지 배경색 |
+| `recentArticles.length` | `src/pages/index.astro` | `6` | 최근 기사 섹션 표시 개수 |
+| `featuredInfluencers.length` | `src/pages/index.astro` | `4` | 추천 인플루언서 섹션 표시 개수 |
+| 트렌딩 요청 | `loadHomeTrending()` | `/api/trending?page=1&limit=3` | 홈 트렌딩 섹션 카드 개수 |
+| `--color-bg` | `src/styles/global.css` | `#FFFFFF` | 페이지 배경색 (라이트 모드 고정) |
+| `color-scheme` | `src/styles/global.css`, `src/layouts/BaseLayout.astro` | `light` | 브라우저 네이티브 위젯(스크롤바/폼)까지 라이트로 강제 |
 
 ## 제약 사항
 
-- 다크모드가 완전히 제거되어 OS 다크모드 설정과 무관하게 항상 라이트 테마로 표시된다
-- 로고 애니메이션은 9개 PNG 이미지에 의존하므로 `public/images/logo/` 디렉토리가 필수
-- 로고 이미지 배경이 흰색이므로 페이지 배경도 흰색으로 고정해야 경계가 보이지 않음
+- OS 다크모드 설정과 무관하게 항상 라이트 테마로 표시된다. 배경 흰색 로고 이미지와 페이지 배경의 경계 문제를 차단하기 위함이다.
+- 홈에 새 컴포넌트를 만들지 않는다. 기존 `ArticleCard`, `InfluencerCard`와 인라인 트렌딩 카드 마크업만 사용한다. 트렌딩 카드는 `.trending-page` 스코프로 묶인 `trending.astro`의 `is:global` 스타일과 선택자가 충돌하지 않도록 `home-playlist-*` 접두어를 사용해 독립적으로 스타일링한다.
+- 기사 날짜 정렬은 `src/lib/article-sort.ts`의 `compareArticles`에 전적으로 위임한다. 홈은 `/articles` 페이지와 정렬 순서가 동일해야 한다.
+- 트렌딩 섹션은 클라이언트 fetch 기반이다. API가 다운되면 섹션은 안내 메시지로 그레이스풀하게 전환되며, 나머지 섹션은 영향을 받지 않는다.
+- `recentArticles`가 0건이거나 `featuredInfluencers`가 0명일 때도 페이지는 정상 렌더링되며 각 섹션이 빈 상태 안내로 대체된다.
 
 ---
 
 ## 관련 문서
 
 - [아키텍처 개요](../architecture/overview.md)
+- [히어로 섹션](./hero-section.md)
+- [트렌딩 플레이리스트](./trending-playlists.md)
+- [추천 인플루언서](./influencers.md)
+- [기사 소스 필터](./source-filter.md)
 
 ## 변경 이력
 
 | 날짜 | 변경 내용 |
 |------|----------|
 | 2026-04-17 | 최초 작성 — 메인 페이지 리디자인 및 다크모드 제거 |
+| 2026-04-17 | 메인 페이지 콘텐츠 허브화 — 소개 섹션·최근 기사 6·트렌딩 3·추천 인플루언서 4 섹션 추가, `color-scheme: light` CSS/Meta로 라이트 모드 명시 고정 |

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -29,6 +29,7 @@ const canonicalUrl = new URL(canonicalPath || Astro.url.pathname, siteUrl).href;
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="color-scheme" content="light" />
     <meta name="description" content={description} />
     <title>{title}</title>
     <link rel="canonical" href={canonicalUrl} />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,5 +1,36 @@
 ---
+import { getCollection } from 'astro:content';
 import BaseLayout from '../layouts/BaseLayout.astro';
+import ArticleCard from '../components/ArticleCard.astro';
+import InfluencerCard from '../components/InfluencerCard.astro';
+import { compareArticles } from '../lib/article-sort';
+
+const curatedEntries = await getCollection('curated', (entry: any) => entry.data.status === 'approved').catch((err: unknown) => {
+  console.error('Failed to load curated collection:', err);
+  return [];
+});
+
+const feedEntries = await getCollection('feeds').catch((err: unknown) => {
+  console.error('Failed to load feeds collection:', err);
+  return [];
+});
+
+const allArticles = [
+  ...curatedEntries.map((e: any) => ({
+    ...e.data,
+    _type: (e.data.source === 'User Submission' || e.data.source === 'YouTube') && e.data.submitted_by ? 'submitted' as const : 'curated' as const,
+    _id: e.id,
+  })),
+  ...feedEntries.map((e: any) => ({ ...e.data, _type: 'feed' as const, _id: e.id })),
+].sort(compareArticles);
+
+const recentArticles = allArticles.slice(0, 6);
+
+const influencerEntries = await getCollection('influencers').catch((err: unknown) => {
+  console.error('Failed to load influencers collection:', err);
+  return [];
+});
+const featuredInfluencers = influencerEntries.slice(0, 4);
 ---
 
 <BaseLayout title="HoneyCombo — 기술 뉴스 큐레이션">
@@ -10,25 +41,133 @@ import BaseLayout from '../layouts/BaseLayout.astro';
       <a href="/trending" class="btn btn-secondary">트렌드 랭킹</a>
     </div>
   </section>
+
+  <section class="home-intro">
+    <h2 class="home-intro-title">저비용 기술 뉴스 큐레이션</h2>
+    <p class="home-intro-description">
+      RSS 자동 수집 · 에디터 큐레이션 · 커뮤니티 제출 —
+      세 가지 소스를 한곳에서 모아 최신 기술 뉴스와 인사이트를 빠르게 탐색하세요.
+    </p>
+    <div class="home-intro-pillars">
+      <span class="badge home-pillar-badge">📡 RSS 피드</span>
+      <span class="badge home-pillar-badge">✍️ 에디터 큐레이션</span>
+      <span class="badge home-pillar-badge">🙋 커뮤니티 제출</span>
+    </div>
+  </section>
+
+  <section class="home-section">
+    <div class="home-section-header">
+      <h2 class="home-section-title">📰 최근 기사</h2>
+      <a href="/articles" class="home-section-link">모든 기사 보기 →</a>
+    </div>
+    {recentArticles.length > 0 ? (
+      <div class="grid grid-3" data-testid="home-recent-articles">
+        {recentArticles.map((article: any) => (
+          <ArticleCard
+            id={article._id}
+            title={article.title}
+            url={article.url}
+            source={article.source}
+            type={article.type}
+            description={article.description}
+            tags={article.tags}
+            date={'submitted_at' in article && article.submitted_at ? article.submitted_at : article.published_at}
+            thumbnail_url={article.thumbnail_url}
+            isExternal={false}
+            slug={article._id}
+            articleOrigin={article._type}
+          />
+        ))}
+      </div>
+    ) : (
+      <p class="home-empty-state">기사를 수집 중입니다. 잠시 후 다시 확인해주세요.</p>
+    )}
+  </section>
+
+  <section class="home-section home-trending-section">
+    <div class="home-section-header">
+      <h2 class="home-section-title">🔥 트렌딩 플레이리스트</h2>
+      <a href="/trending" class="home-section-link">전체 랭킹 보기 →</a>
+    </div>
+    <div class="grid grid-3" id="home-trending-grid" aria-live="polite" data-testid="home-trending-grid">
+      <article class="card home-playlist-card home-playlist-skeleton">
+        <div class="home-playlist-header">
+          <span class="home-skel home-skel-title"></span>
+          <span class="home-skel home-skel-count"></span>
+        </div>
+        <span class="home-skel home-skel-text"></span>
+        <span class="home-skel home-skel-text home-skel-text-short"></span>
+        <div class="home-playlist-footer">
+          <span class="home-skel home-skel-author"></span>
+          <span class="home-skel home-skel-rank"></span>
+        </div>
+      </article>
+      <article class="card home-playlist-card home-playlist-skeleton">
+        <div class="home-playlist-header">
+          <span class="home-skel home-skel-title"></span>
+          <span class="home-skel home-skel-count"></span>
+        </div>
+        <span class="home-skel home-skel-text"></span>
+        <span class="home-skel home-skel-text home-skel-text-short"></span>
+        <div class="home-playlist-footer">
+          <span class="home-skel home-skel-author"></span>
+          <span class="home-skel home-skel-rank"></span>
+        </div>
+      </article>
+      <article class="card home-playlist-card home-playlist-skeleton">
+        <div class="home-playlist-header">
+          <span class="home-skel home-skel-title"></span>
+          <span class="home-skel home-skel-count"></span>
+        </div>
+        <span class="home-skel home-skel-text"></span>
+        <span class="home-skel home-skel-text home-skel-text-short"></span>
+        <div class="home-playlist-footer">
+          <span class="home-skel home-skel-author"></span>
+          <span class="home-skel home-skel-rank"></span>
+        </div>
+      </article>
+    </div>
+  </section>
+
+  <section class="home-section">
+    <div class="home-section-header">
+      <h2 class="home-section-title">⭐ 추천 인플루언서</h2>
+      <a href="/influencers" class="home-section-link">전체 보기 →</a>
+    </div>
+    {featuredInfluencers.length > 0 ? (
+      <div class="grid grid-2" data-testid="home-featured-influencers">
+        {featuredInfluencers.map((inf: any) => (
+          <InfluencerCard
+            id={inf.data.id}
+            name={inf.data.name}
+            platform={inf.data.platform}
+            handle={inf.data.handle}
+            bio={inf.data.bio}
+          />
+        ))}
+      </div>
+    ) : (
+      <p class="home-empty-state">인플루언서를 준비 중입니다.</p>
+    )}
+  </section>
 </BaseLayout>
 
 <style>
 .hero {
   text-align: center;
-  padding: var(--space-xl) 0 var(--space-2xl);
+  padding: var(--space-xl) 0 var(--space-xl);
   display: flex;
   flex-direction: column;
   align-items: center;
 }
 
-/* Honey Combo Logo Animation */
 .honey-combo-logo {
   --hc-duration: 0.7s;
   position: relative;
   width: 100%;
   max-width: 860px;
   aspect-ratio: 4000 / 2209;
-  margin: 0 auto var(--space-xl);
+  margin: 0 auto var(--space-lg);
 }
 
 .honey-combo-logo :global(.hc-piece) {
@@ -56,7 +195,6 @@ import BaseLayout from '../layouts/BaseLayout.astro';
   100% { opacity: 1; transform: translateY(0); }
 }
 
-/* CTA Buttons */
 .hero-actions {
   display: flex;
   gap: var(--space-md);
@@ -99,12 +237,227 @@ import BaseLayout from '../layouts/BaseLayout.astro';
   text-decoration: none;
 }
 
+.home-intro {
+  text-align: center;
+  padding: var(--space-lg) var(--space-md);
+  background: var(--color-bg-secondary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  margin-bottom: var(--space-xl);
+}
+.home-intro-title {
+  font-size: clamp(1.4rem, 3vw, 1.85rem);
+  font-weight: 800;
+  line-height: 1.3;
+  margin-bottom: var(--space-sm);
+  color: var(--color-text);
+}
+.home-intro-description {
+  color: var(--color-text-muted);
+  font-size: 1rem;
+  line-height: 1.6;
+  max-width: 640px;
+  margin: 0 auto var(--space-md);
+}
+.home-intro-pillars {
+  display: flex;
+  gap: var(--space-sm);
+  justify-content: center;
+  flex-wrap: wrap;
+}
+.home-pillar-badge {
+  background: var(--color-bg);
+  color: var(--color-text);
+  border: 1px solid var(--color-border);
+  text-transform: none;
+  letter-spacing: 0;
+  font-weight: 600;
+  padding: var(--space-xs) var(--space-md);
+  font-size: 0.8rem;
+}
+
+.home-section {
+  padding: var(--space-lg) 0;
+}
+.home-section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: var(--space-md);
+  flex-wrap: wrap;
+  gap: var(--space-sm);
+}
+.home-section-title {
+  font-size: 1.4rem;
+  font-weight: 700;
+  color: var(--color-text);
+}
+.home-section-link {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--color-primary);
+  text-decoration: none;
+  transition: color 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+}
+.home-section-link:hover,
+.home-section-link:focus-visible {
+  color: var(--color-primary-hover);
+  text-decoration: underline;
+  outline: none;
+}
+.home-empty-state {
+  text-align: center;
+  padding: var(--space-2xl) var(--space-md);
+  color: var(--color-text-muted);
+  background: var(--color-bg-secondary);
+  border: 1px dashed var(--color-border);
+  border-radius: var(--radius-md);
+}
+
+.home-playlist-card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+  color: var(--color-text);
+  text-decoration: none;
+  min-height: 160px;
+}
+.home-playlist-card:hover {
+  text-decoration: none;
+}
+.home-playlist-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: var(--space-sm);
+}
+.home-playlist-title {
+  font-size: 1.05rem;
+  font-weight: 700;
+  line-height: 1.35;
+}
+.home-playlist-title a {
+  color: var(--color-text);
+  text-decoration: none;
+}
+.home-playlist-title a:hover,
+.home-playlist-title a:focus-visible {
+  color: var(--color-primary);
+  outline: none;
+}
+.home-playlist-count {
+  font-size: 0.8rem;
+  color: var(--color-text-muted);
+  background: var(--color-bg-secondary);
+  padding: 2px var(--space-sm);
+  border-radius: var(--radius-sm);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+.home-playlist-description {
+  font-size: 0.875rem;
+  color: var(--color-text-muted);
+  line-height: 1.5;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+.home-playlist-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: auto;
+  gap: var(--space-sm);
+}
+.home-playlist-curator {
+  font-size: 0.8rem;
+  color: var(--color-text-muted);
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.home-curator-avatar {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  object-fit: cover;
+  flex-shrink: 0;
+}
+.home-playlist-stats {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-sm);
+  flex-shrink: 0;
+}
+.home-rank-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 2.2rem;
+  padding: 0.18rem 0.45rem;
+  border-radius: 999px;
+  background: var(--color-accent);
+  color: var(--color-text);
+  font-weight: 800;
+  font-size: 0.75rem;
+}
+.home-like-count {
+  color: var(--color-text-muted);
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.home-skel {
+  display: block;
+  background: linear-gradient(90deg, var(--color-bg-secondary) 25%, rgba(255, 255, 255, 0.6) 50%, var(--color-bg-secondary) 75%);
+  background-size: 200% 100%;
+  animation: home-skel-shimmer 1.4s ease-in-out infinite;
+  border-radius: var(--radius-sm);
+}
+.home-skel-title { width: 70%; height: 1.1rem; }
+.home-skel-count { width: 2.2rem; height: 1rem; }
+.home-skel-text { width: 100%; height: 0.85rem; }
+.home-skel-text-short { width: 80%; }
+.home-skel-author { width: 6rem; height: 0.8rem; }
+.home-skel-rank { width: 3rem; height: 0.9rem; }
+
+@keyframes home-skel-shimmer {
+  0%   { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+
+@media (max-width: 768px) {
+  .home-playlist-footer {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: var(--space-xs);
+  }
+  .home-playlist-stats {
+    width: 100%;
+    justify-content: flex-end;
+  }
+}
+
 @media (max-width: 600px) {
   .hero {
-    padding: var(--space-md) 0 var(--space-xl);
+    padding: var(--space-md) 0 var(--space-lg);
   }
   .honey-combo-logo {
     max-width: 100%;
+  }
+  .home-intro {
+    padding: var(--space-md);
+  }
+  .home-intro-title {
+    font-size: 1.25rem;
+  }
+  .home-section-header {
+    flex-direction: column;
+    align-items: flex-start;
   }
 }
 </style>
@@ -154,6 +507,66 @@ function initHoneyComboLogo(options: Record<string, any> = {}) {
   });
 }
 
-// Play on page load and on Astro client-side navigation
-document.addEventListener('astro:page-load', () => initHoneyComboLogo());
+function escapeHtml(value: unknown): string {
+  return String(value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+async function loadHomeTrending() {
+  const grid = document.getElementById('home-trending-grid');
+  if (!grid) return;
+
+  try {
+    const res = await fetch('/api/trending?page=1&limit=3', { credentials: 'same-origin' });
+    if (!res.ok) throw new Error('trending fetch failed');
+    const data = await res.json();
+    const playlists = Array.isArray(data?.playlists) ? data.playlists.slice(0, 3) : [];
+
+    if (playlists.length === 0) {
+      grid.innerHTML = '<p class="home-empty-state">아직 공개된 플레이리스트가 없습니다.</p>';
+      return;
+    }
+
+    grid.innerHTML = playlists.map((p: any, index: number) => {
+      const playlistId = escapeHtml(p.id ?? '');
+      const title = escapeHtml(p.title ?? '제목 없음');
+      const itemCount = Number(p.item_count || 0);
+      const likeCount = Number(p.like_count || 0);
+      const username = escapeHtml((p.user && p.user.username) || 'unknown');
+      const description = (p.description && String(p.description).trim())
+        ? escapeHtml(p.description)
+        : `@${username}의 플레이리스트 · ${itemCount}개 기사`;
+      const avatarHtml = p.user && p.user.avatar_url
+        ? `<img src="${escapeHtml(p.user.avatar_url)}" alt="" class="home-curator-avatar" />`
+        : '';
+      const rank = index + 1;
+
+      return `<article class="card home-playlist-card">
+        <div class="home-playlist-header">
+          <h3 class="home-playlist-title"><a href="/p/${playlistId}">${title}</a></h3>
+          <span class="home-playlist-count">${itemCount}개</span>
+        </div>
+        <p class="home-playlist-description">${description}</p>
+        <div class="home-playlist-footer">
+          <span class="home-playlist-curator">${avatarHtml}by @${username}</span>
+          <span class="home-playlist-stats">
+            <span class="home-rank-badge">#${rank}</span>
+            <span class="home-like-count">❤️ ${likeCount}</span>
+          </span>
+        </div>
+      </article>`;
+    }).join('');
+  } catch {
+    grid.innerHTML = '<p class="home-empty-state">트렌딩 플레이리스트를 불러오지 못했습니다. 잠시 후 다시 시도해주세요.</p>';
+  }
+}
+
+document.addEventListener('astro:page-load', () => {
+  initHoneyComboLogo();
+  loadHomeTrending();
+});
 </script>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,5 +1,6 @@
 /* Design Tokens */
 :root {
+  color-scheme: light;
   --color-bg: #FFFFFF;
   --color-bg-secondary: #FFF8F0;
   --color-text: #2F2B31;


### PR DESCRIPTION
## Summary

메인 페이지를 기존 \"히어로 로고 + CTA 2개\" 구성에서 콘텐츠 허브형 레이아웃으로 확장한다. 공백이 많았던 홈 아래 영역을 기존 자산만으로 채워 첫 방문자가 사이트의 3-pillar 큐레이션 모델(RSS 피드 / 에디터 큐레이션 / 커뮤니티 제출)과 실제 콘텐츠를 바로 탐색할 수 있도록 한다.

## 변경 내역

- **`src/pages/index.astro` 재작성**: 히어로 하단 패딩 축소(\`--space-2xl\` → \`--space-xl\`) 후 다음 섹션을 순차 추가
  - 🟠 **Intro 섹션**: README 기반 \"저비용 기술 뉴스 큐레이션\" 카피 + 3-pillar 뱃지
  - 📰 **최근 기사 6개**: \`curated+feeds\` 병합 최신순, \`ArticleCard\` 재사용, \`grid-3\`
  - 🔥 **트렌딩 플레이리스트 3개**: \`/api/trending?page=1&limit=3\` 클라이언트 fetch + 스켈레톤 초기화, 홈 전용 \`home-playlist-*\` 스타일로 \`trending.astro\`의 \`.trending-page\` 스코프와 충돌 방지
  - ⭐ **추천 인플루언서 4명**: \`InfluencerCard\` 재사용, \`grid-2\`
- **라이트 모드 고정**: \`src/styles/global.css\`에 \`color-scheme: light\` 토큰, \`src/layouts/BaseLayout.astro\`에 \`<meta name=\"color-scheme\" content=\"light\">\` 추가. 흰색 배경 로고 이미지와 페이지 배경 사이 경계가 OS 다크모드에서 드러나는 문제를 CSS/HTML 양쪽에서 차단.
- **문서**: \`docs/features/main-page-redesign.md\` 콘텐츠 허브화 반영, \`docs/architecture/overview.md\` 페이지 구조 및 변경 이력 업데이트.

## 설계 원칙

- 새 컴포넌트 미생성 — \`ArticleCard\`, \`InfluencerCard\`만 재사용
- 기사 정렬은 \`src/lib/article-sort.ts\`의 \`compareArticles\`에 위임 (\`/articles\` 페이지와 동일 순서)
- 데이터 소스 실패 시 섹션별로 graceful empty-state 안내 (전체 페이지 크래시 X)
- 디자인 토큰(\`var(--space-*)\`, \`var(--color-*)\`)만 사용, 색상 하드코딩 없음

## 로컬 검증 결과

\`\`\`
bun run validate              → ✅ 208 files valid (2 pre-existing dup warnings, unrelated)
bun run validate:docs         → ✅ 45 docs valid
bun run validate:docs --check-coverage → ✅ coverage OK
bun run build                 → ✅ 439 pages built
bun run test                  → 134/137 pass (3 pre-existing failures in rss-collect/process-submission, 내 변경과 무관 — master stash 상태에서도 동일 실패 확인)
\`\`\`

## 스크린샷 / 수동 QA

로컬 dev 서버에서 \`/\` 방문 시 섹션 순서 확인:
1. Hero (애니메이션 로고 + CTA) — 패딩 축소 확인
2. Intro (3-pillar 뱃지)
3. 최근 기사 6 (3열 × 2행, 모바일 1열)
4. 트렌딩 플레이리스트 3 (스켈레톤 → 실제 카드)
5. 추천 인플루언서 4 (2열 × 2행, 모바일 1열)

OS 다크모드 on 상태에서도 페이지가 라이트 모드로 유지됨을 확인 (\`<meta name=\"color-scheme\">\`).

## 관련 문서

- \`docs/features/main-page-redesign.md\`
- \`docs/architecture/overview.md\`