### PR TITLE
feat(home): refine trending card — /playlists anchor structure + polished typography

### DIFF
--- a/docs/features/main-page-redesign.md
+++ b/docs/features/main-page-redesign.md
@@ -24,9 +24,11 @@
          → compareArticles 로 날짜 내림차순 정렬 → 상위 6개 슬라이싱
          → ArticleCard × 6 (grid-3)
   ↓
-[트렌딩 플레이리스트] 빌드 타임: 스켈레톤 3개 렌더링
+[트렌딩 플레이리스트] 빌드 타임: "불러오는 중..." 로딩 상태 렌더링
          런타임: loadHomeTrending() → fetch('/api/trending?page=1&limit=3')
-         → 응답의 data.playlists.slice(0, 3) 을 인라인 카드 HTML 로 치환
+         → 응답의 data.playlists.slice(0, 3) 을 `<a class="card playlist-card">`
+           (header: 타이틀 2줄 클램프 + 기사 수 pill, footer: 큐레이터 + 랭크 뱃지
+           + 좋아요 수) 구조로 치환
   ↓
 [추천 인플루언서] 빌드 타임: getCollection('influencers').slice(0, 4)
          → InfluencerCard × 4 (grid-2, 모바일 1열)
@@ -67,7 +69,7 @@
 ## 제약 사항
 
 - OS 다크모드 설정과 무관하게 항상 라이트 테마로 표시된다. 배경 흰색 로고 이미지와 페이지 배경의 경계 문제를 차단하기 위함이다.
-- 홈에 새 컴포넌트를 만들지 않는다. 기존 `ArticleCard`, `InfluencerCard`와 인라인 트렌딩 카드 마크업만 사용한다. 트렌딩 카드는 `.trending-page` 스코프로 묶인 `trending.astro`의 `is:global` 스타일과 선택자가 충돌하지 않도록 `home-playlist-*` 접두어를 사용해 독립적으로 스타일링한다.
+- 홈에 새 컴포넌트를 만들지 않는다. 기존 `ArticleCard`, `InfluencerCard`와 `/playlists` 페이지의 카드 마크업(`<a class="card playlist-card">` + `playlist-header`/`-title`/`-count`/`-description`/`-footer`/`-curator`)을 그대로 재사용한다. 트렌딩 전용 랭크 뱃지·좋아요 수(`playlist-stats`·`rank-badge`·`like-count`)는 홈에서만 푸터 우측에 추가한다. 스타일은 `.home-trending-section :global(.playlist-card)` 로 스코프해 `/playlists` 의 `.community-section :global(...)`·`.editor-section :global(...)` 선택자, `/trending` 의 `.trending-page :global(...)` 선택자와 충돌하지 않게 분리한다. 홈 카드는 `/trending` 페이지 대비 타이포를 축소(`0.95rem/600`)하고 랭크 뱃지는 primary→accent 그라데이션 pill 로 정돈해 투박함을 줄였다.
 - 기사 날짜 정렬은 `src/lib/article-sort.ts`의 `compareArticles`에 전적으로 위임한다. 홈은 `/articles` 페이지와 정렬 순서가 동일해야 한다.
 - 트렌딩 섹션은 클라이언트 fetch 기반이다. API가 다운되면 섹션은 안내 메시지로 그레이스풀하게 전환되며, 나머지 섹션은 영향을 받지 않는다.
 - `recentArticles`가 0건이거나 `featuredInfluencers`가 0명일 때도 페이지는 정상 렌더링되며 각 섹션이 빈 상태 안내로 대체된다.
@@ -88,3 +90,4 @@
 |------|----------|
 | 2026-04-17 | 최초 작성 — 메인 페이지 리디자인 및 다크모드 제거 |
 | 2026-04-17 | 메인 페이지 콘텐츠 허브화 — 소개 섹션·최근 기사 6·트렌딩 3·추천 인플루언서 4 섹션 추가, `color-scheme: light` CSS/Meta로 라이트 모드 명시 고정 |
