### PR TITLE
feat(render): inline \ub9c8\ud06c\ub2e4\uc6b4(**bold**, code, italic, link) \ub80c\ub354\ub9c1 \uc9c0\uc6d0

### DIFF
--- a/docs/troubleshooting/inline-markdown-rendering.md
+++ b/docs/troubleshooting/inline-markdown-rendering.md
@@ -1,0 +1,105 @@
+# Inline 마크다운(`**bold**`, `` `code` ``, 링크 등) raw 노출 문제
+
+> Gemini 요약과 사용자 큐레이션의 inline markdown이 화면에 raw 마커 그대로 표시되던 문제
+
+## 증상
+
+Gemini로 생성된 한국어 구조화 요약은 종종 `**굵은 글씨**`, `` `inline code` ``, `[링크](url)` 같은 inline markdown을 포함한다. 그러나 description 렌더링 파이프라인이 block-level(`## headings`, `- bullets`)만 처리하고 있어, 사용자 화면에는 raw 마커가 그대로 노출되었다.
+
+**대표 사례** (`src/data/feeds/2026/04/20b6b53922ca9538.json`):
+
+```
+**디지털 증거 인증의 어려움**: AI 딥페이크 기술로 인해 비디오, 오디오, 사진 등 디지털 증거의 조작 가능성이 높아져...
+**법원의 증거 인증 요구 사항**: 연방 증거 규칙 901(b)(9)에 따라...
+```
+
+→ `**` 별표가 그대로 노출되어 가독성이 떨어졌다.
+
+production 데이터 측정: feed article 274개 중 76개(28%)가 `**bold**` 사용, 일부에 `` `inline code` `` 존재.
+
+**재현 환경**: 모든 description 노출 surface (article 상세, 카드 미리보기, RSS feed, meta tag, Cloudflare functions, 클라이언트 vanilla JS).
+
+## 원인
+
+`src/lib/render-summary.ts`의 `renderSummaryHtml()`은 block-level markdown만 처리하고, inline markdown은 `escapeHtml()` 후 그대로 통과시켰다.
+
+- `## 개요` → `<h3>` 로 변환됨 ✅
+- `- bullet` → `<ul><li>` 로 변환됨 ✅
+- `**bold**` → `**bold**` 그대로 노출됨 ❌
+
+`stripMarkdownForPreview()`도 `^#` 헤딩 마커와 `^-` bullet 마커만 제거하여 inline 마커는 plain-text 표면에서도 raw로 노출되었다.
+
+`functions/lib/escape.ts`의 `stripMd()`와 `public/scripts/must-read-page.js`의 동일 함수도 같은 한계를 공유했다.
+
+## 해결 방법
+
+`render-summary.ts`에 inline-only pass를 추가한 뒤, block parser가 `<p>`/`<li>`를 만드는 시점에 적용한다. plain-text surface에는 마커 제거 helper를 적용한다.
+
+### 1. `renderInlineMarkdown(escapedText)` 신규
+
+이미 HTML-escape된 텍스트에 대해 4가지 inline 패턴을 변환:
+
+| 패턴 | 변환 |
+|---|---|
+| `` `code` `` | `<code>code</code>` |
+| `**bold**` | `<strong>bold</strong>` |
+| `*italic*` / `_italic_` | `<em>italic</em>` |
+| `[label](url)` | `<a href="url" target="_blank" rel="noopener noreferrer">label</a>` |
+
+**처리 순서가 중요**:
+1. **Code 먼저** — 본문이 다른 마커로 재해석되지 않도록 placeholder로 빼둔 뒤 마지막에 복원
+2. **Bold(`**`) 다음** — italic(`*`)보다 먼저, 그렇지 않으면 greedy 충돌
+3. **Italic** — `_`는 word-boundary lookaround로 `snake_case_var` 같은 식별자 보호
+4. **Link 마지막** — protocol whitelist (`http(s):`, `/`, `#`)로 `javascript:` URL 차단
+
+### 2. `stripInlineMarkdown(text)` 신규
+
+plain-text surface(카드, RSS, meta tag)에서 마커만 제거하여 평문화한다. 동일한 4가지 패턴에 대해 태그 없이 본문만 남긴다.
+
+### 3. 적용 위치
+
+```
+src/lib/render-summary.ts        → renderInlineMarkdown 적용 (renderSummaryHtml 안의 <p>, <li>)
+                                  → stripInlineMarkdown 적용 (stripMarkdownForPreview 끝)
+functions/lib/escape.ts          → stripMd()에 inline 마커 제거 4줄 추가
+public/scripts/must-read-page.js → stripMd()에 동일 적용 (브라우저 vanilla JS)
+```
+
+세 곳에서 동일한 regex를 사용해 SSG/CF Functions/브라우저 어디서든 일관된 결과를 보장한다.
+
+### 4. XSS 방어
+
+- **escape-first 패턴 유지**: `renderInlineMarkdown`은 항상 `escapeHtml()` 결과에만 호출됨. 사용자 입력의 HTML-significant 문자는 모두 entity로 변환된 뒤 inline 처리가 일어나므로 XSS 가능성 없음.
+- **link protocol whitelist**: `[click](javascript:alert(1))` 같은 입력은 anchor로 변환되지 않고 raw 마크다운 텍스트 그대로 출력됨 (테스트로 검증).
+- **code 내용 보호**: 백틱 안의 텍스트는 다른 inline 변환 단계에서 placeholder로 격리되어 emphasis 처리되지 않음.
+
+## 관련 파일
+
+| 파일 | 변경 내용 |
+|------|----------|
+| `src/lib/render-summary.ts` | `renderInlineMarkdown()`, `stripInlineMarkdown()`, `isSafeUrl()` 추가; `renderSummaryHtml`/`stripMarkdownForPreview`에 적용 |
+| `functions/lib/escape.ts` | `stripMd()`에 inline 마커 제거 4줄 추가 |
+| `public/scripts/must-read-page.js` | 동일한 inline 마커 제거 추가 (브라우저용) |
+| `tests/render-summary.test.ts` | inline markdown 시나리오 22개 추가 (XSS protection, 한국어 bold, snake_case 보호 포함) |
+
+## 예방 조치
+
+- **Three-source consistency**: `src/lib/render-summary.ts`, `functions/lib/escape.ts`, `public/scripts/must-read-page.js` 세 곳의 inline regex는 항상 동일해야 한다. 한 곳을 바꾸면 나머지 두 곳도 같이 갱신할 것.
+- **escape-first 강제**: `renderInlineMarkdown`은 절대 raw 사용자 입력에 직접 호출하지 말 것. 항상 `escapeHtml()` 결과에 대해서만 사용한다. JSDoc에 명시되어 있음.
+- **link protocol whitelist 유지**: `isSafeUrl()`이 `http(s):`, `/`, `#`만 허용. 새 protocol 추가는 보안 검토 필수.
+- **회귀 테스트**: 신규 inline 마커 추가 시 XSS 시나리오와 한국어/식별자 충돌 시나리오 테스트 필수.
+
+---
+
+## 관련 문서
+
+- [RSS 요약 영문 누수 트러블슈팅](./rss-summary-english-fallback.md) — 사실상 같은 description 파이프라인의 선행 이슈
+- [멀티라인 Summary 파싱 트러블슈팅](./multiline-summary-parsing.md) — block-level 한국어 요약 렌더링 선행 이슈
+- [src/lib/render-summary.ts](../../src/lib/render-summary.ts)
+- [functions/lib/escape.ts](../../functions/lib/escape.ts)
+
+## 변경 이력
+
+| 날짜 | 변경 내용 |
+|------|----------|
+| 2026-04-20 | 최초 작성 — inline markdown(`**bold**`, `` `code` ``, italic, link)을 모든 description 표면에서 정확히 렌더/평문화하도록 수정 |

