### PR TITLE
fix(articles): address Oracle verification blockers from PR #119

### DIFF
--- a/docs/features/article-search.md
+++ b/docs/features/article-search.md
@@ -49,7 +49,7 @@
 | `src/components/ArticleSearch.astro` | 검색 입력 UI + debounce + 이벤트 발행 + URL 동기화 |
 | `src/components/InterestTagPanel.astro` | `article-search-changed` 수신 → 결과 렌더링 + 카운트 갱신 |
 | `src/components/SourceFilter.astro` | `source-counts-update` 수신 → 카운트 동적 갱신 |
-| `src/lib/article-search.ts` | 순수 검색 로직 (`searchArticles`) — 단위 테스트의 단일 진실 공급원 |
+| `src/lib/article-search.ts` | 순수 검색 로직 (`searchArticles`, `getFilteredPool`) — 필터 파이프라인 계약의 단일 진실 공급원. 인라인 컴포넌트 스크립트는 동일 로직을 미러링하며, 계약 검증은 `tests/article-search.test.ts`의 `getFilteredPool` 서브를 통해 이뤄진다. |
 | `src/lib/serialize-articles.ts` | 빌드 시 모든 기사를 클라이언트 JSON으로 직렬화 |
 | `tests/article-search.test.ts` | 검색·관심사 헬퍼 단위 테스트 |
 | `src/pages/articles/index.astro` | ArticleSearch 컴포넌트 마운트 (1페이지) |
@@ -83,3 +83,4 @@
 | 날짜 | 변경 내용 |
 |------|----------|
 | 2026-04-20 | 최초 작성 — `/articles/` 페이지에 제목 검색 기능 추가 |
+| 2026-04-20 | Oracle 검증 대응 — ArticleSearch 입력 리스너와 `source-filter-changed` 도큐먼트 리스너에 누적 방지 가드(`__articleSearchState`) 추가. 페이지 네비게이션 시 검색 캐시 초기화. `getFilteredPool` 통합 테스트 10건 추가. |

--- a/docs/features/interest-tag-panel.md
+++ b/docs/features/interest-tag-panel.md
@@ -19,7 +19,7 @@ InterestTagPanel은 다음과 같이 통합한다.
 
 - **하나의 칩 = 두 가지 액션**: 본문 클릭 = hard 태그 필터, 별표(☆) 클릭 = 관심사 토글
 - **인기 태그 6개만 상시 노출**: "모든 태그 보기" 토글로 전체 241개 펼쳐 보기
-- **저장된 관심사는 항상 우선 노출**: 상시 노출 6개 슬롯에 관심사가 먼저 들어가고, 남은 자리를 인기 태그가 채움
+- **저장된 관심사는 항상 우선 노출 (런타임 재조립)**: 상시 노출 6개 슬롯을 클라이언트에서 재렌더링하여 localStorage 관심사를 먼저 채우고, 남은 자리를 인기 태그가 채운다. (SSR 시점에는 사용자의 localStorage 내용을 알 수 없으므로 반드시 런타임 `refreshTopRow()`이 필요하다.)
 - **관심사 매칭을 강조 표시**: 매칭 카드에 `⭐ 관심` 코너 뱃지 + 노란 배경 그라데이션 + 노란 그림자 → "차이 없어" 문제 해결
 - **헤더에 "관심사 일치 N건" 카운트 뱃지**: 정량 피드백 제공
 
@@ -58,9 +58,9 @@ InterestTagPanel은 다음과 같이 통합한다.
 
 검색 / origin / tag / 관심사가 모두 동시에 적용 가능하다. 우선순위는:
 
-1. **검색** (있으면 풀이 됨; ArticleSearch가 origin을 미리 적용한 결과)
-2. **origin** (검색이 없을 때 풀에서 origin으로 필터)
-3. **tag** (위 풀에서 태그 필터)
+1. **검색** (있으면 주 풌이 됨)
+2. **태그** (위 풌에서 태그 필터)
+3. **origin** (위 풌에서 origin으로 스코프 적용 — SourceFilter는 origin 적용 *전* 풌의 per-origin 카운트를 받아 "제출 기사 N · RSS M" 식으로 정직하게 표시)
 4. **관심사** (위 결과 내에서 매칭 카드를 상단으로 pin + 시각 강조)
 
 검색·origin·tag 중 하나라도 활성이면 SSR 카드 + 페이지네이션이 숨겨지고 동적 결과 컨테이너가 표시된다.
@@ -72,7 +72,7 @@ InterestTagPanel은 다음과 같이 통합한다.
 | `src/components/InterestTagPanel.astro` | 통합 패널 컴포넌트 (UI + 모든 클라이언트 로직) |
 | `src/components/ArticleSearch.astro` | 제목 검색. `article-search-changed` 이벤트로 결과 전달 |
 | `src/components/SourceFilter.astro` | 출처 필터 탭. `source-counts-update` 수신 |
-| `src/lib/article-search.ts` | 순수 헬퍼 (`getTopTags`, `getInterestMatches`, `pinInterestMatches`) — 단위 테스트의 단일 진실 공급원 |
+| `src/lib/article-search.ts` | 순수 헬퍼 (`searchArticles`, `getTopTags`, `getInterestMatches`, `pinInterestMatches`, `getFilteredPool`) — 단위 테스트의 단일 진실 공급원. 컴포넌트 사용자 소수 함수(`computeTopTags`, `getFilteredPool` 동일 로직)는 에이셔블 컴포넌트에 미러링 구현되어 있으며, 계약은 이 파일이 정의한다. |
 | `tests/article-search.test.ts` | 헬퍼 단위 테스트 |
 | `src/pages/articles/index.astro` | InterestTagPanel 마운트 + `tagCounts` prop 계산 |
 | `src/pages/articles/page/[...page].astro` | InterestTagPanel 마운트 (페이지네이션) |
@@ -83,16 +83,18 @@ InterestTagPanel은 다음과 같이 통합한다.
 | 이름 | 위치 | 기본값 | 설명 |
 |------|------|--------|------|
 | `STORAGE_KEY` | `src/components/InterestTagPanel.astro` (인라인 상수) | `'honeycombo_interests'` | localStorage 키. 기존 PersonalizationBar와 동일 → 마이그레이션 불필요 |
-| `TOP_N` | `src/components/InterestTagPanel.astro` (frontmatter) | `6` | 상시 노출 칩 슬롯 개수 |
+| `TOP_N` | `src/components/InterestTagPanel.astro` (인라인 상수) | `6` | 상시 노출 칩 슬롯 개수 |
 | `?tag=` | URL 쿼리 파라미터 | (없음) | 활성 태그 필터 (페이지 새로고침 시 복원) |
 
 ## 제약 사항
 
 - 칩 클릭은 항상 cross-page hard 필터로 동작한다 (현재 페이지에 매칭이 없어도 전체 기사에서 찾아 표시).
 - 관심사 매칭 강조(`.interest-match` 클래스)는 ArticleCard의 `<style is:global>`과 InterestTagPanel의 글로벌 스타일을 함께 사용한다. 다른 페이지에서 ArticleCard를 사용해도 InterestTagPanel이 마운트되지 않으면 `.interest-match` 클래스가 부여되지 않으므로 효과는 발생하지 않는다.