+| 2026-04-17 | 홈 트렌딩 카드 UI를 `/playlists` 구조(`<a class="card playlist-card">`)로 정렬하면서 랭크·좋아요 스탯은 유지. 타이포 축소(0.95rem/600), 랭크 뱃지 primary→accent 그라데이션 pill, 기사 수 tabular-nums pill, 아바타 18px, hover translateY(-2px) 등으로 정돈 |

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -89,43 +89,8 @@ const featuredInfluencers = influencerEntries.slice(0, 4);
       <h2 class="home-section-title">🔥 트렌딩 플레이리스트</h2>
       <a href="/trending" class="home-section-link">전체 랭킹 보기 →</a>
     </div>
-    <div class="grid grid-3" id="home-trending-grid" aria-live="polite" data-testid="home-trending-grid">
-      <article class="card home-playlist-card home-playlist-skeleton">
-        <div class="home-playlist-header">
-          <span class="home-skel home-skel-title"></span>
-          <span class="home-skel home-skel-count"></span>
-        </div>
-        <span class="home-skel home-skel-text"></span>
-        <span class="home-skel home-skel-text home-skel-text-short"></span>
-        <div class="home-playlist-footer">
-          <span class="home-skel home-skel-author"></span>
-          <span class="home-skel home-skel-rank"></span>
-        </div>
-      </article>
-      <article class="card home-playlist-card home-playlist-skeleton">
-        <div class="home-playlist-header">
-          <span class="home-skel home-skel-title"></span>
-          <span class="home-skel home-skel-count"></span>
-        </div>
-        <span class="home-skel home-skel-text"></span>
-        <span class="home-skel home-skel-text home-skel-text-short"></span>
-        <div class="home-playlist-footer">
-          <span class="home-skel home-skel-author"></span>
-          <span class="home-skel home-skel-rank"></span>
-        </div>
-      </article>
-      <article class="card home-playlist-card home-playlist-skeleton">
-        <div class="home-playlist-header">
-          <span class="home-skel home-skel-title"></span>
-          <span class="home-skel home-skel-count"></span>
-        </div>
-        <span class="home-skel home-skel-text"></span>
-        <span class="home-skel home-skel-text home-skel-text-short"></span>
-        <div class="home-playlist-footer">
-          <span class="home-skel home-skel-author"></span>
-          <span class="home-skel home-skel-rank"></span>
-        </div>
-      </article>
+    <div class="playlist-grid grid grid-3" id="home-trending-grid" aria-live="polite" data-testid="home-trending-grid">
+      <p class="loading-state">불러오는 중...</p>
     </div>
   </section>
 
@@ -314,48 +279,57 @@ const featuredInfluencers = influencerEntries.slice(0, 4);
   border-radius: var(--radius-md);
 }
 