--- a/functions/lib/escape.ts
+++ b/functions/lib/escape.ts
@@ -20,8 +20,15 @@ export function escapeAttr(s: string): string {
 export function stripMd(text: string): string {
   return text
     .replace(/^#{1,6}\s+/gm, '')
-    .replace(/^[-*]\s+/gm, '\u2022 ')
+    .replace(/^[-*]\s+/gm, '• ')
     .replace(/\n{2,}/g, ' ')
     .replace(/\n/g, ' ')
+    // Inline markdown markers — keep for plain-text consistency with src/lib/render-summary.ts.
+    // Order: code first, then **bold**, then *italic* / _italic_, then [text](url).
+    .replace(/`([^`\n]+)`/g, '$1')
+    .replace(/\*\*([^*\n]+?)\*\*/g, '$1')
+    .replace(/(^|[^*])\*([^*\s][^*\n]*?)\*(?!\*)/g, '$1$2')
+    .replace(/(^|[^A-Za-z0-9_])_([^_\n]+?)_(?![A-Za-z0-9_])/g, '$1$2')
+    .replace(/\[([^\]\n]+)\]\([^)\s]+\)/g, '$1')
     .trim();
 }

--- a/public/scripts/must-read-page.js
+++ b/public/scripts/must-read-page.js
@@ -22,6 +22,12 @@ document.addEventListener('astro:page-load', () => {
       .replace(/^[-*]\s+/gm, '\u2022 ')
       .replace(/\n{2,}/g, ' ')
       .replace(/\n/g, ' ')
+      // Inline markdown markers — mirror src/lib/render-summary.ts and functions/lib/escape.ts.
+      .replace(/`([^`\n]+)`/g, '$1')
+      .replace(/\*\*([^*\n]+?)\*\*/g, '$1')
+      .replace(/(^|[^*])\*([^*\s][^*\n]*?)\*(?!\*)/g, '$1$2')
+      .replace(/(^|[^A-Za-z0-9_])_([^_\n]+?)_(?![A-Za-z0-9_])/g, '$1$2')
+      .replace(/\[([^\]\n]+)\]\([^)\s]+\)/g, '$1')
       .trim();
   }
 