+- "관심사 일치 N건" 뱃지는 전체 기사 데이터셋을 기준으로 계산된다 (`refreshMatchBadgeFromFullDataset`). 현재 페이지에 보이는 20개 카드가 아니라 총 299건 중 일치하는 수 — 사용자가 "차이 없어" 는낀 문제를 해소.
 - `serializeArticles()`가 임베드한 JSON에 의존한다. 페이지에 `<script id="all-articles-data">`가 없으면 cross-page 필터는 빈 결과를 반환한다.
 - `getInterests()`는 손상된 localStorage 값을 만나면 빈 배열로 fallback한다 (사용자 데이터 손실 가능성 차단).
 - 펼침 패널의 전체 태그 리스트는 SSR로 렌더링되므로 페이지 HTML 크기가 태그 수에 비례한다 (현재 ~241개 기준 영향 미미).
+- 칩 UI는 *chip-wrap* 래퍼 안에 칩 버튼(태그 필터용)과 별표 버튼(관심사 토글용)을 *형제*로 둘다. 과거의 중첩 `<button>` 마크업(유효하지 않고 키보드로 관심사 조작 불가)을 사용하지 않으며, 둘 다 독립적으로 키보드 포커스가 가능하다 (Tab 이동 + Enter/Space).
 
 ---
 
@@ -108,3 +110,4 @@ InterestTagPanel은 다음과 같이 통합한다.
 | 날짜 | 변경 내용 |
 |------|----------|
 | 2026-04-20 | 최초 작성 — PersonalizationBar + TagFilter 통합, 인기 태그 6개 상시 노출 + 관심사 매칭 시각 강조 추가 |
+| 2026-04-20 | Oracle 검증 대응 — (1) 상단 6칩 런타임 재조립으로 관심사 우선 표시, (2) per-origin 카운트를 search∩tag 풌 기준으로 계산, (3) 관심사 뱃지를 전체 데이터셋 기준으로 계산, (4) 별표을 chip-wrap 형제 버튼으로 분리 (유효 HTML + 키보드 접근성), (5) astro:page-load 리스너 누적 방지 가드 추가. 통합 테스트 10건 추가 (`getFilteredPool` search∩origin∩tag). |

--- a/src/components/ArticleSearch.astro
+++ b/src/components/ArticleSearch.astro
@@ -49,20 +49,29 @@
     isExternal: boolean;
   }
 
-  let allArticlesCache: ClientArticle[] | null = null;
-  let debounceTimer: ReturnType<typeof setTimeout> | null = null;
-  let lastQuery = '';
+  // Per-document state (survives view transitions; resets on full page load).
+const w = window as any;
+if (!w.__articleSearchState) {
+  w.__articleSearchState = {
+    allArticlesCache: null as ClientArticle[] | null,
+    debounceTimer: null as ReturnType<typeof setTimeout> | null,
+    lastQuery: '' as string,
+    docListenersBound: false as boolean,
+    inputBoundOn: null as HTMLInputElement | null,
+  };
+}
+const sstate = w.__articleSearchState;
 
   function getAllArticles(): ClientArticle[] {
-    if (allArticlesCache) return allArticlesCache;
+    if (sstate.allArticlesCache) return sstate.allArticlesCache;
     const el = document.getElementById('all-articles-data');
     if (!el?.textContent) return [];
     try {
-      allArticlesCache = JSON.parse(el.textContent) as ClientArticle[];
+      sstate.allArticlesCache = JSON.parse(el.textContent) as ClientArticle[];
     } catch {
-      allArticlesCache = [];
+      sstate.allArticlesCache = [];
     }
-    return allArticlesCache;
+    return sstate.allArticlesCache;
   }
 
   function getActiveOrigin(): string {
@@ -104,43 +113,56 @@
   }
 
   function applySearch(query: string, origin?: string) {
-    lastQuery = query;
+    sstate.lastQuery = query;
     const clearBtn = document.getElementById('article-search-clear');
     if (clearBtn) clearBtn.hidden = !query.trim();
     dispatchSearchChange(query, origin);
   }
 
