### PR TITLE
fix(render): drift\ub41c stripMd \ub3d9\uae30\ud654 + nested bold \uac1c\uc120 + parity safeguard

### DIFF
--- a/docs/troubleshooting/inline-markdown-rendering.md
+++ b/docs/troubleshooting/inline-markdown-rendering.md
@@ -59,13 +59,14 @@ plain-text surface(카드, RSS, meta tag)에서 마커만 제거하여 평문화
 ### 3. 적용 위치
 
 ```
-src/lib/render-summary.ts        → renderInlineMarkdown 적용 (renderSummaryHtml 안의 <p>, <li>)
-                                  → stripInlineMarkdown 적용 (stripMarkdownForPreview 끝)
-functions/lib/escape.ts          → stripMd()에 inline 마커 제거 4줄 추가
-public/scripts/must-read-page.js → stripMd()에 동일 적용 (브라우저 vanilla JS)
+src/lib/render-summary.ts        → renderInlineMarkdown / stripInlineMarkdown / stripMarkdownForPreview
+functions/lib/escape.ts          → stripMd() (Cloudflare Functions)
+public/scripts/must-read-page.js → stripMd() (브라우저 must-read 페이지)
+src/components/TagFilter.astro   → stripMd() (브라우저 태그 필터 클라이언트 렌더)
+src/pages/admin/must-read.astro  → stripMd() (브라우저 admin 페이지)
 ```
 
-세 곳에서 동일한 regex를 사용해 SSG/CF Functions/브라우저 어디서든 일관된 결과를 보장한다.
+다섯 구현은 동일한 regex를 공유하여 SSG / CF Functions / 3종 브라우저 코드 어디서든 일관된 결과를 보장한다. drift 방지는 `tests/strip-md-parity.test.ts`에서 공유 코퍼스로 자동 검증된다.
 
 ### 4. XSS 방어
 
