### PR TITLE
fix: 멀티라인 Summary 마크다운 구조화 렌더링

### DIFF
--- a/docs/troubleshooting/multiline-summary-parsing.md
+++ b/docs/troubleshooting/multiline-summary-parsing.md
@@ -82,17 +82,36 @@ export function extractTitleFromNote(note: string): string {
 + let title = extractTitleFromNote(note) || url;
 ```
 
+### 4. UI 렌더링 — 멀티라인 마크다운 구조 표시
+
+파서 수정으로 `description`에 멀티라인 마크다운이 저장되지만, UI가 `<p>` 태그로 렌더링하여 `## 개요` 등 마크다운 마커가 원시 텍스트로 노출되는 문제 추가 수정.
+
+- `src/lib/render-summary.ts` 유틸리티 추가:
+  - `renderSummaryHtml()`: `## ` → `<h3>`, `- ` → `<li>`, 단락 → `<p>` 변환 (HTML 이스케이프 후 적용으로 XSS 방지)
+  - `stripMarkdownForPreview()`: 카드/메타 태그용 평문 변환 (헤딩 마커 제거, 줄바꿈 공백 변환)
+- `ContentTabs.astro`: `set:html`로 구조화 HTML 렌더링 (상세 페이지)
+- `ArticleCard.astro`: `stripMarkdownForPreview`로 카드 미리보기 정리
+- `TagFilter.astro`: 클라이언트 사이드 `stripMd` 인라인 함수로 동적 카드 정리
+- `[...slug].astro`: 메타 태그 description에 `stripMarkdownForPreview` 적용
+
 ## 관련 파일
 
 | 파일 | 변경 내용 |
 |------|----------|
 | `scripts/process-submission.ts` | `parseIssueBody` 멀티라인 note 수집, `extractTitleFromNote` 함수 추가, `processSubmission`/`processBulkSubmission` 제목 파생 변경 |
 | `tests/process-submission.test.ts` | 멀티라인 Summary 테스트, 구조화 Summary 테스트, `extractTitleFromNote` 단위 테스트, 제목 파생 통합 테스트 추가 |
+| `src/lib/render-summary.ts` | `renderSummaryHtml`, `stripMarkdownForPreview` 유틸리티 신규 |
+| `tests/render-summary.test.ts` | 렌더링/스트립 유틸리티 단위 테스트 |
+| `src/components/ContentTabs.astro` | 구조화 HTML 렌더링으로 변경 |
+| `src/components/ArticleCard.astro` | 마크다운 마커 제거 미리보기 |
+| `src/components/TagFilter.astro` | 클라이언트 사이드 마크다운 스트립 |
+| `src/pages/articles/[...slug].astro` | 메타 태그 description 마크다운 스트립 |
 
 ## 예방 조치
 
 - `### Summary` 섹션은 `### URL`, `### Type`, `### Tags`와 달리 단일 값이 아닌 자유 형식 텍스트를 받는 섹션이므로, 향후 유사한 자유 형식 섹션 추가 시 동일한 멀티라인 수집 패턴을 적용해야 함.
 - 대량 제출(`parseBulkIssueBody`)은 파이프 구분 단일 행 포맷이므로 이 문제와 무관함.
+- 향후 마크다운 포맷이 확장되면(코드 블록, 링크 등) `renderSummaryHtml`에 해당 변환 추가 필요.
 
 ---
 
@@ -106,3 +125,4 @@ export function extractTitleFromNote(note: string): string {
 | 날짜 | 변경 내용 |
 |------|----------|
 | 2026-04-20 | 최초 작성 |
+| 2026-04-20 | UI 렌더링 수정 추가 (ContentTabs, ArticleCard, TagFilter, 메타 태그) |

--- a/src/components/ArticleCard.astro
+++ b/src/components/ArticleCard.astro
@@ -1,6 +1,7 @@
 ---
 import AddToPlaylist from './AddToPlaylist.astro';
 import BookmarkButton from './BookmarkButton.astro';
+import { stripMarkdownForPreview } from '../lib/render-summary';
 
 interface Props {
   id: string;
@@ -41,7 +42,7 @@ const formattedDate = new Date(date).toLocaleDateString('ko-KR', { year: 'numeri
         {title}
       </a>
     </h3>
-    {description && <p class="article-description">{description}</p>}
+    {description && <p class="article-description">{stripMarkdownForPreview(description)}</p>}
     <div class="article-tags">
       {tags.map(tag => <span class="tag">{tag}</span>)}
     </div>

--- a/src/components/ContentTabs.astro
+++ b/src/components/ContentTabs.astro
@@ -1,9 +1,11 @@
 ---
+import { renderSummaryHtml } from '../lib/render-summary';
 interface Props {
   description?: string;
   url: string;
 }
 const { description, url } = Astro.props;
+const summaryHtml = description ? renderSummaryHtml(description) : '';
 ---
 
 <div class="content-tabs" data-url={url}>
@@ -30,9 +32,9 @@ const { description, url } = Astro.props;
 
   <div class="tab-panels">
     <div class="tab-panel active" id="panel-summary" role="tabpanel" data-panel="summary">
-      {description ? (
+      {summaryHtml ? (
         <div class="article-summary">
-          <p>{description}</p>
+          <Fragment set:html={summaryHtml} />
         </div>
       ) : (
         <p class="no-summary">요약이 제공되지 않았습니다.</p>
@@ -178,6 +180,28 @@ const { description, url } = Astro.props;
   .article-summary p {
     color: var(--color-text);
     line-height: 1.7;
+  }
+
+  .article-summary .summary-heading {
+    font-size: 1rem;
+    font-weight: 700;
+    color: var(--color-text);
+    margin: var(--space-md) 0 var(--space-xs);
+  }
+
+  .article-summary .summary-heading:first-child {
+    margin-top: 0;
+  }
+
+  .article-summary .summary-list {
+    margin: var(--space-xs) 0;
+    padding-left: var(--space-lg);
+    color: var(--color-text);
+    line-height: 1.7;
+  }
+
+  .article-summary .summary-list li {
+    margin-bottom: var(--space-xs);
   }
 
   .no-summary {

--- a/src/components/TagFilter.astro
+++ b/src/components/TagFilter.astro
@@ -59,6 +59,15 @@ function escapeHtml(str: string): string {
     .replace(/"/g, '&quot;');
 }
 
+function stripMd(text: string): string {
+  return text
+    .replace(/^#{1,6}\s+/gm, '')
+    .replace(/^[-*]\s+/gm, '• ')
+    .replace(/\n{2,}/g, ' ')
+    .replace(/\n/g, ' ')
+    .trim();
+}
+
 function renderCard(a: ClientArticle): string {
   const articleUrl = a.isExternal ? a.url : `/articles/${a.slug || a._id}`;
   const target = a.isExternal ? ' target="_blank" rel="noopener noreferrer"' : '';
@@ -76,7 +85,7 @@ function renderCard(a: ClientArticle): string {
   const sourceLabel = a.articleOrigin === 'submitted' ? 'User Submission' : source;
 
   const desc = a.description
-    ? `<p class="article-description">${escapeHtml(a.description)}</p>`
+    ? `<p class="article-description">${escapeHtml(stripMd(a.description))}</p>`
     : '';
 
   const tagsHtml = a.tags.map(t => `<span class="tag">${escapeHtml(t)}</span>`).join('');

--- a/src/lib/render-summary.ts
+++ b/src/lib/render-summary.ts
@@ -1,0 +1,92 @@
+/**
+ * Lightweight markdown rendering for structured article summaries.
+ *
+ * Supports the Korean summary format: ## headings, bullet lists, paragraphs.
+ * No external dependency — handles only the subset used by the submission spec.
+ *
+ * Security: all input is HTML-escaped before markdown transformation,
+ * preventing XSS from user-submitted content.
+ */
+
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+/**
+ * Convert structured summary markdown to HTML for the detail view.
+ *
+ * Input format (from agent-submission spec):
+ *   ## 개요
+ *   AI 에이전트를 프로덕션 환경에서 활용하는 실전 분석 기사
+ *   ## 주요 내용
+ *   - 에이전트 아키텍처 설계 패턴
+ *   - 프로덕션 배포 시 고려사항
+ *   ## 시사점
+ *   실무에서 바로 적용 가능한 에이전트 구축 가이드
+ *
+ * Also handles plain single-line descriptions for backward compatibility.
+ */
+export function renderSummaryHtml(markdown: string): string {
+  if (!markdown) return '';
+
+  const escaped = escapeHtml(markdown);
+  const blocks = escaped.split(/\n\n+/);
+  const html: string[] = [];
+
+  for (const block of blocks) {
+    const trimmed = block.trim();
+    if (!trimmed) continue;
+
+    const lines = trimmed.split('\n');
+
+    // Heading block: starts with ## (level-2 heading)
+    if (lines[0].startsWith('## ')) {
+      html.push(`<h3 class="summary-heading">${lines[0].slice(3)}</h3>`);
+      // Remaining lines in the same block are body text
+      const rest = lines.slice(1).filter((l) => l.trim());
+      if (rest.length > 0) {
+        if (rest.every((l) => l.trimStart().startsWith('- '))) {
+          html.push(
+            `<ul class="summary-list">${rest.map((l) => `<li>${l.trimStart().slice(2)}</li>`).join('')}</ul>`,
+          );
+        } else {
+          html.push(`<p>${rest.join('<br>')}</p>`);
+        }
+      }
+      continue;
+    }
+
+    // Standalone list block
+    if (lines.every((l) => l.trimStart().startsWith('- '))) {
+      html.push(
+        `<ul class="summary-list">${lines.map((l) => `<li>${l.trimStart().slice(2)}</li>`).join('')}</ul>`,
+      );
+      continue;
+    }
+
+    // Plain paragraph (including single-line legacy descriptions)
+    html.push(`<p>${lines.join('<br>')}</p>`);
+  }
+
+  return html.join('');
+}
+
+/**
+ * Strip markdown markers for plain-text contexts (card previews, meta tags, RSS).
+ *
+ * Converts structured markdown to a clean single-line text suitable for
+ * <meta> tags, RSS descriptions, and 2-line card previews.
+ */
+export function stripMarkdownForPreview(markdown: string): string {
+  if (!markdown) return '';
+  return markdown
+    .replace(/^#{1,6}\s+/gm, '')
+    .replace(/^[-*]\s+/gm, '• ')
+    .replace(/\n{2,}/g, ' ')
+    .replace(/\n/g, ' ')
+    .trim();
+}

--- a/src/pages/articles/[...slug].astro
+++ b/src/pages/articles/[...slug].astro
@@ -15,6 +15,7 @@ import ContentTabs from '../../components/ContentTabs.astro';
 import AddToPlaylist from '../../components/AddToPlaylist.astro';
 import ShareButtons from '../../components/ShareButtons.astro';
 import BookmarkButton from '../../components/BookmarkButton.astro';
+import { stripMarkdownForPreview } from '../../lib/render-summary';
 
 export async function getStaticPaths() {
   const curatedEntries = await getCollection('curated', (entry: any) => entry.data.status === 'approved').catch((err: unknown) => {
@@ -59,7 +60,7 @@ const pageUrl = new URL(canonicalPath, 'https://honeycombo.pages.dev').href;
 
 <BaseLayout
   title={`${article.title} — HoneyCombo`}
-  description={article.description || `${article.title} - ${article.source}에서 큐레이션된 기사`}
+  description={article.description ? stripMarkdownForPreview(article.description) : `${article.title} - ${article.source}에서 큐레이션된 기사`}
   ogImage={article.thumbnail_url}
   ogType="article"
   canonicalPath={canonicalPath}

--- a/tests/render-summary.test.ts
+++ b/tests/render-summary.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import { renderSummaryHtml, stripMarkdownForPreview } from '../src/lib/render-summary';
+
+describe('renderSummaryHtml', () => {
+  it('renders full structured Korean summary as HTML', () => {
+    const md = [
+      '## 개요',
+      'AI 에이전트를 프로덕션 환경에서 활용하는 실전 분석 기사',
+      '',
+      '## 주요 내용',
+      '- 에이전트 아키텍처 설계 패턴',
+      '- 프로덕션 배포 시 고려사항',
+      '',
+      '## 시사점',
+      '실무에서 바로 적용 가능한 에이전트 구축 가이드',
+    ].join('\n');
+    const html = renderSummaryHtml(md);
+
+    expect(html).toContain('<h3 class="summary-heading">개요</h3>');
+    expect(html).toContain('<p>AI 에이전트를 프로덕션 환경에서 활용하는 실전 분석 기사</p>');
+    expect(html).toContain('<h3 class="summary-heading">주요 내용</h3>');
+    expect(html).toContain('<li>에이전트 아키텍처 설계 패턴</li>');
+    expect(html).toContain('<li>프로덕션 배포 시 고려사항</li>');
+    expect(html).toContain('<h3 class="summary-heading">시사점</h3>');
+    expect(html).toContain('<p>실무에서 바로 적용 가능한 에이전트 구축 가이드</p>');
+  });
+
+  it('renders single-line plain description as paragraph', () => {
+    expect(renderSummaryHtml('A great AI article.')).toBe('<p>A great AI article.</p>');
+  });
+
+  it('returns empty string for empty input', () => {
+    expect(renderSummaryHtml('')).toBe('');
+  });
+
+  it('escapes HTML entities to prevent XSS', () => {
+    const html = renderSummaryHtml('<script>alert("xss")</script>');
+    expect(html).not.toContain('<script>');
+    expect(html).toContain('&lt;script&gt;');
+  });
+
+  it('handles heading-only block without body text', () => {
+    const html = renderSummaryHtml('## 제목만');
+    expect(html).toBe('<h3 class="summary-heading">제목만</h3>');
+  });
+
+  it('handles standalone bullet list', () => {
+    const html = renderSummaryHtml('- 항목 1\n- 항목 2\n- 항목 3');
+    expect(html).toContain('<ul class="summary-list">');
+    expect(html).toContain('<li>항목 1</li>');
+    expect(html).toContain('<li>항목 2</li>');
+    expect(html).toContain('<li>항목 3</li>');
+  });
+});
+
+describe('stripMarkdownForPreview', () => {
+  it('strips heading markers from structured summary', () => {
+    const md = '## 개요\nAI 에이전트를 프로덕션 환경에서 활용\n\n## 주요 내용\n- 설계 패턴';
+    const result = stripMarkdownForPreview(md);
+
+    expect(result).not.toContain('##');
+    expect(result).toContain('개요');
+    expect(result).toContain('AI 에이전트를 프로덕션 환경에서 활용');
+    expect(result).toContain('주요 내용');
+  });
+
+  it('converts bullet markers to bullet symbols', () => {
+    const result = stripMarkdownForPreview('- item 1\n- item 2');
+    expect(result).toContain('• item 1');
+    expect(result).toContain('• item 2');
+  });
+
+  it('returns plain text as-is', () => {
+    expect(stripMarkdownForPreview('A great article.')).toBe('A great article.');
+  });
+
+  it('returns empty string for empty input', () => {
+    expect(stripMarkdownForPreview('')).toBe('');
+  });
+
+  it('collapses multiline into single line', () => {
+    const result = stripMarkdownForPreview('Line 1\n\nLine 2\nLine 3');
+    expect(result).not.toContain('\n');
+  });
+});


### PR DESCRIPTION
## Summary

- #101 후속: 파서 수정으로 `description`에 멀티라인 마크다운이 저장되지만, UI가 `<p>` 태그로 렌더링하여 `## 개요` 등 마크다운 마커가 원시 텍스트로 노출되던 문제 수정
- `renderSummaryHtml` (상세 페이지): `## ` → `<h3>`, `- ` → `<li>`, 단락 → `<p>` 변환. HTML 이스케이프 후 적용으로 XSS 방지
- `stripMarkdownForPreview` (카드/메타): 마크다운 마커 제거, 줄바꿈 공백 변환으로 깨끗한 미리보기

## 변경 파일

| 파일 | 변경 |
|------|------|
| `src/lib/render-summary.ts` | 렌더링/스트립 유틸리티 신규 |
| `tests/render-summary.test.ts` | 유틸리티 단위 테스트 11건 |
| `src/components/ContentTabs.astro` | `set:html`로 구조화 HTML 렌더링 + 스타일 추가 |
| `src/components/ArticleCard.astro` | `stripMarkdownForPreview`로 카드 미리보기 |
| `src/components/TagFilter.astro` | 클라이언트 사이드 `stripMd` 인라인 함수 |
| `src/pages/articles/[...slug].astro` | 메타 태그 마크다운 제거 |
| `docs/troubleshooting/multiline-summary-parsing.md` | UI 렌더링 수정 내용 추가 |

## 검증

- `bun run validate:docs` ✅
- `bun run validate:docs -- --check-coverage` ✅
- `bun run build` ✅ (627 pages)
- `bun run test` ✅ (160 tests, 13 files)