### PR TITLE
fix(ui): 요약 마크다운 자식 요소에 :global() 래퍼 적용 (#105 후속)

### DIFF
--- a/docs/troubleshooting/article-summary-modern-markdown-ui.md
+++ b/docs/troubleshooting/article-summary-modern-markdown-ui.md
@@ -93,10 +93,37 @@
 - **디자인 토큰 재사용**: 색상·간격은 `--color-*`, `--space-*` 디자인 토큰만 사용하고 하드코딩 금지 (AGENTS.md UI 디자인 원칙 준수).
 - **참조 디자인 연결**: 동일한 톤의 UI를 여러 곳에서 사용한다면 디자인 결정을 `docs/decisions/`로 승격해 일관성 유지.
 
+## 후속 이슈: 동적 innerHTML 자식에 scoped CSS 미적용
+
+최초 적용(PR #105) 후 사용자 피드백으로 "헤딩 아래 구분선이 안 보이고 헤딩-본문 간격이 좁다"는 문제가 보고됐다. 원인은 Astro scoped CSS 동작:
+
+- `<div class="article-summary">`는 Astro 정적 요소 → `data-astro-cid-xutx2pvd` 부여됨
+- 그 안의 `<h3 class="summary-heading">`, `<p>`, `<ul>` 등은 `set:html={summaryHtml}`로 주입되는 raw HTML 문자열 → `data-astro-cid-*` 미부여
+- 컴파일된 셀렉터 `.article-summary[data-astro-cid-xutx2pvd] .summary-heading[data-astro-cid-xutx2pvd]`가 **자식에 매칭 실패** → border-bottom, font-size, margin 등이 모두 무시됨
+- 결과: 헤딩이 그냥 브라우저 기본 `<h3>` 스타일로 보이고 단락 마진도 사라짐
+
+### 해결: 자식 셀렉터에 `:global()` 적용
+
+[astro-scoped-css-dynamic-innerhtml.md](./astro-scoped-css-dynamic-innerhtml.md)에 정리된 패턴을 그대로 적용:
+
+```diff
+- .article-summary .summary-heading { ... }
++ .article-summary :global(.summary-heading) { ... }
+- .article-summary p { ... }
++ .article-summary :global(p) { ... }
+- .article-summary .summary-list li { ... }
++ .article-summary :global(.summary-list li) { ... }
+```
+
+정적 부모(`.article-summary`)는 scoped 유지, 동적 자식만 `:global()`로 unscoped 매칭. 컴파일 결과 `.article-summary[data-astro-cid-*] .summary-heading`가 되어 동적 주입 요소에도 정상 적용된다.
+
+**교훈**: `set:html`로 마크다운 등 raw HTML을 렌더링하는 모든 Astro 컴포넌트에서, 그 자식 요소를 스타일링할 때는 반드시 `:global()` 래퍼를 사용한다. 단순히 `<style is:global>`로 전환하는 것도 가능하지만, 글로벌 오염을 피하려면 부모-자식 패턴이 더 안전하다.
+
 ---
 
 ## 관련 문서
 
+- [Astro Scoped CSS가 동적 innerHTML 요소에 적용되지 않는 문제](./astro-scoped-css-dynamic-innerhtml.md)
 - [기사 탭별 UI 불일치](./article-tab-ui-inconsistency.md)
 - [멀티라인 요약 파싱](./multiline-summary-parsing.md)
 
@@ -104,4 +131,5 @@
 
 | 날짜 | 변경 내용 |
 |------|----------|
-| 2026-04-20 | 최초 작성 — 요약 카드를 모던 마크다운 스타일로 개선 |
+| 2026-04-20 | 최초 작성 — 요약 카드를 모던 마크다운 스타일로 개선 (PR #105) |
+| 2026-04-20 | scoped CSS 관련 후속 이슈 명시 — 동적 innerHTML 자식에 :global() 적용 |

--- a/src/components/ContentTabs.astro
+++ b/src/components/ContentTabs.astro
@@ -177,17 +177,17 @@ const summaryHtml = description ? renderSummaryHtml(description) : '';
     font-size: 1rem;
   }
 
-  .article-summary p {
+  .article-summary :global(p) {
     color: var(--color-text);
     line-height: 1.75;
     margin: var(--space-sm) 0 var(--space-lg);
   }
 
-  .article-summary p:last-child {
+  .article-summary :global(p:last-child) {
     margin-bottom: 0;
   }
 
-  .article-summary .summary-heading {
+  .article-summary :global(.summary-heading) {
     font-size: 1.35rem;
     font-weight: 700;
     color: var(--color-text);
@@ -198,26 +198,26 @@ const summaryHtml = description ? renderSummaryHtml(description) : '';
     line-height: 1.3;
   }
 
-  .article-summary .summary-heading:first-child {
+  .article-summary :global(.summary-heading:first-child) {
     margin-top: 0;
   }
 
-  .article-summary .summary-list {
+  .article-summary :global(.summary-list) {
     margin: var(--space-sm) 0 var(--space-lg);
     padding-left: var(--space-lg);
     color: var(--color-text);
     line-height: 1.75;
   }
 
-  .article-summary .summary-list li {
+  .article-summary :global(.summary-list li) {
     margin-bottom: var(--space-sm);
   }
 
-  .article-summary .summary-list li::marker {
+  .article-summary :global(.summary-list li::marker) {
     color: var(--color-text-muted);
   }
 
-  .article-summary .summary-list li:last-child {
+  .article-summary :global(.summary-list li:last-child) {
     margin-bottom: 0;
   }
 


### PR DESCRIPTION
## Summary

PR #105 머지 후 사용자 보고: 헤딩 아래 구분선이 보이지 않고 헤딩-본문 간격도 좁다는 문제 발생. 원인은 Astro scoped CSS가 `set:html`로 주입된 동적 자식 요소에 적용되지 않는 알려진 함정. 자식 셀렉터에 `:global()`을 적용해 해결.

## Problem

PR #105가 머지된 후에도 다음 스타일이 모두 미적용:
- 섹션 헤딩(`개요`/`주요 내용`/`시사점`) 아래 `border-bottom` 구분선
- 헤딩 폰트 크기 1.35rem (브라우저 기본 `<h3>` 크기로 표시됨)
- 헤딩-본문 간격 (`margin: var(--space-xl) 0 var(--space-md)`)
- 단락 마진 (`margin: var(--space-sm) 0 var(--space-lg)`)
- 리스트 마커 색상

## Root Cause

`ContentTabs.astro`의 `.article-summary` 자식 요소들은 `set:html={summaryHtml}`로 주입되는 raw HTML 문자열이라 Astro가 `data-astro-cid-*` 속성을 부여하지 않습니다.

기존 셀렉터 `.article-summary .summary-heading`는 빌드 시 다음과 같이 컴파일됨:
```css
.article-summary[data-astro-cid-xutx2pvd] .summary-heading[data-astro-cid-xutx2pvd] { ... }
```

자식의 `[data-astro-cid-xutx2pvd]` 조건 때문에 동적 주입된 `<h3 class="summary-heading">`(속성 없음)에 매칭 실패 → CSS 무시.

이 문제는 프로젝트 내 [`docs/troubleshooting/astro-scoped-css-dynamic-innerhtml.md`](https://github.com/orientpine/honeycombo/blob/master/docs/troubleshooting/astro-scoped-css-dynamic-innerhtml.md)에 이미 정리된 패턴.

## Fix

자식 셀렉터를 `:global()` 래퍼로 감싸 부모만 scoped, 자식은 unscoped로 매칭되게 함:

```diff
- .article-summary .summary-heading { ... }
+ .article-summary :global(.summary-heading) { ... }
- .article-summary p { ... }
+ .article-summary :global(p) { ... }
- .article-summary .summary-list li { ... }
+ .article-summary :global(.summary-list li) { ... }
```

컴파일 결과: `.article-summary[data-astro-cid-xutx2pvd] .summary-heading` → 동적 자식에도 정상 매칭.

## Verification

- ✅ `bun run build` — 627 페이지 빌드 (7.99s)
- ✅ `bun run test` — 160/160 통과
- ✅ `bun run validate:docs` — 47개 문서 유효
- ✅ Production CSS 확인 (`dist/_astro/_..*.css`):
  ```
  .article-summary[data-astro-cid-xutx2pvd] .summary-heading{font-size:1.35rem;...border-bottom:1px solid var(--color-border);...}
  ```
  자식 셀렉터에 `[data-astro-cid]` 속성 없음 → 동적 주입된 `<h3 class="summary-heading">`에 정상 매칭

## RSS Feed Article 적용 여부

검토 결과 동일하게 적용됨. AI 요약 점진 적용 시 자동으로 새 UI 활성화. plain text description도 `<p>` 단락 스타일이 정상 적용되어 중간 상태에서도 UX 깨짐 없음. 상세는 troubleshooting 문서 참조.

## Files

- `src/components/ContentTabs.astro` — 자식 셀렉터에 `:global()` 적용
- `docs/troubleshooting/article-summary-modern-markdown-ui.md` — 후속 이슈 섹션 추가

Refs #105 (closes #106)