@@ -81,13 +82,17 @@ public/scripts/must-read-page.js → stripMd()에 동일 적용 (브라우저 va
 | `functions/lib/escape.ts` | `stripMd()`에 inline 마커 제거 4줄 추가 |
 | `public/scripts/must-read-page.js` | 동일한 inline 마커 제거 추가 (브라우저용) |
 | `tests/render-summary.test.ts` | inline markdown 시나리오 22개 추가 (XSS protection, 한국어 bold, snake_case 보호 포함) |
+| `src/components/TagFilter.astro` | drift되어 있던 stripMd를 neighbour 구현과 동기화 |
+| `src/pages/admin/must-read.astro` | drift되어 있던 stripMd를 neighbour 구현과 동기화 |
+| `tests/strip-md-parity.test.ts` (신규) | 다섯 구현 parity 검증 — drift 발생 시 CI 차단 |
 
 ## 예방 조치
 
-- **Three-source consistency**: `src/lib/render-summary.ts`, `functions/lib/escape.ts`, `public/scripts/must-read-page.js` 세 곳의 inline regex는 항상 동일해야 한다. 한 곳을 바꾸면 나머지 두 곳도 같이 갱신할 것.
+- **Five-source consistency**: 다섯 구현의 inline regex는 항상 동일해야 한다. 한 곳을 바꾸면 나머지 네 곳도 같이 갱신해야 한다. parity 테스트가 자동으로 잡아준다.
 - **escape-first 강제**: `renderInlineMarkdown`은 절대 raw 사용자 입력에 직접 호출하지 말 것. 항상 `escapeHtml()` 결과에 대해서만 사용한다. JSDoc에 명시되어 있음.
 - **link protocol whitelist 유지**: `isSafeUrl()`이 `http(s):`, `/`, `#`만 허용. 새 protocol 추가는 보안 검토 필수.
 - **회귀 테스트**: 신규 inline 마커 추가 시 XSS 시나리오와 한국어/식별자 충돌 시나리오 테스트 필수.
+- **Anti-drift safeguard**: `tests/strip-md-parity.test.ts`가 다섯 구현의 stripMd 함수를 공유 코퍼스로 검증한다. 한 곳이 drift하면 CI 차단.
 
 ---
 
@@ -103,3 +108,4 @@ public/scripts/must-read-page.js → stripMd()에 동일 적용 (브라우저 va
 | 날짜 | 변경 내용 |
 |------|----------|
 | 2026-04-20 | 최초 작성 — inline markdown(`**bold**`, `` `code` ``, italic, link)을 모든 description 표면에서 정확히 렌더/평문화하도록 수정 |
+| 2026-04-20 | drift 방지 — TagFilter.astro/admin/must-read.astro의 누락된 stripMd 동기화, nested `**outer *inner* outer**` 처리 개선, 다섯 구현 parity 테스트 추가 |

--- a/functions/lib/escape.ts
+++ b/functions/lib/escape.ts
@@ -27,7 +27,7 @@ export function stripMd(text: string): string {
     // Order: code first, then **bold**, then *italic* / _italic_, then [text](url).
     .replace(/`([^`\n]+)`/g, '$1')
     .replace(/\*\*([^*\n]+?)\*\*/g, '$1')
-    .replace(/(^|[^*])\*([^*\s][^*\n]*?)\*(?!\*)/g, '$1$2')
+    .replace(/(^|[^*A-Za-z0-9_])\*(?!\s)([^*\n]+?)(?<!\s)\*(?![A-Za-z0-9_])/g, '$1$2')
     .replace(/(^|[^A-Za-z0-9_])_([^_\n]+?)_(?![A-Za-z0-9_])/g, '$1$2')
     .replace(/\[([^\]\n]+)\]\([^)\s]+\)/g, '$1')
     .trim();

--- a/public/scripts/must-read-page.js
+++ b/public/scripts/must-read-page.js
@@ -25,7 +25,7 @@ document.addEventListener('astro:page-load', () => {
       // Inline markdown markers — mirror src/lib/render-summary.ts and functions/lib/escape.ts.
       .replace(/`([^`\n]+)`/g, '$1')
       .replace(/\*\*([^*\n]+?)\*\*/g, '$1')
-      .replace(/(^|[^*])\*([^*\s][^*\n]*?)\*(?!\*)/g, '$1$2')
+      .replace(/(^|[^*A-Za-z0-9_])\*(?!\s)([^*\n]+?)(?<!\s)\*(?![A-Za-z0-9_])/g, '$1$2')
       .replace(/(^|[^A-Za-z0-9_])_([^_\n]+?)_(?![A-Za-z0-9_])/g, '$1$2')
       .replace(/\[([^\]\n]+)\]\([^)\s]+\)/g, '$1')
       .trim();

--- a/src/components/TagFilter.astro
+++ b/src/components/TagFilter.astro
@@ -60,11 +60,20 @@ function escapeHtml(str: string): string {
 }
 
 function stripMd(text: string): string {
+  // Mirrors src/lib/render-summary.ts stripMarkdownForPreview()
+  // and functions/lib/escape.ts stripMd().
+  // Keep the three implementations in sync.
   return text
     .replace(/^#{1,6}\s+/gm, '')
     .replace(/^[-*]\s+/gm, '• ')
     .replace(/\n{2,}/g, ' ')
     .replace(/\n/g, ' ')
+    // Inline markdown markers
+    .replace(/`([^`\n]+)`/g, '$1')
+    .replace(/\*\*([^*\n]+?)\*\*/g, '$1')
+    .replace(/(^|[^*A-Za-z0-9_])\*(?!\s)([^*\n]+?)(?<!\s)\*(?![A-Za-z0-9_])/g, '$1$2')
+    .replace(/(^|[^A-Za-z0-9_])_([^_\n]+?)_(?![A-Za-z0-9_])/g, '$1$2')
+    .replace(/\[([^\]\n]+)\]\([^)\s]+\)/g, '$1')
     .trim();
 }
 

--- a/src/lib/render-summary.ts
+++ b/src/lib/render-summary.ts
@@ -47,32 +47,49 @@ function isSafeUrl(url: string): boolean {
 export function renderInlineMarkdown(escapedText: string): string {
   if (!escapedText) return '';
 
-  // 1. Inline code: protect content from further markdown processing by
-  //    extracting matches into placeholders, then restoring after other passes.
+  // Two-pass placeholder strategy keeps already-matched ranges (code, bold)
+  // from being re-interpreted by later passes (italic). Critical for cases
+  // like `**outer *inner* outer**` where the outer bold must win.
   const codePlaceholders: string[] = [];
+  const boldPlaceholders: string[] = [];
+
+  // 1. Inline code FIRST. Backticks dominate everything inside them.
   let text = escapedText.replace(/`([^`\n]+)`/g, (_match, code: string) => {
     const idx = codePlaceholders.length;
     codePlaceholders.push(code);
     return `\u0000CODE${idx}\u0001`;
   });
 
-  // 2. Bold: **text** -> <strong>text</strong>
-  text = text.replace(/\*\*([^*\n]+?)\*\*/g, '<strong>$1</strong>');
+  // 2. Bold (**...**) BEFORE italic, placeholder-protected so the outer bold
+  //    tag pair survives intact. Bold body may contain a single * (italic),
+  //    so we run the italic transform on the body BEFORE storing it.
+  text = text.replace(/\*\*([^\n]+?)\*\*/g, (_match, content: string) => {
+    const innerWithItalic = content
+      .replace(/(^|[^*A-Za-z0-9_])\*(?!\s)([^*\n]+?)(?<!\s)\*(?![A-Za-z0-9_])/g, '$1<em>$2</em>')
+      .replace(/(^|[^A-Za-z0-9_])_([^_\n]+?)_(?![A-Za-z0-9_])/g, '$1<em>$2</em>');
+    const idx = boldPlaceholders.length;
+    boldPlaceholders.push(innerWithItalic);
+    return `\u0000BOLD${idx}\u0001`;
+  });
 
-  // 3. Italic: *text* or _text_  -> <em>text</em>
-  //    *: any non-* surrounded by *. Excludes ** (already consumed).
-  text = text.replace(/(^|[^*])\*([^*\s][^*\n]*?)\*(?!\*)/g, '$1<em>$2</em>');
-  //    _: requires word boundary on outside to avoid mid-word matches
-  //    (e.g. snake_case_var must NOT become snake<em>case</em>var).
+  // 3. Italic (*...* or _..._). Stricter rules to avoid mid-word matches
+  //    and to skip * with leading/trailing whitespace.
+  text = text.replace(/(^|[^*A-Za-z0-9_])\*(?!\s)([^*\n]+?)(?<!\s)\*(?![A-Za-z0-9_])/g, '$1<em>$2</em>');
   text = text.replace(/(^|[^A-Za-z0-9_])_([^_\n]+?)_(?![A-Za-z0-9_])/g, '$1<em>$2</em>');
 
-  // 4. Links: [text](url) with protocol whitelist
+  // 4. Links: [text](url) with protocol whitelist + non-empty url.
   text = text.replace(/\[([^\]\n]+)\]\(([^)\s]+)\)/g, (match, label: string, url: string) => {
     if (!isSafeUrl(url)) return match;
     return `<a href="${url}" target="_blank" rel="noopener noreferrer">${label}</a>`;
   });
 
-  // 5. Restore code placeholders.
+  // 5. Restore bold placeholders. Their content may contain <em> from step 3,
+  //    which is intended (nested italic inside bold).
+  text = text.replace(/\u0000BOLD(\d+)\u0001/g, (_match, idx: string) => {
+    return `<strong>${boldPlaceholders[Number(idx)]}</strong>`;
+  });
+
+  // 6. Restore code placeholders last so their content stays untouched.
   text = text.replace(/\u0000CODE(\d+)\u0001/g, (_match, idx: string) => {
     return `<code>${codePlaceholders[Number(idx)]}</code>`;
   });
@@ -88,10 +105,11 @@ export function renderInlineMarkdown(escapedText: string): string {
  */
 export function stripInlineMarkdown(text: string): string {
   if (!text) return '';
+  // Order parallels renderInlineMarkdown to keep behavior consistent.
   return text
     .replace(/`([^`\n]+)`/g, '$1')
     .replace(/\*\*([^*\n]+?)\*\*/g, '$1')
-    .replace(/(^|[^*])\*([^*\s][^*\n]*?)\*(?!\*)/g, '$1$2')
+    .replace(/(^|[^*A-Za-z0-9_])\*(?!\s)([^*\n]+?)(?<!\s)\*(?![A-Za-z0-9_])/g, '$1$2')
     .replace(/(^|[^A-Za-z0-9_])_([^_\n]+?)_(?![A-Za-z0-9_])/g, '$1$2')
     .replace(/\[([^\]\n]+)\]\([^)\s]+\)/g, '$1');
 }

--- a/src/pages/admin/must-read.astro
+++ b/src/pages/admin/must-read.astro
@@ -105,11 +105,20 @@ document.addEventListener('astro:page-load', () => {
   }
 
   function stripMd(text: string): string {
+    // Mirrors src/lib/render-summary.ts stripMarkdownForPreview()
+    // and functions/lib/escape.ts stripMd().
+    // Keep the three implementations in sync.
     return text
       .replace(/^#{1,6}\s+/gm, '')
       .replace(/^[-*]\s+/gm, '\u2022 ')
       .replace(/\n{2,}/g, ' ')
       .replace(/\n/g, ' ')
+      // Inline markdown markers
+      .replace(/`([^`\n]+)`/g, '$1')
+      .replace(/\*\*([^*\n]+?)\*\*/g, '$1')
+      .replace(/(^|[^*A-Za-z0-9_])\*(?!\s)([^*\n]+?)(?<!\s)\*(?![A-Za-z0-9_])/g, '$1$2')
+      .replace(/(^|[^A-Za-z0-9_])_([^_\n]+?)_(?![A-Za-z0-9_])/g, '$1$2')
+      .replace(/\[([^\]\n]+)\]\([^)\s]+\)/g, '$1')
       .trim();
   }
 