-.home-playlist-card {
+.home-trending-section :global(.playlist-card) {
   display: flex;
   flex-direction: column;
   gap: var(--space-sm);
+  padding: var(--space-md) var(--space-md) var(--space-sm);
+  text-decoration: none;
   color: var(--color-text);
-  text-decoration: none;
-  min-height: 160px;
+  min-height: 148px;
+  transition: transform 0.2s cubic-bezier(0.4, 0, 0.2, 1), box-shadow 0.2s cubic-bezier(0.4, 0, 0.2, 1), border-color 0.2s;
 }
-.home-playlist-card:hover {
+.home-trending-section :global(.playlist-card:hover) {
   text-decoration: none;
+  transform: translateY(-2px);
 }
-.home-playlist-header {
+.home-trending-section :global(.playlist-header) {
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
   gap: var(--space-sm);
 }
-.home-playlist-title {
-  font-size: 1.05rem;
-  font-weight: 700;
-  line-height: 1.35;
-}
-.home-playlist-title a {
+.home-trending-section :global(.playlist-title) {
+  font-size: 0.95rem;
+  font-weight: 600;
+  line-height: 1.4;
+  letter-spacing: -0.005em;
   color: var(--color-text);
-  text-decoration: none;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  min-width: 0;
+  flex: 1;
 }
-.home-playlist-title a:hover,
-.home-playlist-title a:focus-visible {
-  color: var(--color-primary);
-  outline: none;
-}
-.home-playlist-count {
-  font-size: 0.8rem;
+.home-trending-section :global(.playlist-count) {
+  font-size: 0.7rem;
+  font-weight: 600;
   color: var(--color-text-muted);
   background: var(--color-bg-secondary);
-  padding: 2px var(--space-sm);
-  border-radius: var(--radius-sm);
+  padding: 2px 8px;
+  border-radius: 999px;
   white-space: nowrap;
   flex-shrink: 0;
+  line-height: 1.5;
 }
-.home-playlist-description {
-  font-size: 0.875rem;
+.home-trending-section :global(.playlist-count)::after {
+  content: '개';
+  margin-left: 1px;
+  opacity: 0.7;
+}
+.home-trending-section :global(.playlist-description) {
+  font-size: 0.8rem;
   color: var(--color-text-muted);
   line-height: 1.5;
   display: -webkit-box;
@@ -363,82 +337,81 @@ const featuredInfluencers = influencerEntries.slice(0, 4);
   -webkit-box-orient: vertical;
   overflow: hidden;
 }
-.home-playlist-footer {
+.home-trending-section :global(.playlist-footer) {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-top: auto;
   gap: var(--space-sm);
+  margin-top: auto;
+  padding-top: var(--space-xs);
 }
-.home-playlist-curator {
-  font-size: 0.8rem;
+.home-trending-section :global(.playlist-curator) {
+  font-size: 0.75rem;
   color: var(--color-text-muted);
   display: inline-flex;
   align-items: center;
-  gap: 4px;
+  gap: 6px;
+  min-width: 0;
+  flex-shrink: 1;
+}
+.home-trending-section :global(.playlist-curator-name) {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  min-width: 0;
 }
-.home-curator-avatar {
-  width: 16px;
-  height: 16px;
+.home-trending-section :global(.curator-avatar) {
+  width: 18px;
+  height: 18px;
   border-radius: 50%;
   object-fit: cover;
   flex-shrink: 0;
 }
-.home-playlist-stats {
+.home-trending-section :global(.playlist-stats) {
   display: inline-flex;
   align-items: center;
   gap: var(--space-sm);
   flex-shrink: 0;
 }
-.home-rank-badge {
+.home-trending-section :global(.rank-badge) {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-width: 2.2rem;
-  padding: 0.18rem 0.45rem;
+  min-width: 1.75rem;
+  padding: 3px 9px;
   border-radius: 999px;
-  background: var(--color-accent);
-  color: var(--color-text);
-  font-weight: 800;
-  font-size: 0.75rem;
+  background: linear-gradient(135deg, var(--color-primary), var(--color-accent));
+  color: white;
+  font-weight: 700;
+  font-size: 0.7rem;
+  letter-spacing: 0;
+  box-shadow: 0 1px 4px rgba(245, 124, 34, 0.25);
 }
-.home-like-count {
+.home-trending-section :global(.like-count) {
   color: var(--color-text-muted);
-  font-size: 0.8rem;
+  font-size: 0.75rem;
   font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  font-variant-numeric: tabular-nums;
+}
+.home-trending-section :global(.loading-state),
+.home-trending-section :global(.error-state),
+.home-trending-section :global(.empty-state) {
+  grid-column: 1 / -1;
+  text-align: center;
+  padding: var(--space-xl);
+  color: var(--color-text-muted);
 }
 
-.home-skel {
-  display: block;
-  background: linear-gradient(90deg, var(--color-bg-secondary) 25%, rgba(255, 255, 255, 0.6) 50%, var(--color-bg-secondary) 75%);
-  background-size: 200% 100%;
-  animation: home-skel-shimmer 1.4s ease-in-out infinite;
-  border-radius: var(--radius-sm);
-}
-.home-skel-title { width: 70%; height: 1.1rem; }
-.home-skel-count { width: 2.2rem; height: 1rem; }
-.home-skel-text { width: 100%; height: 0.85rem; }
-.home-skel-text-short { width: 80%; }
-.home-skel-author { width: 6rem; height: 0.8rem; }
-.home-skel-rank { width: 3rem; height: 0.9rem; }
-
-@keyframes home-skel-shimmer {
-  0%   { background-position: 200% 0; }
-  100% { background-position: -200% 0; }
-}
-
-@media (max-width: 768px) {
-  .home-playlist-footer {
-    flex-direction: column;
-    align-items: flex-start;
-    gap: var(--space-xs);
+@media (max-width: 600px) {
+  .home-trending-section :global(.playlist-footer) {
+    flex-wrap: wrap;
+    gap: var(--space-xs) var(--space-sm);
   }
-  .home-playlist-stats {
-    width: 100%;
-    justify-content: flex-end;
+  .home-trending-section :global(.playlist-stats) {
+    margin-left: auto;
   }
 }
 
@@ -527,7 +500,7 @@ async function loadHomeTrending() {
     const playlists = Array.isArray(data?.playlists) ? data.playlists.slice(0, 3) : [];
 
     if (playlists.length === 0) {
-      grid.innerHTML = '<p class="home-empty-state">아직 공개된 플레이리스트가 없습니다.</p>';
+      grid.innerHTML = '<p class="empty-state">아직 공개된 플레이리스트가 없습니다.</p>';
       return;
     }
 
@@ -537,31 +510,34 @@ async function loadHomeTrending() {
       const itemCount = Number(p.item_count || 0);
       const likeCount = Number(p.like_count || 0);
       const username = escapeHtml((p.user && p.user.username) || 'unknown');
-      const description = (p.description && String(p.description).trim())
-        ? escapeHtml(p.description)
-        : `@${username}의 플레이리스트 · ${itemCount}개 기사`;
+      const descriptionHtml = (p.description && String(p.description).trim())
+        ? `<p class="playlist-description">${escapeHtml(p.description)}</p>`
+        : '';
       const avatarHtml = p.user && p.user.avatar_url
-        ? `<img src="${escapeHtml(p.user.avatar_url)}" alt="" class="home-curator-avatar" />`
+        ? `<img src="${escapeHtml(p.user.avatar_url)}" alt="" class="curator-avatar" />`
         : '';
       const rank = index + 1;
 
-      return `<article class="card home-playlist-card">
-        <div class="home-playlist-header">
-          <h3 class="home-playlist-title"><a href="/p/${playlistId}">${title}</a></h3>
-          <span class="home-playlist-count">${itemCount}개</span>
+      return `<a href="/p/${playlistId}" class="card playlist-card">
+        <div class="playlist-header">
+          <h3 class="playlist-title">${title}</h3>
+          <span class="playlist-count">${itemCount}</span>
         </div>
-        <p class="home-playlist-description">${description}</p>
-        <div class="home-playlist-footer">
-          <span class="home-playlist-curator">${avatarHtml}by @${username}</span>
-          <span class="home-playlist-stats">
-            <span class="home-rank-badge">#${rank}</span>
-            <span class="home-like-count">❤️ ${likeCount}</span>
+        ${descriptionHtml}
+        <div class="playlist-footer">
+          <span class="playlist-curator">
+            ${avatarHtml}
+            <span class="playlist-curator-name">@${username}</span>
+          </span>
+          <span class="playlist-stats">
+            <span class="rank-badge">#${rank}</span>
+            <span class="like-count" aria-label="좋아요 ${likeCount}"><span aria-hidden="true">♥</span> ${likeCount}</span>
           </span>
         </div>
-      </article>`;
+      </a>`;
     }).join('');
   } catch {
-    grid.innerHTML = '<p class="home-empty-state">트렌딩 플레이리스트를 불러오지 못했습니다. 잠시 후 다시 시도해주세요.</p>';
+    grid.innerHTML = '<p class="error-state">트렌딩 플레이리스트를 불러오지 못했습니다. 잠시 후 다시 시도해주세요.</p>';
   }
 }
 


### PR DESCRIPTION
## Summary

홈 트렌딩 플레이리스트 카드 UI를 \`/playlists\` 페이지와 동일한 앵커 래퍼 구조로 정렬하되, 트렌딩 고유의 **랭크 뱃지 + 좋아요 수는 유지**. 타이포·뱃지·간격을 축소·정돈해 투박함을 줄였다.

> 이전 구현(PR #81)의 피드백: *\"랭크·좋아요 구조는 좋은데 타이틀이 너무 크고 전반적으로 투박하다. 장점만 통합해라.\"*

## /playlists 에서 가져온 것

- `<a class=\"card playlist-card\">` — 카드 전체 클릭 영역
- `playlist-header` / `playlist-title` / `playlist-count` / `playlist-description` / `playlist-footer` / `playlist-curator` 클래스 네이밍
- \"불러오는 중...\" 단일 로딩 메시지 (스켈레톤 3카드 제거)

## 트렌딩 고유로 유지한 것

- `playlist-stats` wrapper
- `rank-badge` — 순위 표시 (primary → accent 그라데이션 pill, subtle shadow)
- `like-count` — 좋아요 수 (♥ 기호 + tabular-nums 숫자 정렬)

## 정돈(refinement) 내역

| 요소 | 이전 | 이후 |
|---|---|---|
| 타이틀 | 1.05rem / weight 700 | **0.95rem / weight 600** + letter-spacing -0.005em + 2-line clamp |
| 기사 수 pill | radius 4px | **radius 999px** (pill), ::after 로 '개' 자동 추가 |
| 아바타 | 16 × 16px | **18 × 18px** (상대 비율 개선) |
| 랭크 뱃지 | 단색 accent 배경 | **primary → accent 그라데이션 pill** + 0 1px 4px rgba(primary,0.25) shadow |
| 좋아요 수 | ❤️ 이모지 | **♥ 기호** + `font-variant-numeric: tabular-nums` |
| Hover | — | **translateY(-2px)** + 기존 `.card:hover` border/shadow 상속 |
| 설명 | 0.875rem | **0.8rem** (무게 감소) |
| 패딩 | `.card` 기본값 var(--space-md) | `var(--space-md) var(--space-md) var(--space-sm)` (footer 축소) |
| 스켈레톤 | 3카드 shimmer | \"불러오는 중...\" 단일 텍스트 |

## 스타일 스코프

- `.home-trending-section :global(.playlist-card)` 로 스코프
- `/trending` 의 `.trending-page :global(...)` 와 **충돌 없음**
- `/playlists` 의 `.community-section :global(...)` / `.editor-section :global(...)` 와 **충돌 없음**

## 로컬 검증

\`\`\`
bun run validate                       → ✅ 208 files valid
bun run validate:docs                  → ✅ 45 docs valid  
bun run validate:docs --check-coverage → ✅ coverage OK
bun run build                          → ✅ 439 pages built in 9.9s
\`\`\`

빌드된 \`dist/index.html\` 에서 확인:
- `<div class=\"playlist-grid grid grid-3\" id=\"home-trending-grid\">` 내부 초기 `<p class=\"loading-state\">불러오는 중...</p>` 렌더
- CSS: `.home-trending-section[data-astro-cid-j7pv25f6] .playlist-card` + `.rank-badge` (gradient) + `.like-count` (tabular-nums) 전부 포함
- JS: `/api/trending?page=1&limit=3` fetch → `map((t, u) => ... rank=u+1 ...)` 로 랭크 산출 + 3개 카드 치환

## 관련 문서

- `docs/features/main-page-redesign.md` (변경 이력 추가)