### PR TITLE
fix(render+summarize): Oracle gap closure round 2 (stale fallback + nested strip + source-regex parity)

### DIFF
--- a/docs/troubleshooting/inline-markdown-rendering.md
+++ b/docs/troubleshooting/inline-markdown-rendering.md
@@ -109,3 +109,4 @@ src/pages/admin/must-read.astro  → stripMd() (브라우저 admin 페이지)
 |------|----------|
 | 2026-04-20 | 최초 작성 — inline markdown(`**bold**`, `` `code` ``, italic, link)을 모든 description 표면에서 정확히 렌더/평문화하도록 수정 |
 | 2026-04-20 | drift 방지 — TagFilter.astro/admin/must-read.astro의 누락된 stripMd 동기화, nested `**outer *inner* outer**` 처리 개선, 다섯 구현 parity 테스트 추가 |
+| 2026-04-20 | Oracle gap closure — stripInlineMarkdown에 nested bold placeholder 전략 적용, summarize-articles에 clearStaleDescription() 추가 (요약 실패 시 stale 영문 description 자동 제거), parity test에 source-regex byte parity 검증 추가 |

--- a/docs/troubleshooting/rss-summary-english-fallback.md
+++ b/docs/troubleshooting/rss-summary-english-fallback.md
@@ -157,3 +157,4 @@ per-article try/catch로 격리되어 있어 한 article의 API 실패가 전체
 |------|----------|
 | 2026-04-20 | 최초 작성 — RSS contentSnippet이 description으로 누수되어 요약기가 매번 0건 스킵하던 문제 진단 및 수정 |
 | 2026-04-20 | 회귀 방지 — curated/feeds 처리 분리 추가. 사용자가 직접 적은 curated description(영문/한 줄짜리 등)을 Gemini가 덮어쓰지 않도록 `allowResummarize` 플래그 도입 |
+| 2026-04-20 | Stale fallback policy — fetch 실패 또는 Gemini 실패 시 clearStaleDescription()으로 stale 영문 description을 즉시 제거. 다음 run에서 가드가 다시 픽업해 재시도 |

--- a/scripts/summarize-articles.ts
+++ b/scripts/summarize-articles.ts
@@ -215,6 +215,24 @@ export async function updateArticleFile(filePath: string, data: Record<string, u
   await writeFile(filePath, `${JSON.stringify(updated, null, 2)}\n`, 'utf-8');
 }
 