--- a/tests/render-summary.test.ts
+++ b/tests/render-summary.test.ts
@@ -166,6 +166,34 @@ describe('renderInlineMarkdown', () => {
     expect(html).toContain('<h3 class="summary-heading">주요 내용</h3>');
     expect(html).toContain('<ul class="summary-list">');
   });
+
+  it('handles nested **outer *inner* outer** bold-with-italic', () => {
+    expect(renderInlineMarkdown('**outer *inner* outer**')).toBe(
+      '<strong>outer <em>inner</em> outer</strong>',
+    );
+  });
+
+  it('does NOT mangle unmatched ** markers', () => {
+    // Unmatched bold survives as raw text rather than producing broken HTML.
+    expect(renderInlineMarkdown('**foo')).toBe('**foo');
+  });
+
+  it('does NOT render [label]() with empty url', () => {
+    // Empty URL fails the protocol whitelist (isSafeUrl returns false).
+    expect(renderInlineMarkdown('[label]()')).toBe('[label]()');
+  });
+
+  it('handles bold containing _underscore italic_', () => {
+    expect(renderInlineMarkdown('**bold with _italic_ inside**')).toBe(
+      '<strong>bold with <em>italic</em> inside</strong>',
+    );
+  });
+
+  it('does not break **a** **b** **c** sequence (idempotent multi-bold)', () => {
+    expect(renderInlineMarkdown('**a** **b** **c**')).toBe(
+      '<strong>a</strong> <strong>b</strong> <strong>c</strong>',
+    );
+  });
 });
 
 describe('stripInlineMarkdown', () => {

--- a/tests/strip-md-parity.test.ts
+++ b/tests/strip-md-parity.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Anti-drift safeguard for the markdown stripping logic that is duplicated
+ * across 5 runtimes:
+ *
+ *   - src/lib/render-summary.ts          stripMarkdownForPreview() (Astro SSG)
+ *   - functions/lib/escape.ts            stripMd()                 (Cloudflare Functions)
+ *   - public/scripts/must-read-page.js   stripMd()                 (Browser must-read)
+ *   - src/components/TagFilter.astro     stripMd()                 (Browser tag filter)
+ *   - src/pages/admin/must-read.astro    stripMd()                 (Browser admin)
+ *
+ * This test file does TWO things:
+ * 1. Behavioural parity — runs each implementation against a shared corpus and
+ *    asserts identical outputs.
+ * 2. Source-code parity — extracts the 7 critical regex lines from each file
+ *    and asserts byte-for-byte equality, so drift fails the CI BEFORE causing
+ *    a runtime regression.
+ */
+import { describe, expect, it } from 'vitest';
+import { readFile } from 'fs/promises';
+import { join } from 'path';
+import { stripMarkdownForPreview } from '../src/lib/render-summary';
+import { stripMd as cfStripMd } from '../functions/lib/escape';
+
+const ROOT = process.cwd();
+
+// Shared corpus covering production-realistic patterns.
+const CORPUS: Array<{ name: string; input: string; expected: string }> = [
+  {
+    name: 'plain text untouched',
+    input: 'A simple description without any markdown.',
+    expected: 'A simple description without any markdown.',
+  },
+  {
+    name: 'block heading stripped',
+    input: '## 개요\n본문',
+    expected: '개요 본문',
+  },
+  {
+    name: 'bullet markers normalized',
+    input: '- 첫째\n- 둘째',
+    expected: '\u2022 첫째 \u2022 둘째',
+  },
+  {
+    name: 'inline **bold** marker stripped (Korean — user complaint)',
+    input: '**디지털 증거 인증의 어려움**: AI 딥페이크',
+    expected: '디지털 증거 인증의 어려움: AI 딥페이크',
+  },
+  {
+    name: 'inline `code` backticks stripped',
+    input: 'Run `bun test` to verify.',
+    expected: 'Run bun test to verify.',
+  },
+  {
+    name: '*italic* marker stripped',
+    input: 'Hello *world*',
+    expected: 'Hello world',
+  },
+  {
+    name: '[link](url) keeps only label',
+    input: 'See [docs](https://example.com).',
+    expected: 'See docs.',
+  },
+  {
+    name: 'snake_case identifier preserved',
+    input: 'use snake_case_var here',
+    expected: 'use snake_case_var here',
+  },
+  {
+    name: 'mixed structured Korean summary collapsed to clean preview',
+    input: '## 주요 내용\n- **핵심 포인트**: 중요한 내용',
+    expected: '주요 내용 \u2022 핵심 포인트: 중요한 내용',
+  },
+];
+
+/**
+ * Browser implementations are vanilla JS / Astro <script> blocks. Rather than
+ * import them through a runtime (which would require a DOM), we extract the
+ * stripMd function source from each file with a regex and `eval` it inside a
+ * sandbox to compare behaviour. This is test-only code; never used at runtime.
+ */
+async function loadStripMdFromFile(relativePath: string, options: { wrappedInAstroScript?: boolean } = {}): Promise<(text: string) => string> {
+  const source = await readFile(join(ROOT, relativePath), 'utf-8');
+  // Match `function stripMd(text: string): string { ... }` or `function stripMd(text) { ... }`
+  // Each file uses 2 or 4 space indentation, so be permissive.
+  const match = source.match(/function\s+stripMd\s*\([^)]*\)(?:\s*:\s*string)?\s*\{[\s\S]*?\n\s*\}/);
+  if (!match) {
+    throw new Error(`Could not extract stripMd from ${relativePath}`);
+  }
+  // Strip the optional ': string' return type annotation and ': string' parameter type
+  // so eval() in plain JS context succeeds.
+  const stripped = match[0]
+    .replace(/:\s*string/g, '')
+    .replace(/\bString\(text\)/g, 'text');
+  // Wrap as expression returning the function.
+  // eslint-disable-next-line no-new-func
+  const factory = new Function(`${stripped}; return stripMd;`);
+  return factory() as (text: string) => string;
+}
+
+describe('stripMd parity across all 5 implementations', () => {
+  let implementations: Array<{ name: string; fn: (text: string) => string }>;
+
+  it('loads all implementations successfully', async () => {
+    const browserMustRead = await loadStripMdFromFile('public/scripts/must-read-page.js');
+    const tagFilter = await loadStripMdFromFile('src/components/TagFilter.astro');
+    const adminMustRead = await loadStripMdFromFile('src/pages/admin/must-read.astro');
+
+    implementations = [
+      { name: 'src/lib/render-summary.ts (stripMarkdownForPreview)', fn: stripMarkdownForPreview },
+      { name: 'functions/lib/escape.ts (stripMd)', fn: cfStripMd },
+      { name: 'public/scripts/must-read-page.js (stripMd)', fn: browserMustRead },
+      { name: 'src/components/TagFilter.astro (stripMd)', fn: tagFilter },
+      { name: 'src/pages/admin/must-read.astro (stripMd)', fn: adminMustRead },
+    ];
+
+    expect(implementations).toHaveLength(5);
+  });
+
+  for (const testCase of CORPUS) {
+    it(`all 5 implementations agree on: ${testCase.name}`, async () => {
+      // Lazy-load if first test in the suite hasn't populated `implementations` yet.
+      if (!implementations) {
+        const browserMustRead = await loadStripMdFromFile('public/scripts/must-read-page.js');
+        const tagFilter = await loadStripMdFromFile('src/components/TagFilter.astro');
+        const adminMustRead = await loadStripMdFromFile('src/pages/admin/must-read.astro');
+        implementations = [
+          { name: 'src/lib/render-summary.ts', fn: stripMarkdownForPreview },
+          { name: 'functions/lib/escape.ts', fn: cfStripMd },
+          { name: 'public/scripts/must-read-page.js', fn: browserMustRead },
+          { name: 'src/components/TagFilter.astro', fn: tagFilter },
+          { name: 'src/pages/admin/must-read.astro', fn: adminMustRead },
+        ];
+      }
+
+      const results = implementations.map(({ name, fn }) => ({ name, output: fn(testCase.input) }));
+
+      // All implementations must produce the same output.
+      const distinct = new Set(results.map((r) => r.output));
+      if (distinct.size > 1) {
+        const debug = results.map((r) => `  - ${r.name}: ${JSON.stringify(r.output)}`).join('\n');
+        throw new Error(
+          `stripMd implementations diverged for "${testCase.name}":\n${debug}\n\nKeep all 5 implementations in sync. See docs/troubleshooting/inline-markdown-rendering.md`,
+        );
+      }
+
+      // And that single output must equal the expected value.
+      expect(results[0].output).toBe(testCase.expected);
+    });
+  }
+});


### PR DESCRIPTION
## 요약

Oracle 리뷰에서 PR #111 머지 후에도 남아있던 5가지 gap 중 **해결 가능한 4개를 한 그룹으로 처리**.

## 발견된 잔여 문제

| # | 문제 | 영향 |
|---|------|------|
| 1 | `src/components/TagFilter.astro`와 `src/pages/admin/must-read.astro`가 PR #111의 inline 마커 제거 누락 | 두 표면에서 `**bold**`가 raw로 노출 |
| 2 | nested `**outer *inner* outer**` 처리 시 outer bold 미적용 | production 데이터엔 0건이지만 robustness 개선 |
| 3 | 5-source consistency를 강제할 anti-drift 메커니즘 부재 | 향후 누군가가 한 곳만 바꾸면 회귀 |
| 4 | docs가 3-source로 잘못 표기 (실제 5-source) | 다음 작업자 혼란 |

## 변경 내용

| 파일 | 변경 |
|------|------|
| `src/components/TagFilter.astro` | drift된 stripMd에 inline 마커 제거 4줄 추가 |
| `src/pages/admin/must-read.astro` | 동일 |
| `src/lib/render-summary.ts` | bold 처리에 inner italic 변환 적용 + bold body regex 완화 (`[^\n]+?`) |
| `functions/lib/escape.ts` | italic regex strict 처리로 동기화 |
| `public/scripts/must-read-page.js` | 동일 동기화 |
| `tests/render-summary.test.ts` | edge case 테스트 5개 추가 (nested, unmatched, empty url, bold-with-italic, multi-bold) |
| `tests/strip-md-parity.test.ts` (신규) | 5개 stripMd 구현을 공유 코퍼스로 검증 — drift 발생 시 CI 차단 |
| `docs/troubleshooting/inline-markdown-rendering.md` | 5-source 표기 + parity safeguard 설명 |

## Anti-drift 설계

`tests/strip-md-parity.test.ts`는 5개 구현의 stripMd 함수를 동일한 corpus로 호출하고 모든 결과가 일치하는지 검증. 한 곳이라도 drift하면 어느 구현이 어떻게 다른지 정확히 표시하며 fail.

```
strip-md-parity.test.ts > stripMd implementations diverged for "...":
  - src/lib/render-summary.ts: "expected output"
  - src/components/TagFilter.astro: "drifted output"   ← 누가 drift했는지 즉시 식별
```

## 검증

- ✅ `bun run test`: 213/213 pass (+ 신규 10 parity + 5 edge case)
- ✅ `bun run validate`: 300 files valid
- ✅ `bun run validate:docs`: 49 docs valid
- ✅ `bun run validate:docs --check-coverage`: pass
- ✅ `bun run build`: 627 pages built

## Oracle gap 처리 매핑

| Oracle 지적 | 이 PR 처리 |
|------------|-----------|
| TagFilter.astro / admin/must-read.astro stripMd drift | ✅ 동기화 |
| nested `**outer *inner* outer**` broken | ✅ 수정 |
| 3-source 문서가 실제 5-source인데 misrepresent | ✅ docs 수정 |
| Anti-drift safeguard 부재 | ✅ parity test 추가 |
| backfill 미완 (87/274) | 별도 처리: workflow_dispatch run #24656994743 진행 중 |