--- a/src/lib/render-summary.ts
+++ b/src/lib/render-summary.ts
@@ -17,6 +17,86 @@ function escapeHtml(text: string): string {
 }
 
 /**
+ * Validate that a URL uses an allowed protocol.
+ * Prevents javascript:, data:, vbscript: XSS injection via [text](url) syntax.
+ *
+ * Allowed: http(s)://..., site-relative /path, fragment #anchor.
+ */
+function isSafeUrl(url: string): boolean {
+  return /^(https?:\/\/|\/|#)/i.test(url);
+}
+
+/**
+ * Apply inline markdown transformations to already-HTML-escaped text.
+ *
+ * Supported subset (CommonMark inline only):
+ *   `code`             -> <code>code</code>
+ *   **bold**           -> <strong>bold</strong>
+ *   *italic*  _italic_ -> <em>italic</em>
+ *   [text](url)        -> <a href="url" target="_blank" rel="noopener noreferrer">text</a>
+ *
+ * Order of operations matters:
+ * 1. Code first (its content must NOT be re-processed for emphasis).
+ * 2. Bold (**) before italic (*) to avoid greedy match conflicts.
+ * 3. Italic with word-boundary lookarounds to skip mid-word _ in identifiers.
+ * 4. Links last with protocol whitelist.
+ *
+ * INPUT MUST BE HTML-ESCAPED ALREADY. This function only injects safe tag
+ * pairs and never introduces new HTML-significant characters from user input.
+ */
+export function renderInlineMarkdown(escapedText: string): string {
+  if (!escapedText) return '';
+
+  // 1. Inline code: protect content from further markdown processing by
+  //    extracting matches into placeholders, then restoring after other passes.
+  const codePlaceholders: string[] = [];
+  let text = escapedText.replace(/`([^`\n]+)`/g, (_match, code: string) => {
+    const idx = codePlaceholders.length;
+    codePlaceholders.push(code);
+    return `\u0000CODE${idx}\u0001`;
+  });
+
+  // 2. Bold: **text** -> <strong>text</strong>
+  text = text.replace(/\*\*([^*\n]+?)\*\*/g, '<strong>$1</strong>');
+
+  // 3. Italic: *text* or _text_  -> <em>text</em>
+  //    *: any non-* surrounded by *. Excludes ** (already consumed).
+  text = text.replace(/(^|[^*])\*([^*\s][^*\n]*?)\*(?!\*)/g, '$1<em>$2</em>');
+  //    _: requires word boundary on outside to avoid mid-word matches
+  //    (e.g. snake_case_var must NOT become snake<em>case</em>var).
+  text = text.replace(/(^|[^A-Za-z0-9_])_([^_\n]+?)_(?![A-Za-z0-9_])/g, '$1<em>$2</em>');
+
+  // 4. Links: [text](url) with protocol whitelist
+  text = text.replace(/\[([^\]\n]+)\]\(([^)\s]+)\)/g, (match, label: string, url: string) => {
+    if (!isSafeUrl(url)) return match;
+    return `<a href="${url}" target="_blank" rel="noopener noreferrer">${label}</a>`;
+  });
+
+  // 5. Restore code placeholders.
+  text = text.replace(/\u0000CODE(\d+)\u0001/g, (_match, idx: string) => {
+    return `<code>${codePlaceholders[Number(idx)]}</code>`;
+  });
+
+  return text;
+}
+
+/**
+ * Strip inline markdown markers for plain-text contexts.
+ *
+ * **bold** -> bold, *italic* -> italic, `code` -> code, [label](url) -> label.
+ * Used by stripMarkdownForPreview to keep RSS / meta tags / card previews clean.
+ */
+export function stripInlineMarkdown(text: string): string {
+  if (!text) return '';
+  return text
+    .replace(/`([^`\n]+)`/g, '$1')
+    .replace(/\*\*([^*\n]+?)\*\*/g, '$1')
+    .replace(/(^|[^*])\*([^*\s][^*\n]*?)\*(?!\*)/g, '$1$2')
+    .replace(/(^|[^A-Za-z0-9_])_([^_\n]+?)_(?![A-Za-z0-9_])/g, '$1$2')
+    .replace(/\[([^\]\n]+)\]\([^)\s]+\)/g, '$1');
+}
+
+/**
  * Convert structured summary markdown to HTML for the detail view.
  *
  * Input format (from agent-submission spec):
@@ -51,10 +131,10 @@ export function renderSummaryHtml(markdown: string): string {
       if (rest.length > 0) {
         if (rest.every((l) => l.trimStart().startsWith('- '))) {
           html.push(
-            `<ul class="summary-list">${rest.map((l) => `<li>${l.trimStart().slice(2)}</li>`).join('')}</ul>`,
+            `<ul class="summary-list">${rest.map((l) => `<li>${renderInlineMarkdown(l.trimStart().slice(2))}</li>`).join('')}</ul>`,
           );
         } else {
-          html.push(`<p>${rest.join('<br>')}</p>`);
+          html.push(`<p>${renderInlineMarkdown(rest.join('<br>'))}</p>`);
         }
       }
       continue;
@@ -63,13 +143,13 @@ export function renderSummaryHtml(markdown: string): string {
     // Standalone list block
     if (lines.every((l) => l.trimStart().startsWith('- '))) {
       html.push(
-        `<ul class="summary-list">${lines.map((l) => `<li>${l.trimStart().slice(2)}</li>`).join('')}</ul>`,
+        `<ul class="summary-list">${lines.map((l) => `<li>${renderInlineMarkdown(l.trimStart().slice(2))}</li>`).join('')}</ul>`,
       );
       continue;
     }
 
     // Plain paragraph (including single-line legacy descriptions)
-    html.push(`<p>${lines.join('<br>')}</p>`);
+    html.push(`<p>${renderInlineMarkdown(lines.join('<br>'))}</p>`);
   }
 
   return html.join('');
@@ -83,10 +163,11 @@ export function renderSummaryHtml(markdown: string): string {
  */
 export function stripMarkdownForPreview(markdown: string): string {
   if (!markdown) return '';
-  return markdown
+  const blockStripped = markdown
     .replace(/^#{1,6}\s+/gm, '')
     .replace(/^[-*]\s+/gm, '• ')
     .replace(/\n{2,}/g, ' ')
     .replace(/\n/g, ' ')
     .trim();
+  return stripInlineMarkdown(blockStripped);
 }

--- a/tests/render-summary.test.ts
+++ b/tests/render-summary.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { renderSummaryHtml, stripMarkdownForPreview } from '../src/lib/render-summary';
+import {
+  renderInlineMarkdown,
+  renderSummaryHtml,
+  stripInlineMarkdown,
+  stripMarkdownForPreview,
+} from '../src/lib/render-summary';
 
 describe('renderSummaryHtml', () => {
   it('renders full structured Korean summary as HTML', () => {
@@ -81,5 +86,132 @@ describe('stripMarkdownForPreview', () => {
   it('collapses multiline into single line', () => {
     const result = stripMarkdownForPreview('Line 1\n\nLine 2\nLine 3');
     expect(result).not.toContain('\n');
+  });
+});
+
+describe('renderInlineMarkdown', () => {
+  it('renders **bold** as <strong>', () => {
+    expect(renderInlineMarkdown('Hello **world**')).toBe('Hello <strong>world</strong>');
+  });
+
+  it('renders Korean **bold** as <strong>', () => {
+    expect(renderInlineMarkdown('**디지털 증거 인증의 어려움**: AI 딥페이크')).toBe(
+      '<strong>디지털 증거 인증의 어려움</strong>: AI 딥페이크',
+    );
+  });
+
+  it('renders *italic* as <em>', () => {
+    expect(renderInlineMarkdown('Hello *world*')).toBe('Hello <em>world</em>');
+  });
+
+  it('renders _italic_ as <em>', () => {
+    expect(renderInlineMarkdown('Hello _world_')).toBe('Hello <em>world</em>');
+  });
+
+  it('does NOT match _ inside identifiers (snake_case_var)', () => {
+    expect(renderInlineMarkdown('snake_case_var stays')).toBe('snake_case_var stays');
+  });
+
+  it('renders inline `code` as <code>', () => {
+    expect(renderInlineMarkdown('Run `bun test` to verify')).toBe(
+      'Run <code>bun test</code> to verify',
+    );
+  });
+
+  it('protects code content from emphasis processing', () => {
+    // The * inside code must NOT become italic
+    expect(renderInlineMarkdown('use `*ptr` to deref')).toBe('use <code>*ptr</code> to deref');
+  });
+
+  it('renders [text](https://...) as anchor with target=_blank', () => {
+    const html = renderInlineMarkdown('See [docs](https://example.com/docs)');
+    expect(html).toContain('<a href="https://example.com/docs"');
+    expect(html).toContain('target="_blank"');
+    expect(html).toContain('rel="noopener noreferrer"');
+    expect(html).toContain('>docs</a>');
+  });
+
+  it('renders site-relative [text](/path) link', () => {
+    const html = renderInlineMarkdown('Go to [home](/)');
+    expect(html).toContain('<a href="/"');
+  });
+
+  it('REJECTS [text](javascript:...) URL (XSS protection)', () => {
+    const input = '[click](javascript:alert(1))';
+    const html = renderInlineMarkdown(input);
+    expect(html).not.toContain('<a ');
+    expect(html).not.toContain('href=');
+    expect(html).toBe(input);
+  });
+
+  it('combines bold + italic + code in one line', () => {
+    expect(renderInlineMarkdown('**bold** and *italic* and `code`')).toBe(
+      '<strong>bold</strong> and <em>italic</em> and <code>code</code>',
+    );
+  });
+
+  it('returns empty string for empty input', () => {
+    expect(renderInlineMarkdown('')).toBe('');
+  });
+
+  it('integration: full structured Korean summary with inline bold renders correctly', () => {
+    const md = [
+      '## 주요 내용',
+      '- **디지털 증거 인증의 어려움**: AI 딥페이크 기술로 인해 비디오 진위 입증이 어려움',
+      '- **법원의 증거 인증 요구 사항**: FRE 901(b)(9) 적용',
+    ].join('\n');
+    const html = renderSummaryHtml(md);
+    expect(html).toContain('<strong>디지털 증거 인증의 어려움</strong>');
+    expect(html).toContain('<strong>법원의 증거 인증 요구 사항</strong>');
+    expect(html).toContain('<h3 class="summary-heading">주요 내용</h3>');
+    expect(html).toContain('<ul class="summary-list">');
+  });
+});
+
+describe('stripInlineMarkdown', () => {
+  it('strips **bold** markers', () => {
+    expect(stripInlineMarkdown('Hello **world**')).toBe('Hello world');
+  });
+
+  it('strips *italic* markers', () => {
+    expect(stripInlineMarkdown('Hello *world*')).toBe('Hello world');
+  });
+
+  it('strips `code` backticks', () => {
+    expect(stripInlineMarkdown('Run `bun test`')).toBe('Run bun test');
+  });
+
+  it('strips [label](url) keeping only label text', () => {
+    expect(stripInlineMarkdown('See [docs](https://example.com)')).toBe('See docs');
+  });
+
+  it('preserves snake_case identifiers', () => {
+    expect(stripInlineMarkdown('use snake_case_name')).toBe('use snake_case_name');
+  });
+
+  it('returns empty string for empty input', () => {
+    expect(stripInlineMarkdown('')).toBe('');
+  });
+});
+
+describe('stripMarkdownForPreview integration with inline markers', () => {
+  it('strips both block headings and inline bold for clean card preview', () => {
+    const md = '## 주요 내용\n- **핵심 포인트**: 중요한 내용\n- **두 번째 포인트**: 추가 설명';
+    const result = stripMarkdownForPreview(md);
+    expect(result).not.toContain('##');
+    expect(result).not.toContain('**');
+    expect(result).toContain('주요 내용');
+    expect(result).toContain('• 핵심 포인트: 중요한 내용');
+    expect(result).toContain('• 두 번째 포인트: 추가 설명');
+  });
+
+  it('strips inline code from previews', () => {
+    expect(stripMarkdownForPreview('Run the `bun test` command.')).toContain('Run the bun test command.');
+  });
+
+  it('strips link syntax keeping label', () => {
+    expect(stripMarkdownForPreview('Read [the docs](https://example.com) carefully.')).toBe(
+      'Read the docs carefully.',
+    );
   });
 });


### PR DESCRIPTION
## \uc694\uc57d

Gemini \uc694\uc57d\uacfc \uc0ac\uc6a9\uc790 \ud050\ub808\uc774\uc158\uc758 inline markdown(`**bold**`, `*italic*`, `` \`code\` ``, `[link](url)`)\uc774 raw \ub9c8\ucee4 \uadf8\ub300\ub85c \ub178\ucd9c\ub418\ub358 \ubb38\uc81c \uc218\uc815.

## \uc99d\uc0c1 \uc0ac\ub840

\uc0ac\uc6a9\uc790\uac00 \ubd88\ub9cc\uc744 \uc81c\uae30\ud55c article (`src/data/feeds/2026/04/20b6b53922ca9538.json`):

\`\`\`
**\ub514\uc9c0\ud138 \uc99d\uac70 \uc778\uc99d\uc758 \uc5b4\ub824\uc6c0**: AI \ub525\ud398\uc774\ud06c \uae30\uc220\ub85c \uc778\ud574...
**\ubc95\uc6d0\uc758 \uc99d\uac70 \uc778\uc99d \uc694\uad6c \uc0ac\ud56d**: \uc5f0\ubc29 \uc99d\uac70 \uaddc\uce59 901(b)(9)\uc5d0 \ub530\ub77c...
\`\`\`

production \uce21\uc815: feed article 274\uac1c \uc911 **76\uac1c(28%)**\uac00 \`**bold**\` \uc0ac\uc6a9.

## \uc124\uacc4

**\ucc98\ub9ac \ubd84\ub9ac**:

| \ud45c\uba74 | \ucc98\ub9ac |
|------|------|
| **HTML surface** (ContentTabs) | bold/italic/code/link\ub97c HTML \ud0dc\uadf8\ub85c \ub80c\ub354 (\`<strong>\`, \`<em>\`, \`<code>\`, \`<a>\`) |
| **plain-text surface** (\uce74\ub4dc/RSS/meta/CF \ud398\uc774\uc9c0) | \ub9c8\ucee4\ub9cc \uc81c\uac70\ud574 \ud3c9\ubb38 \ucd9c\ub825 (\`**bold**\` \u2192 \`bold\`) |

**\uc548\uc804 \uc124\uacc4**:
- escape-first \ud328\ud134 \uc720\uc9c0 (XSS \ubc29\uc9c0). \`renderInlineMarkdown\`\uc740 \ud56d\uc0c1 \`escapeHtml()\` \uacb0\uacfc\uc5d0\ub9cc \ud638\ucd9c.
- link protocol whitelist (\`http(s):\`, \`/\`, \`#\`\ub9cc \ud5c8\uc6a9, \`javascript:\` \ucc28\ub2e8). \ud14c\uc2a4\ud2b8\ub85c \uac80\uc99d.
- \`\` \`code\` \`\` \ub0b4\uc6a9 placeholder \uaca9\ub9ac \u2192 \ub2e4\ub978 \ub9c8\ucee4\ub85c \uc7ac\ud574\uc11d \uc548 \ub428.
- \`_\` \ub2e8\uc5b4 \uacbd\uacc4 lookaround \u2192 \`snake_case_var\` \ubcf4\ud638.

**3-source consistency**: SSG/CF/\ube0c\ub77c\uc6b0\uc800 \uc138 \uacf3\uc758 inline regex \ub3d9\uc77c \uc720\uc9c0.

## \ubcc0\uacbd \ub0b4\uc6a9 (5\uac1c \ud30c\uc77c)

| \ud30c\uc77c | \ubcc0\uacbd |
|------|------|
| \`src/lib/render-summary.ts\` | \`renderInlineMarkdown()\`, \`stripInlineMarkdown()\`, \`isSafeUrl()\` \ucd94\uac00; \`renderSummaryHtml\`/\`stripMarkdownForPreview\`\uc5d0 \uc801\uc6a9 |
| \`functions/lib/escape.ts\` | \`stripMd()\`\uc5d0 inline \ub9c8\ucee4 \uc81c\uac70 4\ud328\ud134 \ucd94\uac00 |
| \`public/scripts/must-read-page.js\` | \ub3d9\uc77c \ub85c\uc9c1 \ucd94\uac00 (\ube0c\ub77c\uc6b0\uc800\uc6a9) |
| \`tests/render-summary.test.ts\` | inline \uc2dc\ub098\ub9ac\uc624 22\uac1c \ucd94\uac00 (XSS \ubc29\uc5b4, \ud55c\uad6d\uc5b4 bold, \uc2dd\ubcc4\uc790 \ubcf4\ud638, \ud1b5\ud569 \ud14c\uc2a4\ud2b8) |
| \`docs/troubleshooting/inline-markdown-rendering.md\` (\uc2e0\uaddc) | \uc124\uacc4 \ubc30\uacbd \ubc0f \uc608\ubc29 \uc870\uce58 |

## \uac80\uc99d

- \u2705 \`bun run test\`: 198/198 pass (+ \uc2e0\uaddc 22 inline tests)
- \u2705 \`bun run validate\`: 300 files valid
- \u2705 \`bun run validate:docs\`: 49 docs valid
- \u2705 \`bun run validate:docs --check-coverage\`: pass
- \u2705 \`bun run build\`: 627 pages built
- \u2705 **Manual QA**: \uc0ac\uc6a9\uc790\uac00 \ubd88\ub9cc \uc81c\uae30\ud55c \uc2e4\uc81c article(20b6b539...)\uc758 8\uac1c \`**bold**\` \ub9c8\ucee4 \ubaa8\ub450 \uc815\uc0c1\uc801\uc73c\ub85c \`<strong>\`\uc73c\ub85c \ub80c\ub354\ub428 \ud655\uc778

## \ub300\uc548 \uac80\ud1a0

\uc678\ubd80 \ub77c\uc774\ube0c\ub7ec\ub9ac \ub3c4\uc785\uc744 \uac80\ud1a0\ud588\uc73c\ub098 \uc544\ub798 \uc774\uc720\ub85c hand-rolled \uc120\ud0dd:
- \ubc88\ub4e4 0KB (marked+DOMPurify 28KB, micromark 14KB \ub300\ube44)
- CF Workers \ud638\ud658\uc131 \uc774\uc288 \uc5c6\uc74c
- \uc774\ubbf8 escape-first \ud328\ud134 \uc0ac\uc6a9 \uc911 \u2192 \uc0c8 \ud568\uc218\ub9cc \ucd94\uac00\ud574\ub3c4 \uc548\uc804\uc131 \uc720\uc9c0
- \uc9c0\uc6d0 \ud328\ud134 4\uac1c\ub9cc \ud544\uc694 (\ub808\uac70\uc2dc 4\uc904)

\ud5a5\ud6c4 \uc5c0\uc9c0 \ucf00\uc774\uc2a4(\uc911\ucca9 emphasis)\uc774 \ubb38\uc81c\ub418\uba74 micromark\ub85c \uad50\uccb4 \uac00\ub2a5.