+/**
+ * Remove a stale description so the article does not keep showing raw English /
+ * RSS contentSnippet to users while it waits for a future summarize run.
+ *
+ * Called when the article currently has a non-Korean-structured description AND
+ * we failed to produce a fresh Korean summary (fetch returned too little content,
+ * or Gemini returned an error).
+ *
+ * The article will be picked up again by `findArticlesNeedingSummary` on the next
+ * run because the description is now empty.
+ */
+export async function clearStaleDescription(filePath: string, data: Record<string, unknown>): Promise<void> {
+  if (!data.description) return; // already empty, nothing to do
+  const cleaned = { ...data };
+  delete cleaned.description;
+  await writeFile(filePath, `${JSON.stringify(cleaned, null, 2)}\n`, 'utf-8');
+}
+
 export async function summarizeArticles(options: SummarizeOptions = {}): Promise<SummarizeResult> {
   const {
     curatedDir = CURATED_DIR,
@@ -254,6 +272,11 @@ export async function summarizeArticles(options: SummarizeOptions = {}): Promise
 
       if (!content || content.length < 100) {
         console.warn('  Skipped: insufficient content extracted');
+        // Clear any stale RSS contentSnippet so users do not keep seeing the raw
+        // English/non-Korean text while we cannot produce a fresh summary.
+        if (!dryRun) {
+          await clearStaleDescription(filePath, data);
+        }
         skipped += 1;
         continue;
       }
@@ -266,6 +289,11 @@ export async function summarizeArticles(options: SummarizeOptions = {}): Promise
       if (!summary) {
         const message = `Failed to generate summary for: ${title}`;
         console.error(`  ${message}`);
+        // Same fallback as the fetch-failure branch: clear stale description so it
+        // does not linger in the UI between summarize runs.
+        if (!dryRun) {
+          await clearStaleDescription(filePath, data);
+        }
         errors.push(message);
         continue;
       }

--- a/src/lib/render-summary.ts
+++ b/src/lib/render-summary.ts
@@ -105,13 +105,38 @@ export function renderInlineMarkdown(escapedText: string): string {
  */
 export function stripInlineMarkdown(text: string): string {
   if (!text) return '';
-  // Order parallels renderInlineMarkdown to keep behavior consistent.
-  return text
-    .replace(/`([^`\n]+)`/g, '$1')
-    .replace(/\*\*([^*\n]+?)\*\*/g, '$1')
+  // Mirror renderInlineMarkdown's two-pass placeholder strategy so nested
+  // patterns like `**outer *inner* outer**` lose BOTH outer and inner markers.
+  const codePlaceholders: string[] = [];
+  const boldPlaceholders: string[] = [];
+
+  let result = text.replace(/`([^`\n]+)`/g, (_match, code: string) => {
+    const idx = codePlaceholders.length;
+    codePlaceholders.push(code);
+    return `\u0000CODE${idx}\u0001`;
+  });
+
+  result = result.replace(/\*\*([^\n]+?)\*\*/g, (_match, content: string) => {
+    const innerStripped = content
+      .replace(/(^|[^*A-Za-z0-9_])\*(?!\s)([^*\n]+?)(?<!\s)\*(?![A-Za-z0-9_])/g, '$1$2')
+      .replace(/(^|[^A-Za-z0-9_])_([^_\n]+?)_(?![A-Za-z0-9_])/g, '$1$2');
+    const idx = boldPlaceholders.length;
+    boldPlaceholders.push(innerStripped);
+    return `\u0000BOLD${idx}\u0001`;
+  });
+
+  result = result
     .replace(/(^|[^*A-Za-z0-9_])\*(?!\s)([^*\n]+?)(?<!\s)\*(?![A-Za-z0-9_])/g, '$1$2')
     .replace(/(^|[^A-Za-z0-9_])_([^_\n]+?)_(?![A-Za-z0-9_])/g, '$1$2')
     .replace(/\[([^\]\n]+)\]\([^)\s]+\)/g, '$1');
+
+  result = result.replace(/\u0000BOLD(\d+)\u0001/g, (_match, idx: string) => {
+    return boldPlaceholders[Number(idx)];
+  });
+  result = result.replace(/\u0000CODE(\d+)\u0001/g, (_match, idx: string) => {
+    return codePlaceholders[Number(idx)];
+  });
+  return result;
 }
 
 /**

--- a/tests/render-summary.test.ts
+++ b/tests/render-summary.test.ts
@@ -220,6 +220,17 @@ describe('stripInlineMarkdown', () => {
   it('returns empty string for empty input', () => {
     expect(stripInlineMarkdown('')).toBe('');
   });
+
+  it('strips nested **outer *inner* outer** completely (no leftover markers)', () => {
+    // Two-pass placeholder strategy ensures BOTH outer bold and inner italic markers are removed.
+    expect(stripInlineMarkdown('**outer *inner* outer**')).toBe('outer inner outer');
+  });
+
+  it('strips multiple bold + inline code combo cleanly', () => {
+    expect(stripInlineMarkdown('**bold** and `code` and **more**')).toBe(
+      'bold and code and more',
+    );
+  });
 });
 
 describe('stripMarkdownForPreview integration with inline markers', () => {

--- a/tests/strip-md-parity.test.ts
+++ b/tests/strip-md-parity.test.ts
@@ -148,3 +148,68 @@ describe('stripMd parity across all 5 implementations', () => {
     });
   }
 });
+
+describe('stripMd source-regex byte parity (catches drift before runtime)', () => {
+  // Tokens that MUST appear byte-equal in EVERY one of the 5 stripMd implementations.
+  // If you change any of these, you must change ALL FIVE files.
+  // Source of truth: src/lib/render-summary.ts (stripMarkdownForPreview / stripInlineMarkdown).
+  const REQUIRED_TOKENS_ALL = [
+    String.raw`/^#{1,6}\s+/gm`,
+    String.raw`/^[-*]\s+/gm`,
+    String.raw`/\n{2,}/g`,
+    '/`([^`\\n]+)`/g',
+    String.raw`/(^|[^*A-Za-z0-9_])\*(?!\s)([^*\n]+?)(?<!\s)\*(?![A-Za-z0-9_])/g`,
+    String.raw`/(^|[^A-Za-z0-9_])_([^_\n]+?)_(?![A-Za-z0-9_])/g`,
+    String.raw`/\[([^\]\n]+)\]\([^)\s]+\)/g`,
+  ];
+
+  // Bold pattern intentionally diverges:
+  //   render-summary.ts uses /\*\*([^\n]+?)\*\*/g (allows internal *) for nested bold support
+  //     via two-pass placeholder strategy.
+  //   Other 4 files use /\*\*([^*\n]+?)\*\*/g (single-line strict) because they don't
+  //     run a placeholder pass; nested bold passes through to plain text via stripMarkdownForPreview.
+  // Both are accepted, but each file must use exactly one of these forms.
+  const BOLD_PATTERN_OPTIONS = [
+    String.raw`/\*\*([^\n]+?)\*\*/g`,         // render-summary.ts only
+    String.raw`/\*\*([^*\n]+?)\*\*/g`,        // simple form for the other 4 files
+  ];
+
+  const FILES = [
+    'src/lib/render-summary.ts',
+    'functions/lib/escape.ts',
+    'public/scripts/must-read-page.js',
+    'src/components/TagFilter.astro',
+    'src/pages/admin/must-read.astro',
+  ];
+
+  for (const file of FILES) {
+    it(`${file} contains all required regex tokens (byte parity)`, async () => {
+      const source = await readFile(join(ROOT, file), 'utf-8');
+      const missing = REQUIRED_TOKENS_ALL.filter((token) => !source.includes(token));
+      const hasSomeBold = BOLD_PATTERN_OPTIONS.some((token) => source.includes(token));
+
+      const errors: string[] = [];
+      if (missing.length > 0) {
+        errors.push(
+          `Missing ${missing.length} required regex token(s):\n` +
+            missing.map((t) => `  - ${t}`).join('\n'),
+        );
+      }
+      if (!hasSomeBold) {
+        errors.push(
+          `Missing a recognized bold-strip pattern. Must contain ONE of:\n` +
+            BOLD_PATTERN_OPTIONS.map((t) => `  - ${t}`).join('\n'),
+        );
+      }
+      if (errors.length > 0) {
+        throw new Error(
+          `${file} drifted:\n${errors.join('\n')}\n\n` +
+            `Update this file to match the source of truth (src/lib/render-summary.ts).\n` +
+            `See docs/troubleshooting/inline-markdown-rendering.md`,
+        );
+      }
+      expect(missing).toEqual([]);
+      expect(hasSomeBold).toBe(true);
+    });
+  }
+});