-  function initArticleSearch() {
+function initArticleSearch() {
     const input = document.getElementById('article-search-input') as HTMLInputElement | null;
     const clearBtn = document.getElementById('article-search-clear');
     if (!input) return;
 
-    // Apply initial query from URL
+    // Reset article cache on each page load — different page = different #all-articles-data.
+    sstate.allArticlesCache = null;
+
+    // Apply initial query from URL (do this on every page load so navigation respects ?q=).
     const initialQuery = new URLSearchParams(window.location.search).get('q') || '';
     if (initialQuery) {
       input.value = initialQuery;
       if (clearBtn) clearBtn.hidden = false;
-      // Defer to next tick so InterestTagPanel/SourceFilter listeners are attached
+      // Defer to next tick so InterestTagPanel/SourceFilter listeners are attached.
       setTimeout(() => applySearch(initialQuery), 0);
+    } else {
+      // No query in URL — ensure we reset state when navigating between pages.
+      input.value = '';
+      if (clearBtn) clearBtn.hidden = true;
+      sstate.lastQuery = '';
     }
 
-    input.addEventListener('input', () => {
-      const value = input.value;
-      if (debounceTimer) clearTimeout(debounceTimer);
-      debounceTimer = setTimeout(() => applySearch(value), 150);
-    });
+    // Bind input listener once per <input> element. View Transitions reuse the same DOM,
+    // so the same input persists — don't rebind. On full reload the new input is different.
+    if (sstate.inputBoundOn !== input) {
+      sstate.inputBoundOn = input;
+      input.addEventListener('input', () => {
+        const value = input.value;
+        if (sstate.debounceTimer) clearTimeout(sstate.debounceTimer);
+        sstate.debounceTimer = setTimeout(() => applySearch(value), 150);
+      });
+      clearBtn?.addEventListener('click', () => {
+        input.value = '';
+        applySearch('');
+        input.focus();
+      });
+    }
 
-    clearBtn?.addEventListener('click', () => {
-      input.value = '';
-      applySearch('');
-      input.focus();
-    });
-
-    // Re-scope when source filter changes
+    // Document-level listeners bound exactly once per page load (full reload).
+    if (sstate.docListenersBound) return;
+    sstate.docListenersBound = true;
     document.addEventListener('source-filter-changed', ((e: CustomEvent<{ origin: string }>) => {
-      // Only re-dispatch if there's an active query
-      if (lastQuery.trim()) {
-        dispatchSearchChange(lastQuery, e.detail.origin);
+      if (sstate.lastQuery.trim()) {
+        dispatchSearchChange(sstate.lastQuery, e.detail.origin);
       }
     }) as EventListener);
   }

--- a/src/components/InterestTagPanel.astro
+++ b/src/components/InterestTagPanel.astro
@@ -10,7 +10,9 @@
 //                         Articles matching saved interests get a visible "interest" highlight
 //                         (background tint + corner star) and are pinned to the top of the list.
 //   - "전체" chip       -> clears the active tag filter.
-//   - Top 5-6 chips    -> always visible. Saved interests come first, then most-used tags.
+//   - Top 6 chips      -> always visible. Saved interests come first (client-side rewrite),
+//                         then most-used tags. Built at runtime so per-user interests can
+//                         actually be promoted (SSG cannot know per-user localStorage).
 //   - Toggle button    -> expands the full tag list (all tags), grouped into
 //                         "내 관심사" (saved) and "전체 태그".
 //
@@ -32,14 +34,17 @@ interface Props {
 }
 const { availableTags, tagCounts } = Astro.props;
 
-// Sort tags by article count desc, then alphabetically — used for both the
-// "top tags" row and the full tag list.
+// Sort tags by article count desc, then alphabetically — used as the fallback popular order
+// when a user has no saved interests. The actual top row is rebuilt client-side because we
+// can't know the user's saved interests at build time.
 const sortedTags = [...availableTags].sort((a, b) => {
   const diff = (tagCounts[b] || 0) - (tagCounts[a] || 0);
   if (diff !== 0) return diff;
   return a.localeCompare(b);
 });
-const TOP_N = 6;
+
+// Embed tag counts as JSON so client code can call getTopTags() at runtime.
+const tagCountsJson = JSON.stringify(tagCounts);
 ---
 
 <div class="interest-tag-panel" data-testid="interest-tag-panel">
@@ -59,17 +64,32 @@ const TOP_N = 6;
     </button>
   </div>
 
-  <!-- Always-visible top row -->
+  <!--
+    Always-visible top row.
+    Rendered server-side with popular tags as a fallback so JS-disabled or pre-hydration users
+    still see something useful. Once the script runs, refreshTopRow() rewrites this row to put
+    saved interests first.
+  -->
   <div class="itp-chips-row" id="itp-chips-row" data-testid="itp-chips-row">
     <button class="itp-chip itp-chip-all active" data-tag="all" type="button">
       <span class="itp-chip-label">전체</span>
     </button>
-    {sortedTags.slice(0, TOP_N).map((tag) => (
-      <button class="itp-chip" data-tag={tag} type="button">
-        <span class="itp-chip-star" data-star data-tag={tag} role="button" aria-label={`${tag} 관심사로 저장`} title="관심사로 저장">☆</span>
-        <span class="itp-chip-label">{tag}</span>
-        <span class="itp-chip-count">{tagCounts[tag] ?? 0}</span>
-      </button>
+    {sortedTags.slice(0, 6).map((tag) => (
+      <span class="itp-chip-wrap">
+        <button class="itp-chip" data-tag={tag} type="button">
+          <span class="itp-chip-label">{tag}</span>
+          <span class="itp-chip-count">{tagCounts[tag] ?? 0}</span>
+        </button>
+        <button
+          class="itp-chip-star"
+          type="button"
+          data-star
+          data-tag={tag}
+          aria-label={`${tag} 관심사로 저장`}
+          aria-pressed="false"
+          title="관심사로 저장"
+        >☆</button>
+      </span>
     ))}
   </div>
 
@@ -92,16 +112,29 @@ const TOP_N = 6;
       </div>
       <div class="itp-all-tags" id="itp-all-tags">
         {sortedTags.map((tag) => (
-          <button class="itp-chip" data-tag={tag} type="button">
-            <span class="itp-chip-star" data-star data-tag={tag} role="button" aria-label={`${tag} 관심사로 저장`} title="관심사로 저장">☆</span>
-            <span class="itp-chip-label">{tag}</span>
-            <span class="itp-chip-count">{tagCounts[tag] ?? 0}</span>
-          </button>
+          <span class="itp-chip-wrap">
+            <button class="itp-chip" data-tag={tag} type="button">
+              <span class="itp-chip-label">{tag}</span>
+              <span class="itp-chip-count">{tagCounts[tag] ?? 0}</span>
+            </button>
+            <button
+              class="itp-chip-star"
+              type="button"
+              data-star
+              data-tag={tag}
+              aria-label={`${tag} 관심사로 저장`}
+              aria-pressed="false"
+              title="관심사로 저장"
+            >☆</button>
+          </span>
         ))}
       </div>
     </section>
   </div>
 </div>
+
+<!-- tagCounts payload for runtime getTopTags() -->
+<script type="application/json" id="itp-tag-counts" set:html={tagCountsJson} />
 
 <!-- Container for dynamically-rendered cross-page filtered/searched results -->
 <div class="itp-filtered-results" id="itp-filtered-results" style="display:none;">
@@ -131,12 +164,24 @@ const TOP_N = 6;
   }
 
   const STORAGE_KEY = 'honeycombo_interests';
-  let allArticlesCache: ClientArticle[] | null = null;
+  const TOP_N = 6;
 
-  // Active state
-  let activeTag = 'all';
-  let activeSearchQuery = '';
-  let activeSearchResults: ClientArticle[] | null = null; // null = no active search
+  // ---- Per-document state. Resets on full page load; survives view transitions ----
+  // We hang state off `window` so re-runs of this script (View Transitions, HMR) don't
+  // accidentally start with a stale module-scope cache.
+  const w = window as any;
+  if (!w.__itpState) {
+    w.__itpState = {
+      allArticles: null as ClientArticle[] | null,
+      tagCounts: null as Record<string, number> | null,
+      activeTag: 'all' as string,
+      activeSearchQuery: '' as string,
+      activeSearchResults: null as ClientArticle[] | null, // null = no active search
+      // Track delegated listeners so we never bind twice across astro:page-load.
+      listenersBound: false as boolean,
+    };
+  }
+  const state = w.__itpState;
 
   // ---------- localStorage interests ----------
   function getInterests(): string[] {
@@ -165,34 +210,46 @@ const TOP_N = 6;
     document.dispatchEvent(
       new CustomEvent('interests-changed', { detail: { interests } })
     );
+    refreshTopRow();
     refreshInterestsUI();
     applyInterestHighlights();
-    // If the filtered grid is currently shown, re-render it (matched cards pin to top).
-    if (isFilteredViewActive()) {
-      renderFilteredView();
-    }
+    refreshMatchBadgeFromFullDataset();
+    if (isFilteredViewActive()) renderFilteredView();
   }
   function clearInterests(): void {
     saveInterests([]);
     document.dispatchEvent(
       new CustomEvent('interests-changed', { detail: { interests: [] } })
     );
+    refreshTopRow();
     refreshInterestsUI();
     applyInterestHighlights();
+    refreshMatchBadgeFromFullDataset();
     if (isFilteredViewActive()) renderFilteredView();
   }
 
-  // ---------- Articles JSON ----------
+  // ---------- Articles + tag counts JSON ----------
   function getAllArticles(): ClientArticle[] {
-    if (allArticlesCache) return allArticlesCache;
+    if (state.allArticles) return state.allArticles;
     const el = document.getElementById('all-articles-data');
     if (!el?.textContent) return [];
     try {
-      allArticlesCache = JSON.parse(el.textContent) as ClientArticle[];
+      state.allArticles = JSON.parse(el.textContent) as ClientArticle[];
     } catch {
-      allArticlesCache = [];
+      state.allArticles = [];
     }
-    return allArticlesCache;
+    return state.allArticles;
+  }
+  function getTagCounts(): Record<string, number> {
+    if (state.tagCounts) return state.tagCounts;
+    const el = document.getElementById('itp-tag-counts');
+    if (!el?.textContent) return {};
+    try {
+      state.tagCounts = JSON.parse(el.textContent) as Record<string, number>;
+    } catch {
+      state.tagCounts = {};
+    }
+    return state.tagCounts;
   }
 
   function getActiveOrigin(): string {
@@ -200,6 +257,29 @@ const TOP_N = 6;
       '[data-testid="source-filter"] .source-filter-btn.active'
     );
     return active?.dataset.origin || 'all';
+  }
+
+  // ---------- Pure helper: getTopTags (mirrors src/lib/article-search.ts) ----------
+  function computeTopTags(interests: readonly string[], counts: Record<string, number>, limit = TOP_N): string[] {
+    const result: string[] = [];
+    const seen = new Set<string>();
+    for (const tag of interests) {
+      if (seen.has(tag) || result.length >= limit) continue;
+      seen.add(tag);
+      result.push(tag);
+    }
+    if (result.length >= limit) return result.slice(0, limit);
+    const sorted = Object.keys(counts).sort((a, b) => {
+      const diff = (counts[b] || 0) - (counts[a] || 0);
+      if (diff !== 0) return diff;
+      return a.localeCompare(b);
+    });
+    for (const tag of sorted) {
+      if (seen.has(tag) || result.length >= limit) continue;
+      seen.add(tag);
+      result.push(tag);
+    }
+    return result.slice(0, limit);
   }
 
   // ---------- Card rendering (mirrors ArticleCard.astro) ----------
@@ -305,27 +385,38 @@ const TOP_N = 6;
 
   // ---------- Filter pipeline ----------
   function isFilteredViewActive(): boolean {
-    return activeTag !== 'all' || getActiveOrigin() !== 'all' || activeSearchResults !== null;
+    return (
+      state.activeTag !== 'all' ||
+      getActiveOrigin() !== 'all' ||
+      state.activeSearchResults !== null
+    );
   }
 
-  function getFilteredArticles(): ClientArticle[] {
+  /**
+   * Build the active pool for the filtered view.
+   *
+   * Search/origin/tag are all applied. We re-derive search from the canonical
+   * `getAllArticles()` so changes to origin AFTER search dispatch don't see a
+   * stale origin-scoped search-result snapshot.
+   */
+  function getFilteredPool(): { all: ClientArticle[]; perOrigin: { submitted: number; feed: number; curated: number } } {
     const origin = getActiveOrigin();
+    const q = state.activeSearchQuery.trim().toLowerCase();
+    const tag = state.activeTag;
+    let pool = getAllArticles();
+    if (q) pool = pool.filter((a) => a.title.toLowerCase().includes(q));
+    if (tag !== 'all') pool = pool.filter((a) => a.tags.includes(tag));
 
-    // Search takes precedence as the article pool
-    let articles: ClientArticle[];
-    if (activeSearchResults !== null) {
-      articles = activeSearchResults;
-    } else {
-      articles = getAllArticles();
-      if (origin !== 'all') {
-        articles = articles.filter((a) => a.articleOrigin === origin);
-      }
-    }
+    // Per-origin breakdown is computed BEFORE applying origin filter,
+    // so SourceFilter can show "0 in Submitted / N in RSS" honestly.
+    const perOrigin = {
+      submitted: pool.filter((a) => a.articleOrigin === 'submitted').length,
+      feed: pool.filter((a) => a.articleOrigin === 'feed').length,
+      curated: pool.filter((a) => a.articleOrigin === 'curated').length,
+    };
 
-    if (activeTag !== 'all') {
-      articles = articles.filter((a) => a.tags.includes(activeTag));
-    }
-    return articles;
+    const all = origin === 'all' ? pool : pool.filter((a) => a.articleOrigin === origin);
+    return { all, perOrigin };
   }
 
   function buildFilterLabel(count: number): string {
@@ -335,11 +426,11 @@ const TOP_N = 6;
       const m: Record<string, string> = { curated: '에디터 추천', submitted: '제출 기사', feed: 'RSS 피드' };
       labels.push(m[origin] || origin);
     }
-    if (activeTag !== 'all') {
-      labels.push(`"${activeTag}" 태그`);
+    if (state.activeTag !== 'all') {
+      labels.push(`"${state.activeTag}" 태그`);
     }
-    if (activeSearchQuery) {
-      labels.push(`"${activeSearchQuery}" 검색`);
+    if (state.activeSearchQuery) {
+      labels.push(`"${state.activeSearchQuery}" 검색`);
     }
     const prefix = labels.length > 0 ? `${labels.join(' · ')} · ` : '';
     return `${prefix}기사 ${count}건`;
@@ -362,25 +453,27 @@ const TOP_N = 6;
       if (pagination) pagination.style.display = '';
       container.style.display = 'none';
       if (ssrEmpty) ssrEmpty.style.display = 'none';
-      // Reset source counts
+      // Reset source counts to SSR originals
       document.dispatchEvent(
         new CustomEvent('source-counts-update', { detail: { reset: true } })
       );
       // Re-apply highlights to SSR cards (interests may still be active)
       applyInterestHighlights();
       pinInterestMatchesInList();
+      refreshMatchBadgeFromFullDataset();
       return;
     }
 
-    // Hide SSR list & pagination, show filtered grid
+    // Filtered view
     if (ssrList) ssrList.style.display = 'none';
     if (pagination) pagination.style.display = 'none';
     container.style.display = '';
 
     const interests = new Set(getInterests());
-    let articles = getFilteredArticles();
+    const { all: filtered, perOrigin } = getFilteredPool();
 
     // Pin interest-matched articles to top
+    let articles = filtered;
     if (interests.size > 0) {
       const matched: ClientArticle[] = [];
       const unmatched: ClientArticle[] = [];
@@ -392,7 +485,7 @@ const TOP_N = 6;
     }
 
     countEl.textContent = buildFilterLabel(articles.length);
-    grid.dataset.activeTag = activeTag;
+    grid.dataset.activeTag = state.activeTag;
     grid.innerHTML = articles.map((a) => renderCard(a, interests)).join('');
     if (emptyEl) emptyEl.hidden = articles.length > 0;
     if (ssrEmpty) ssrEmpty.style.display = 'none';
@@ -408,40 +501,33 @@ const TOP_N = 6;
       (window as any).__initCommentCounts(grid);
     }
 
-    // Update SourceFilter counts to reflect the active filter pool (search-aware)
-    updateSourceCounts();
-    refreshMatchBadge(articles, interests);
-  }
-
-  function updateSourceCounts() {
-    // When search is active, source counts reflect search results across origins.
-    // Otherwise, source counts reflect all-articles (we let SSR counts stand) — only update if search active.
-    if (activeSearchResults === null) {
-      // No search: restore original SSR counts (they reflect totals).
-      document.dispatchEvent(
-        new CustomEvent('source-counts-update', { detail: { reset: true } })
-      );
-      return;
-    }
-    const pool = activeSearchResults; // already title-filtered, origin-scoped to current selection
-    // We need per-origin breakdown, but search is done against the full pool with current origin pre-applied.
-    // So recompute against ALL articles filtered by query, regardless of origin, to give true per-origin counts.
-    const all = getAllArticles();
-    const q = activeSearchQuery.trim().toLowerCase();
-    const matched = q ? all.filter((a) => a.title.toLowerCase().includes(q)) : all;
-    const submitted = matched.filter((a) => a.articleOrigin === 'submitted').length;
-    const feed = matched.filter((a) => a.articleOrigin === 'feed').length;
-    const curated = matched.filter((a) => a.articleOrigin === 'curated').length;
+    // Update SourceFilter counts based on the current filtered pool
     document.dispatchEvent(
       new CustomEvent('source-counts-update', {
-        detail: { all: submitted + feed + curated, submitted, feed },
+        detail: {
+          all: perOrigin.submitted + perOrigin.feed + perOrigin.curated,
+          submitted: perOrigin.submitted,
+          feed: perOrigin.feed,
+        },
       })
     );
-    // pool referenced to silence unused warning in some bundlers
-    void pool;
+
+    // Match badge counts against the FULL filtered pool (not just rendered cards)
+    refreshMatchBadgeFromArticles(filtered, interests);
   }
 
-  function refreshMatchBadge(articles: ClientArticle[], interests: Set<string>) {
+  /**
+   * Match badge for the SSR view. Counts against the FULL article dataset (not just
+   * current-page cards), so the user sees an honest total even when matches live on
+   * other pages — the user's complaint was that interests appeared to "do nothing"
+   * because the visible 20 cards don't always include matches.
+   */
+  function refreshMatchBadgeFromFullDataset() {
+    const interests = new Set(getInterests());
+    const all = getAllArticles();
+    refreshMatchBadgeFromArticles(all, interests);
+  }
+  function refreshMatchBadgeFromArticles(articles: ClientArticle[], interests: Set<string>) {
     const badge = document.getElementById('itp-match-badge');
     if (!badge) return;
     if (interests.size === 0) {
@@ -459,31 +545,17 @@ const TOP_N = 6;
     badge.textContent = `관심사 일치 ${count}건`;
   }
 
-  // ---------- SSR card highlight + pinning ----------
+  // ---------- SSR card highlight + pinning (current-page visual only) ----------
   function applyInterestHighlights() {
     const list = document.querySelector('[data-testid="article-list"]');
     if (!list) return;
     const interests = new Set(getInterests());
     const cards = list.querySelectorAll<HTMLElement>('[data-testid="article-card"]');
-    let matchCount = 0;
     cards.forEach((card) => {
       const tags = (card.dataset.tags || '').split(',').filter(Boolean);
       const isMatch = interests.size > 0 && tags.some((t) => interests.has(t));
       card.classList.toggle('interest-match', isMatch);
-      if (isMatch) matchCount += 1;
     });
-
-    // Update header badge for the SSR view
-    const badge = document.getElementById('itp-match-badge');
-    if (badge) {
-      if (interests.size === 0 || matchCount === 0) {
-        badge.hidden = true;
-        badge.textContent = '';
-      } else {
-        badge.hidden = false;
-        badge.textContent = `관심사 일치 ${matchCount}건`;
-      }
-    }
   }
 
   function pinInterestMatchesInList() {
@@ -492,13 +564,11 @@ const TOP_N = 6;
     const interests = getInterests();
     const cards = Array.from(list.querySelectorAll<HTMLElement>('[data-testid="article-card"]'));
 
-    // Initialize originalIndex once
     cards.forEach((card, i) => {
       if (!card.dataset.originalIndex) card.dataset.originalIndex = String(i);
     });
 
     if (interests.length === 0) {
-      // Restore original order
       const sorted = [...cards].sort(
         (a, b) => Number(a.dataset.originalIndex ?? 0) - Number(b.dataset.originalIndex ?? 0)
       );
@@ -516,12 +586,48 @@ const TOP_N = 6;
     [...matched, ...unmatched].forEach((card) => list.appendChild(card));
   }
 
-  // ---------- UI: chip rendering / interest pills ----------
+  // ---------- Top-row rebuild (BLOCKER 1 FIX) ----------
+  /**
+   * Rebuild the top-6 row putting saved interests first. This is the user-confirmed
+   * design that build-time SSR cannot satisfy (we don't know per-user interests).
+   * Preserves the active tag highlight.
+   */
+  function refreshTopRow() {
+    const row = document.getElementById('itp-chips-row');
+    if (!row) return;
+    const interests = getInterests();
+    const counts = getTagCounts();
+    const top = computeTopTags(interests, counts, TOP_N);
+    const interestsSet = new Set(interests);
+    const active = state.activeTag;
+
+    const allChip = `<button class="itp-chip itp-chip-all${active === 'all' ? ' active' : ''}" data-tag="all" type="button">
+      <span class="itp-chip-label">전체</span>
+    </button>`;
+
+    const chips = top.map((tag) => {
+      const isActive = active === tag;
+      const isSaved = interestsSet.has(tag);
+      const star = isSaved ? '★' : '☆';
+      const safeTag = escapeHtml(tag);
+      return `<span class="itp-chip-wrap">
+        <button class="itp-chip${isActive ? ' active' : ''}" data-tag="${safeTag}" type="button">
+          <span class="itp-chip-label">${safeTag}</span>
+          <span class="itp-chip-count">${counts[tag] ?? 0}</span>
+        </button>
+        <button class="itp-chip-star${isSaved ? ' on' : ''}" type="button" data-star data-tag="${safeTag}" aria-label="${safeTag} 관심사 토글" aria-pressed="${isSaved}" title="${isSaved ? '관심사에서 제거' : '관심사로 저장'}">${star}</button>
+      </span>`;
+    }).join('');
+
+    row.innerHTML = allChip + chips;
+  }
+
+  // ---------- UI: stars + interest pills (expanded panel) ----------
   function refreshInterestsUI() {
     const interests = getInterests();
     const interestsSet = new Set(interests);
 
-    // Star state on every chip (top row + expanded list)
+    // Star state on every chip across the panel (top row stars are also rebuilt by refreshTopRow).
     document.querySelectorAll<HTMLElement>('[data-star]').forEach((star) => {
       const tag = star.dataset.tag || '';
       const on = interestsSet.has(tag);
@@ -540,7 +646,6 @@ const TOP_N = 6;
           : '⭐ 관심사 & 태그';
     }
 
-    // Interests count + clear button
     const countEl = document.getElementById('itp-interests-count');
     if (countEl) countEl.textContent = `(${interests.length})`;
     const clearBtn = document.getElementById('itp-clear');
@@ -548,7 +653,6 @@ const TOP_N = 6;
     const hint = document.getElementById('itp-interests-hint');
     if (hint) (hint as HTMLElement).hidden = interests.length > 0;
 
-    // Render saved interests as removable pills
     const row = document.getElementById('itp-interests-row');
     if (row) {
       if (interests.length === 0) {
@@ -578,12 +682,11 @@ const TOP_N = 6;
 
   // ---------- Active tag chip styling ----------
   function setActiveTagChip(tag: string) {
-    activeTag = tag;
+    state.activeTag = tag;
     document.querySelectorAll<HTMLElement>('.itp-chip').forEach((chip) => {
       chip.classList.toggle('active', chip.dataset.tag === tag);
     });
 
-    // Update URL ?tag=
     const url = new URL(window.location.href);
     if (tag === 'all') {
       url.searchParams.delete('tag');
@@ -600,67 +703,15 @@ const TOP_N = 6;
 
   // ---------- Initialization ----------
   function initInterestTagPanel() {
+    // Always refresh the top row + UI on every page-load (View Transitions navigation
+    // re-runs astro:page-load even though listeners persist).
+    refreshTopRow();
     refreshInterestsUI();
+    applyInterestHighlights();
+    pinInterestMatchesInList();
+    refreshMatchBadgeFromFullDataset();
 
-    // Chip click delegation for both top row and full list
-    document.querySelectorAll<HTMLElement>('.itp-chip').forEach((chip) => {
-      chip.addEventListener('click', (ev) => {
-        const target = ev.target as HTMLElement;
-        // Star click is handled separately
-        if (target.closest('[data-star]')) return;
-        const tag = chip.dataset.tag || 'all';
-        applyTagFilter(tag);
-      });
-    });
-
-    // Star click for interest toggle
-    document.querySelectorAll<HTMLElement>('[data-star]').forEach((star) => {
-      star.addEventListener('click', (ev) => {
-        ev.stopPropagation();
-        ev.preventDefault();
-        const tag = star.dataset.tag || '';
-        if (tag) toggleInterest(tag);
-      });
-    });
-
-    // Clear all interests
-    document.getElementById('itp-clear')?.addEventListener('click', clearInterests);
-
-    // Remove individual interest from pills row
-    const row = document.getElementById('itp-interests-row');
-    row?.addEventListener('click', (ev) => {
-      const target = (ev.target as HTMLElement).closest('[data-remove-interest]') as HTMLElement | null;
-      if (!target) return;
-      const tag = target.dataset.tag || '';
-      if (tag) toggleInterest(tag);
-    });
-
-    // Toggle expanded panel
-    const toggle = document.getElementById('itp-toggle');
-    const expanded = document.getElementById('itp-expanded');
-    toggle?.addEventListener('click', () => {
-      if (!expanded || !toggle) return;
-      const wasHidden = expanded.hidden;
-      expanded.hidden = !wasHidden;
-      toggle.setAttribute('aria-expanded', String(wasHidden));
-      toggle.textContent = wasHidden ? '접기 ▲' : '모든 태그 보기 ▼';
-    });
-
-    // Listen for source filter changes
-    document.addEventListener('source-filter-changed', (() => {
-      // Source change can affect the filtered view (cross-page) AND search counts.
-      renderFilteredView();
-    }) as EventListener);
-
-    // Listen for search changes
-    document.addEventListener('article-search-changed', ((e: CustomEvent<{ query: string; origin: string; results: ClientArticle[] }>) => {
-      const { query, results } = e.detail;
-      activeSearchQuery = query;
-      activeSearchResults = query ? results : null;
-      renderFilteredView();
-    }) as EventListener);
-
-    // Apply initial state from URL (?tag=)
+    // Apply initial state from URL (?tag=) — must run after refreshTopRow so the chip exists.
     const tagParam = new URLSearchParams(window.location.search).get('tag');
     const validTags = new Set<string>();
     document.querySelectorAll<HTMLElement>('.itp-chip').forEach((c) => {
@@ -669,14 +720,79 @@ const TOP_N = 6;
     const initialTag = tagParam && validTags.has(tagParam) ? tagParam : 'all';
     setActiveTagChip(initialTag);
 
-    // Apply highlights to SSR cards on initial load
-    applyInterestHighlights();
-    pinInterestMatchesInList();
-
-    // If URL had a tag or origin, render the filtered view
-    if (initialTag !== 'all' || getActiveOrigin() !== 'all') {
+    // If URL had a tag or origin or active search, render the filtered view
+    if (initialTag !== 'all' || getActiveOrigin() !== 'all' || state.activeSearchResults !== null) {
       renderFilteredView();
     }
+
+    // Bind document/event delegation listeners ONCE, never re-bind on subsequent page loads.
+    if (state.listenersBound) return;
+    state.listenersBound = true;
+
+    // ----- Delegated click handler covers chips, stars, clear, remove-pill, toggle.
+    // Using event delegation means newly-rendered top-row chips and re-rendered pills
+    // automatically work without re-binding.
+    document.addEventListener('click', (ev) => {
+      const target = ev.target as HTMLElement;
+      if (!target) return;
+
+      // Star toggle (works for both top row and expanded panel; sibling button so no nesting issues)
+      const star = target.closest<HTMLElement>('[data-star]');
+      if (star) {
+        ev.preventDefault();
+        const tag = star.dataset.tag || '';
+        if (tag) toggleInterest(tag);
+        return;
+      }
+
+      // Remove-interest pill
+      const removePill = target.closest<HTMLElement>('[data-remove-interest]');
+      if (removePill) {
+        ev.preventDefault();
+        const tag = removePill.dataset.tag || '';
+        if (tag) toggleInterest(tag);
+        return;
+      }
+
+      // Clear all interests
+      if (target.closest('#itp-clear')) {
+        ev.preventDefault();
+        clearInterests();
+        return;
+      }
+
+      // Expand/collapse toggle
+      const toggle = target.closest<HTMLElement>('#itp-toggle');
+      if (toggle) {
+        const expanded = document.getElementById('itp-expanded');
+        if (!expanded) return;
+        const wasHidden = expanded.hidden;
+        expanded.hidden = !wasHidden;
+        toggle.setAttribute('aria-expanded', String(wasHidden));
+        toggle.textContent = wasHidden ? '접기 ▲' : '모든 태그 보기 ▼';
+        return;
+      }
+
+      // Tag chip body
+      const chip = target.closest<HTMLElement>('.itp-chip');
+      if (chip && chip.closest('.interest-tag-panel')) {
+        const tag = chip.dataset.tag || 'all';
+        applyTagFilter(tag);
+      }
+    });
+
+    // Source filter changes — re-render filtered view (origin is read live via getActiveOrigin()).
+    document.addEventListener('source-filter-changed', () => {
+      renderFilteredView();
+    });
+
+    // Article search — store result and re-render.
+    document.addEventListener('article-search-changed', ((e: CustomEvent<{ query: string; origin: string; results: ClientArticle[] }>) => {
+      const { query, results } = e.detail;
+      state.activeSearchQuery = query;
+      state.activeSearchResults = query ? results : null;
+      renderFilteredView();
+    }) as EventListener);
   }
 
   document.addEventListener('astro:page-load', initInterestTagPanel);
@@ -746,37 +862,64 @@ const TOP_N = 6;
     display: flex;
     flex-wrap: wrap;
     gap: var(--space-xs);
+    align-items: center;
+  }
+
+  /* A chip-wrap groups the chip body button + the star button as siblings.
+     This keeps both buttons separately focusable (keyboard a11y) and avoids
+     the invalid "button inside button" markup that the previous version had. */
+  .itp-chip-wrap {
+    display: inline-flex;
+    align-items: stretch;
+    border-radius: 999px;
+    overflow: hidden;
+    border: 1px solid var(--color-border);
+    background: var(--color-bg);
+    transition: border-color 0.15s;
+  }
+  .itp-chip-wrap:hover {
+    border-color: var(--color-primary);
+  }
+  .itp-chip-wrap:focus-within {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
   }
 
   .itp-chip {
     display: inline-flex;
     align-items: center;
     gap: 4px;
-    padding: 3px var(--space-sm) 3px 4px;
-    border-radius: 999px;
-    background: var(--color-bg);
+    padding: 3px var(--space-sm);
+    border-radius: 0;
+    background: transparent;
     color: var(--color-text-muted);
-    border: 1px solid var(--color-border);
+    border: none;
     cursor: pointer;
     font-family: inherit;
     font-size: 0.78rem;
     line-height: 1.2;
-    transition: background 0.15s, color 0.15s, border-color 0.15s;
+    transition: background 0.15s, color 0.15s;
+  }
+  /* Standalone chips (the "전체" chip is not wrapped) keep their own border/radius. */
+  .itp-chip-all {
+    border: 1px solid var(--color-border);
+    border-radius: 999px;
+    padding: 3px var(--space-sm);
+    background: var(--color-bg);
   }
   .itp-chip:hover {
-    border-color: var(--color-primary);
     color: var(--color-text);
   }
-  .itp-chip.active {
+  .itp-chip.active,
+  .itp-chip-all.active {
     background: var(--color-primary);
     color: white;
+  }
+  .itp-chip-wrap:has(.itp-chip.active) {
     border-color: var(--color-primary);
   }
   .itp-chip.active .itp-chip-count {
     color: rgba(255, 255, 255, 0.85);
-  }
-  .itp-chip-all {
-    padding-left: var(--space-sm);
   }
   .itp-chip-label {
     font-weight: 500;
@@ -786,32 +929,41 @@ const TOP_N = 6;
     color: var(--color-text-muted);
     font-variant-numeric: tabular-nums;
   }
+
+  /* Star button — sibling of chip body inside chip-wrap.
+     Real <button>, fully keyboard-accessible. */
   .itp-chip-star {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    width: 18px;
-    height: 18px;
-    border-radius: 50%;
+    min-width: 22px;
+    padding: 0 6px;
     background: transparent;
     color: var(--color-text-muted);
+    border: none;
+    border-left: 1px solid var(--color-border);
     cursor: pointer;
-    user-select: none;
-    transition: background 0.15s, color 0.15s, transform 0.15s;
+    font-family: inherit;
     font-size: 0.85rem;
+    user-select: none;
+    transition: background 0.15s, color 0.15s;
   }
   .itp-chip-star:hover {
     background: rgba(252, 185, 36, 0.2);
     color: var(--color-accent);
-    transform: scale(1.15);
+  }
+  .itp-chip-star:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: -2px;
   }
   .itp-chip-star.on {
     color: var(--color-accent);
   }
-  .itp-chip.active .itp-chip-star {
+  .itp-chip-wrap:has(.itp-chip.active) .itp-chip-star {
     color: white;
+    border-left-color: rgba(255, 255, 255, 0.3);
   }
-  .itp-chip.active .itp-chip-star.on {
+  .itp-chip-wrap:has(.itp-chip.active) .itp-chip-star.on {
     color: var(--color-accent);
   }
 
@@ -953,7 +1105,6 @@ const TOP_N = 6;
     box-shadow: 0 1px 4px rgba(0, 0, 0, 0.12);
     pointer-events: none;
   }
-  /* Avoid the badge overlapping the thumbnail area in cards with images */
   .article-card.interest-match .article-thumbnail {
     position: relative;
   }

--- a/src/components/SourceFilter.astro
+++ b/src/components/SourceFilter.astro
@@ -65,16 +65,24 @@ function initSourceFilter() {
   // Server-side counts (passed as props) reflect the total across all pages.
   // Do NOT recalculate from rendered cards — that only counts the current page.
 
+  // Per-button click listeners: bind exactly once per element.
+  // View Transitions persist DOM and may re-fire astro:page-load on the same buttons.
   buttons.forEach(btn => {
+    if (btn.dataset.sfBound === 'true') return;
+    btn.dataset.sfBound = 'true';
     btn.addEventListener('click', () => {
       filterByOrigin(btn.dataset.origin || 'all');
     });
   });
 
-  // Listen for dynamic count updates from ArticleSearch / InterestTagPanel.
-  document.addEventListener('source-counts-update', ((e: CustomEvent) => {
-    updateCounts(e.detail || {});
-  }) as EventListener);
+  // Document-level listener: bind exactly once per page.
+  const w = window as any;
+  if (!w.__sourceFilterDocBound) {
+    w.__sourceFilterDocBound = true;
+    document.addEventListener('source-counts-update', ((e: CustomEvent) => {
+      updateCounts(e.detail || {});
+    }) as EventListener);
+  }
 
   const originParam = new URLSearchParams(window.location.search).get('origin');
   if (originParam && validOrigins.has(originParam)) {

--- a/src/lib/article-search.ts
+++ b/src/lib/article-search.ts
@@ -103,3 +103,36 @@ export function pinInterestMatches<T extends SearchableArticle>(
   }
   return [...matched, ...unmatched];
 }
+
+/**
+ * Compute the filtered article pool given the active search query, origin scope,
+ * and tag filter. The per-origin breakdown is computed BEFORE applying the origin
+ * filter so that SourceFilter can show truthful per-tab counts (e.g. "Submitted: 3,
+ * RSS: 12") that reflect the active search/tag, not the global SSR totals.
+ *
+ * This mirrors the in-component logic in InterestTagPanel.astro and is the single
+ * source of truth for the filter pipeline contract.
+ */
+export function getFilteredPool<T extends SearchableArticle>(
+  articles: readonly T[],
+  query: string,
+  origin: 'all' | 'curated' | 'submitted' | 'feed',
+  tag: string,
+): {
+  all: T[];
+  perOrigin: { submitted: number; feed: number; curated: number };
+} {
+  const trimmed = query.trim().toLowerCase();
+  let pool: T[] = articles.slice();
+  if (trimmed) pool = pool.filter((a) => a.title.toLowerCase().includes(trimmed));
+  if (tag !== 'all') pool = pool.filter((a) => a.tags.includes(tag));
+
+  const perOrigin = {
+    submitted: pool.filter((a) => a.articleOrigin === 'submitted').length,
+    feed: pool.filter((a) => a.articleOrigin === 'feed').length,
+    curated: pool.filter((a) => a.articleOrigin === 'curated').length,
+  };
+
+  const all = origin === 'all' ? pool : pool.filter((a) => a.articleOrigin === origin);
+  return { all, perOrigin };
+}

--- a/tests/article-search.test.ts
+++ b/tests/article-search.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  getFilteredPool,
   getInterestMatches,
   getTopTags,
   pinInterestMatches,
@@ -139,5 +140,82 @@ describe('pinInterestMatches', () => {
     const snapshot = sample.slice();
     pinInterestMatches(sample, ['javascript']);
     expect(sample).toEqual(snapshot);
+  });
+});
+
+/**
+ * Integration-style tests for the full filter pipeline (search ∩ origin ∩ tag).
+ * Cover the combined contract that SourceFilter / ArticleSearch / InterestTagPanel
+ * all depend on so that future refactors can't silently change semantics.
+ */
+describe('getFilteredPool', () => {
+  const corpus: SearchableArticle[] = [
+    { _id: 'c1', title: 'Hello World', tags: ['javascript', 'web'], articleOrigin: 'curated' },
+    { _id: 'c2', title: 'Editor Pick', tags: ['ai'], articleOrigin: 'curated' },
+    { _id: 's1', title: 'Submitted Hello', tags: ['javascript'], articleOrigin: 'submitted' },
+    { _id: 's2', title: 'TypeScript Tips', tags: ['typescript', 'javascript'], articleOrigin: 'submitted' },
+    { _id: 's3', title: 'Rust Async Basics', tags: ['rust'], articleOrigin: 'submitted' },
+    { _id: 'f1', title: 'Hello Astro', tags: ['astro', 'javascript'], articleOrigin: 'feed' },
+    { _id: 'f2', title: 'AI Models', tags: ['ai'], articleOrigin: 'feed' },
+    { _id: 'f3', title: 'Hello Rust', tags: ['rust'], articleOrigin: 'feed' },
+  ];
+
+  it('no filters: returns the full corpus and full per-origin breakdown', () => {
+    const out = getFilteredPool(corpus, '', 'all', 'all');
+    expect(out.all).toHaveLength(8);
+    expect(out.perOrigin).toEqual({ curated: 2, submitted: 3, feed: 3 });
+  });
+
+  it('search only: per-origin reflects search results across ALL origins', () => {
+    const out = getFilteredPool(corpus, 'hello', 'all', 'all');
+    expect(out.all.map((a) => a._id).sort()).toEqual(['c1', 'f1', 'f3', 's1']);
+    expect(out.perOrigin).toEqual({ curated: 1, submitted: 1, feed: 2 });
+  });
+
+  it('search + tag: per-origin counts reflect intersection (not search alone)', () => {
+    const out = getFilteredPool(corpus, 'hello', 'all', 'javascript');
+    expect(out.all.map((a) => a._id).sort()).toEqual(['c1', 'f1', 's1']);
+    expect(out.perOrigin).toEqual({ curated: 1, submitted: 1, feed: 1 });
+  });
+
+  it('search + tag + origin: applies origin filter LAST', () => {
+    const out = getFilteredPool(corpus, 'hello', 'submitted', 'javascript');
+    expect(out.all.map((a) => a._id)).toEqual(['s1']);
+    expect(out.perOrigin).toEqual({ curated: 1, submitted: 1, feed: 1 });
+  });
+
+  it('tag only (no search): per-origin reflects tag pool', () => {
+    const out = getFilteredPool(corpus, '', 'all', 'rust');
+    expect(out.all.map((a) => a._id).sort()).toEqual(['f3', 's3']);
+    expect(out.perOrigin).toEqual({ curated: 0, submitted: 1, feed: 1 });
+  });
+
+  it('tag + origin only (no search): origin scoping works without search', () => {
+    const out = getFilteredPool(corpus, '', 'feed', 'rust');
+    expect(out.all.map((a) => a._id)).toEqual(['f3']);
+    expect(out.perOrigin).toEqual({ curated: 0, submitted: 1, feed: 1 });
+  });
+
+  it('origin only: per-origin still computed from full pool', () => {
+    const out = getFilteredPool(corpus, '', 'submitted', 'all');
+    expect(out.all.map((a) => a._id).sort()).toEqual(['s1', 's2', 's3']);
+    expect(out.perOrigin).toEqual({ curated: 2, submitted: 3, feed: 3 });
+  });
+
+  it('search is case-insensitive and trims whitespace', () => {
+    const out = getFilteredPool(corpus, '  HELLO  ', 'all', 'all');
+    expect(out.all.map((a) => a._id).sort()).toEqual(['c1', 'f1', 'f3', 's1']);
+  });
+
+  it('no matches: returns empty pool with zero per-origin counts', () => {
+    const out = getFilteredPool(corpus, 'xyzpdq-no-match', 'all', 'all');
+    expect(out.all).toEqual([]);
+    expect(out.perOrigin).toEqual({ curated: 0, submitted: 0, feed: 0 });
+  });
+
+  it('does not mutate the input array', () => {
+    const snapshot = corpus.slice();
+    getFilteredPool(corpus, 'hello', 'submitted', 'javascript');
+    expect(corpus).toEqual(snapshot);
   });
 });


### PR DESCRIPTION
## Summary

Oracle skeptical review of PR #119 returned **NOT VERIFIED** with 5 blockers. This PR fixes all of them.

| # | Blocker | Fix |
|---|---------|-----|
| 1 | Top-6 row didn't actually prioritize saved interests (built at SSG time, can't see localStorage) | Embed `tagCounts` as `#itp-tag-counts` JSON; `refreshTopRow()` rebuilds the row at runtime via `computeTopTags(interests, counts, 6)` |
| 2 | Source counts ignored tag filter; only updated when search active | New `getFilteredPool()` computes per-origin breakdown over `(search ∩ tag)` and dispatches `source-counts-update` whenever any filter is active |
| 3 | Interest match badge counted current-page SSR cards only (~20), not full ~299 dataset → matches on other pages looked invisible | `refreshMatchBadgeFromFullDataset()` walks the full `getAllArticles()` |
| 4 | Star was a `<span role=\"button\">` nested inside `<button>` — invalid HTML, broken keyboard | Stars are now real `<button>` siblings of the chip body inside an `itp-chip-wrap` flex container; both independently keyboard-focusable |
| 5 | `astro:page-load` re-fired listener bindings each navigation → handler stacking under View Transitions | `state.listenersBound` (ITP), `__articleSearchState.docListenersBound` + `inputBoundOn` (ArticleSearch), `dataset.sfBound` + `window.__sourceFilterDocBound` (SourceFilter) |

## Tests

- Extracted `getFilteredPool()` to `src/lib/article-search.ts`
- **+10 integration tests** for the `search ∩ origin ∩ tag` pipeline (Oracle Minor #7 gap)
- **254 tests pass** (was 244)

## Verification

```
✅ bun run validate              (299 content files valid)
✅ bun run validate:docs         (51 docs valid)
✅ bun run validate:docs --check-coverage
✅ bun run build                 (625 pages, 7.83s)
✅ bun run test                  (254 tests, 16 files)
```

Built HTML inspection:
- 378 `itp-chip-wrap` elements (correct sibling-button structure)
- 378 `itp-chip-star` real `<button>` elements
- 1 `#itp-tag-counts` JSON payload (~3KB) for runtime top-row personalization
- 0 `role=\"button\"` (no nested-button anti-pattern remains)

## Docs updated

- `docs/features/interest-tag-panel.md` — corrected description of top-row personalization, priority order, badge behavior, sibling-button accessibility
- `docs/features/article-search.md` — clarified single-source-of-truth scope

## User impact

The user's original complaint was *\"관심사 기능이 동작하는지 모르겠어. 내가 확인했을 때는 아무런 차이가 없어.\"* PR #119 attempted to fix it with a stronger visual highlight; this PR finishes the job:
- The header badge now shows the **honest total** of matches across all 299 articles, not just visible 20
- Saved interests **actually appear** in the top row, not just in the expanded panel
- Tag-only and search-only filters now show truthful per-tab counts so you can see exactly what each SourceFilter tab would yield