--- a/tests/summarize-articles.test.ts
+++ b/tests/summarize-articles.test.ts
@@ -2,9 +2,11 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { mkdir, rm, writeFile } from 'fs/promises';
 import { join } from 'path';
 import {
+  clearStaleDescription,
   findArticlesNeedingSummary,
   looksLikeKoreanStructuredSummary,
 } from '../scripts/summarize-articles';
+import { readFile } from 'fs/promises';
 
 const ROOT = process.cwd();
 const TEST_DIR = join(ROOT, 'tests/tmp-summarize-test');
@@ -234,5 +236,53 @@ describe('findArticlesNeedingSummary', () => {
 
     expect(result).toHaveLength(1);
     expect(result[0].data.id).toBe('good');
+  });
+});
+
+describe('clearStaleDescription', () => {
+  beforeEach(async () => {
+    await rm(TEST_DIR, { recursive: true, force: true });
+    await mkdir(FEEDS_DIR, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(TEST_DIR, { recursive: true, force: true });
+  });
+
+  it('removes the description field when called on stale article', async () => {
+    const filePath = join(FEEDS_DIR, 'stale.json');
+    const data = {
+      id: 'stale',
+      title: 'Stale article',
+      url: 'https://example.com/stale',
+      description: 'Long raw English RSS contentSnippet that is not Korean structured summary.',
+    };
+    await writeFile(filePath, JSON.stringify(data, null, 2));
+
+    await clearStaleDescription(filePath, data);
+
+    const updated = JSON.parse(await readFile(filePath, 'utf-8'));
+    expect(updated.description).toBeUndefined();
+    // Other fields preserved
+    expect(updated.id).toBe('stale');
+    expect(updated.title).toBe('Stale article');
+    expect(updated.url).toBe('https://example.com/stale');
+  });
+
+  it('is a no-op when description is already missing', async () => {
+    const filePath = join(FEEDS_DIR, 'empty.json');
+    const data = {
+      id: 'empty',
+      title: 'No description article',
+      url: 'https://example.com/empty',
+    };
+    await writeFile(filePath, JSON.stringify(data, null, 2));
+
+    await clearStaleDescription(filePath, data);
+
+    const updated = JSON.parse(await readFile(filePath, 'utf-8'));
+    // File should be unchanged structurally
+    expect(updated.description).toBeUndefined();
+    expect(updated.id).toBe('empty');
   });
 });


### PR DESCRIPTION
## 요약

Oracle 2차 리뷰가 NOT VERIFIED를 발급한 3가지 잔여 gap 해결.

## Oracle 지적 vs 처리

| Gap | Oracle 지적 | 이 PR 처리 |
|-----|------------|----------|
| 2 | 1개 article(`5eff5416...`)이 5000자 raw 본문을 사용자에게 노출. fetch/Gemini 실패 시 stale 데이터 잔존 | `clearStaleDescription()` 신규: 실패 시 stale description 즉시 제거 → UI에 raw 안 보임, 다음 run에서 재시도 |
| 4 | parity test가 source-regex byte parity는 검증 못함 | 5개 구현에 7개 required token + bold pattern 2개 form 중 하나 검증. drift 발생 시 어느 파일이 어느 token 누락했는지 정확히 표시 |
| 5 | `stripInlineMarkdown('**outer *inner* outer**')` → `**outer inner outer**` (outer 마커 잔존) | render-summary.ts의 stripInlineMarkdown을 placeholder 전략으로 재구성. 결과: `outer inner outer` |

## 변경 내용

| 파일 | 변경 |
|------|------|
| `scripts/summarize-articles.ts` | `clearStaleDescription()` 신규 export, fetch/summary 실패 분기에서 호출 |
| `src/lib/render-summary.ts` | stripInlineMarkdown을 두-패스 placeholder 전략으로 재구성 |
| `tests/strip-md-parity.test.ts` | 5개 구현 source-regex byte parity 검증 5개 추가 (필수 7 token + bold pattern allow-list) |
| `tests/render-summary.test.ts` | nested strip + multi-bold strip 테스트 2개 추가 |
| `tests/summarize-articles.test.ts` | clearStaleDescription 테스트 2개 추가 |
| `docs/troubleshooting/inline-markdown-rendering.md` | 변경 이력 갱신 |
| `docs/troubleshooting/rss-summary-english-fallback.md` | 변경 이력 갱신 |

## 검증

- ✅ 222/222 tests pass (+ 신규 9: 5 parity + 2 nested strip + 2 clearStale)
- ✅ validate / validate:docs / check-coverage / build 모두 통과
- ✅ Oracle 지적 모든 gap에 대응

## 후속

7개 fetch-impossible article ("Comments..." 같은 stub)도 이제 clearStaleDescription을 통해 description undefined 상태가 됨. UI는 ArticleCard.astro의 `{description && <p>...}` 가드로 자동 hide.