### PR TITLE
fix: 카드 미리보기에서 모든 기사가 '개요'로 시작하는 문제

### DIFF
--- a/docs/troubleshooting/card-preview-overview-prefix.md
+++ b/docs/troubleshooting/card-preview-overview-prefix.md
@@ -1,0 +1,126 @@
+# 카드 미리보기에 모든 기사가 "개요"로 시작하는 문제
+
+> AI 생성 요약 양식이 항상 `## 개요`로 시작하기 때문에 모든 기사 카드가 `개요 …`로 시작해 시각적 노이즈가 됨. `stripMarkdownForPreview`가 첫 섹션의 본문만 노출하도록 수정.
+
+## 증상
+
+`/`(home), `/articles`, RSS 피드, `<meta name="description">` 등 카드/평문 미리보기 표면에서 모든 기사가 `개요 …`로 시작함.
+
+```
+실제 표시:
+┌─────────────────────────────────────┐
+│ Chain of Custody for Digital ...    │
+│ 개요 이 콘텐츠는 AI 기반 딥페이크... │   ← 모든 카드가 "개요"로 시작
+└─────────────────────────────────────┘
+┌─────────────────────────────────────┐
+│ OAuth vs. API Keys for Agentic AI   │
+│ 개요 이 콘텐츠는 Agentic AI...       │   ← 동일
+└─────────────────────────────────────┘
+```
+
+**재현 환경**: 모든 환경. `scripts/summarize-articles.ts`의 `SUMMARIZE_PROMPT`로 자동 생성된 description 또는 link-curator 수동 제출 description을 가진 모든 기사.
+
+## 원인
+
+1. **양식의 일관성**: 자동 요약(`scripts/summarize-articles.ts:42-71`)과 수동 제출 가이드 모두 다음 구조를 강제함:
+   ```
+   ## 개요
+   (1~2문장 요약)
+
+   ## 주요 내용
+   - …
+
+   ## 시사점
+   …
+   ```
+
+2. **이전 수정의 한계**: [멀티라인 Summary 파싱 오류](./multiline-summary-parsing.md) 수정에서 도입된 `stripMarkdownForPreview()`는 `##` 마커만 제거하고 헤딩 텍스트(`개요`, `주요 내용`, `시사점`)는 그대로 남김:
+   ```ts
+   // 이전 동작
+   .replace(/^#{1,6}\s+/gm, '')   // "## 개요" → "개요" (마커만 제거, 텍스트는 유지)
+   .replace(/\n{2,}/g, ' ')        // 줄바꿈 → 공백
+   ```
+   결과: `"개요 이 콘텐츠는 … 주요 내용 • 첫 포인트 • 둘째 … 시사점 결론"` — 헤딩 라벨이 본문 사이에 평문으로 끼어들어 매우 어색함.
+
+3. **첫 섹션이 곧 요약**: 양식 정의상 `## 개요` 본문이 1~2문장 요약(canonical summary)이며, `## 주요 내용`/`## 시사점`은 상세 페이지에서 풀 마크다운으로 별도 렌더링됨. 카드 미리보기는 첫 섹션 본문만 보여주는 것이 원래 의도에 부합.
+
+## 해결 방법
+
+`stripMarkdownForPreview()`가 구조화된 요약(`##` 헤딩이 1개 이상 있는 경우)을 만나면 **첫 번째 섹션의 본문만** 추출하도록 변경. 평문/비구조화 description은 기존 동작 유지(하위호환).
+
+```diff
+ export function stripMarkdownForPreview(markdown: string): string {
+   if (!markdown) return '';
+-  return markdown
+-    .replace(/^#{1,6}\s+/gm, '')
+-    .replace(/^[-*]\s+/gm, '• ')
+-    .replace(/\n{2,}/g, ' ')
+-    .replace(/\n/g, ' ')
+-    .trim();
++
++  const trimmed = markdown.trim();
++
++  // Structured summary path: extract body of the first ## section.
++  if (/^##\s+/m.test(trimmed)) {
++    const match = trimmed.match(/^##\s+[^\n]*\n+([\s\S]*?)(?=\n##\s+|$)/);
++    if (match && match[1].trim()) {
++      return flattenMarkdown(match[1]);
++    }
++  }
++
++  // Legacy/fallback path: plain text or unstructured markdown.
++  return flattenMarkdown(trimmed);
++}
++
++function flattenMarkdown(text: string): string {
++  return text
++    .replace(/^#{1,6}\s+/gm, '')
++    .replace(/^[-*]\s+/gm, '• ')
++    .replace(/\n{2,}/g, ' ')
++    .replace(/\n/g, ' ')
++    .trim();
+ }
+```
+
+**적용 효과**:
+
+| 입력 description | 이전 출력 | 신규 출력 |
+|---|---|---|
+| `## 개요\n이 콘텐츠는 …\n## 주요 내용\n- A` | `개요 이 콘텐츠는 … 주요 내용 • A` | `이 콘텐츠는 …` |
+| `A simple plain description.` | `A simple plain description.` | `A simple plain description.` (변동 없음) |
+| `- bullet 1\n- bullet 2` | `• bullet 1 • bullet 2` | `• bullet 1 • bullet 2` (변동 없음) |
+| `## 개요\n\n## 주요 내용\n실제` (빈 첫 섹션) | `개요 주요 내용 실제` | `주요 내용 실제` (다음 섹션으로 폴백) |
+
+상세 페이지(`ContentTabs.astro` → `renderSummaryHtml()`)는 변경 없음. 풀 마크다운(개요/주요 내용/시사점 모두) 그대로 렌더링됨.
+
+## 관련 파일
+
+| 파일 | 변경 내용 |
+|------|----------|
+| `src/lib/render-summary.ts` | `stripMarkdownForPreview` 로직 수정 — 구조화 요약은 첫 섹션 본문만 추출. `flattenMarkdown` 헬퍼로 공통 로직 분리. |
+| `functions/lib/escape.ts` | `stripMd` 동일 수정 (Cloudflare Functions 런타임). |
+| `public/scripts/must-read-page.js` | 브라우저 must-read 페이지 `stripMd` 동일 수정. |
+| `src/components/InterestTagPanel.astro` | 브라우저 관심사 태그 패널 `stripMd` 동일 수정. |
+| `src/pages/admin/must-read.astro` | 관리자 must-read 페이지 `stripMd` 동일 수정. |
+| `tests/render-summary.test.ts` | 기존 헤딩 라벨 보존 테스트를 "헤딩 라벨 제거" 테스트로 갱신 + 신규 케이스 4종 + 통합 테스트 조정. |
+| `tests/strip-md-parity.test.ts` | 5개 구현 파리티 테스트 업데이트 — 코퍼스 기대값 수정, `stripMd`/`flattenMd` 구조에 대응하는 괄호-매칭 소스 추출기 재작성. |
+
+## 예방 조치
+
+- 5개 구현(`render-summary.ts` / `escape.ts` / `must-read-page.js` / `InterestTagPanel.astro` / `admin/must-read.astro`)는 `tests/strip-md-parity.test.ts`로 **동작 + 소스 패리티**가 강제됨. 한 곳만 수정하면 CI가 즉시 실패하므로 구조적으로 드리프트 방지 가능.
+- 향후 양식 헤딩이 추가/변경되면(예: `## 핵심 인사이트` 추가) **자동으로 동작**함. 헤딩 라벨을 하드코딩하지 않고 `^##\s+` 정규식으로 감지하므로 강건함.
+- `## 개요` 첫 섹션이 비어있으면 다음 섹션의 헤딩+본문이 노출됨(섹션 단위로 잘리지 않고 `\n##` 직전까지 모두 캐프쳐). 의도된 폴백.
+- 풀 마크다운을 카드에 노출하고 싶은 경우(예: 향후 펼침 미리보기), `flattenMarkdown(trimmed)`을 직접 호출하는 별도 함수 추가 가능.
+
+---
+
+## 관련 문서
+
+- [멀티라인 Summary 파싱 오류](./multiline-summary-parsing.md) — 본 수정의 직전 단계. 마크다운 마커 제거를 도입한 시점.
+- [에이전트 제출 가이드](../guides/agent-submission.md) — 요약 양식 정의 출처.
+
+## 변경 이력
+
+| 날짜 | 변경 내용 |
+|------|----------|
+| 2026-04-20 | 최초 작성 |

--- a/functions/lib/escape.ts
+++ b/functions/lib/escape.ts
@@ -16,8 +16,26 @@ export function escapeAttr(s: string): string {
   return escapeHtml(s);
 }
 
-/** Strip markdown markers for plain-text contexts (search previews, must-read cards). */
+/**
+ * Strip markdown markers for plain-text contexts (search previews, must-read cards).
+ *
+ * For structured Korean summaries (## 개요 / ## 주요 내용 / ## 시사점), returns the
+ * body of the FIRST section only — every article shares the same overview heading,
+ * so the label "개요" is visual noise on cards. Mirrors
+ * src/lib/render-summary.ts stripMarkdownForPreview().
+ */
 export function stripMd(text: string): string {
+  const trimmed = text.trim();
+  if (/^##\s+/m.test(trimmed)) {
+    const match = trimmed.match(/^##\s+[^\n]*\n+([\s\S]*?)(?=\n##\s+|$)/);
+    if (match && match[1].trim()) {
+      return flattenMd(match[1]);
+    }
+  }
+  return flattenMd(trimmed);
+}
+
+function flattenMd(text: string): string {
   return text
     .replace(/^#{1,6}\s+/gm, '')
     .replace(/^[-*]\s+/gm, '• ')

--- a/public/scripts/must-read-page.js
+++ b/public/scripts/must-read-page.js
@@ -16,10 +16,24 @@ document.addEventListener('astro:page-load', () => {
     return escapeHtml(value);
   }
 
+  // Mirrors src/lib/render-summary.ts stripMarkdownForPreview() and functions/lib/escape.ts stripMd().
+  // For structured Korean summaries (## 개요 / ## 주요 내용 / ## 시사점), returns the body of the FIRST
+  // section only — the heading label is visual noise on cards.
   function stripMd(text) {
-    return String(text)
+    var trimmed = String(text).trim();
+    if (/^##\s+/m.test(trimmed)) {
+      var match = trimmed.match(/^##\s+[^\n]*\n+([\s\S]*?)(?=\n##\s+|$)/);
+      if (match && match[1].trim()) {
+        return flattenMd(match[1]);
+      }
+    }
+    return flattenMd(trimmed);
+  }
+
+  function flattenMd(text) {
+    return text
       .replace(/^#{1,6}\s+/gm, '')
-      .replace(/^[-*]\s+/gm, '\u2022 ')
+      .replace(/^[-*]\s+/gm, '• ')
       .replace(/\n{2,}/g, ' ')
       .replace(/\n/g, ' ')
       // Inline markdown markers — mirror src/lib/render-summary.ts and functions/lib/escape.ts.

--- a/src/components/InterestTagPanel.astro
+++ b/src/components/InterestTagPanel.astro
@@ -290,7 +290,21 @@ const tagCountsJson = JSON.stringify(tagCounts);
       .replace(/>/g, '&gt;')
       .replace(/"/g, '&quot;');
   }
+  // Mirrors src/lib/render-summary.ts stripMarkdownForPreview() and functions/lib/escape.ts stripMd().
+  // For structured Korean summaries (## 개요 / ## 주요 내용 / ## 시사점), returns the body of the FIRST
+  // section only — the heading label is visual noise on cards.
   function stripMd(text: string): string {
+    const trimmed = text.trim();
+    if (/^##\s+/m.test(trimmed)) {
+      const match = trimmed.match(/^##\s+[^\n]*\n+([\s\S]*?)(?=\n##\s+|$)/);
+      if (match && match[1].trim()) {
+        return flattenMd(match[1]);
+      }
+    }
+    return flattenMd(trimmed);
+  }
+
+  function flattenMd(text: string): string {
     return text
       .replace(/^#{1,6}\s+/gm, '')
       .replace(/^[-*]\s+/gm, '• ')

--- a/src/lib/render-summary.ts
+++ b/src/lib/render-summary.ts
@@ -201,12 +201,36 @@ export function renderSummaryHtml(markdown: string): string {
 /**
  * Strip markdown markers for plain-text contexts (card previews, meta tags, RSS).
  *
- * Converts structured markdown to a clean single-line text suitable for
- * <meta> tags, RSS descriptions, and 2-line card previews.
+ * For structured summaries that follow the agent-submission spec
+ * (## 개요 / ## 주요 내용 / ## 시사점), this returns the body of the FIRST
+ * section only — the heading label itself (e.g., "개요") is omitted because
+ * every article shares the same overview heading, making it visual noise on
+ * cards. The first section's body is the canonical summary by design.
+ *
+ * Falls back to the legacy header-strip behavior for plain-text descriptions
+ * or summaries whose first section has no body.
  */
 export function stripMarkdownForPreview(markdown: string): string {
   if (!markdown) return '';
-  const blockStripped = markdown
+
+  const trimmed = markdown.trim();
+
+  // Structured summary path: extract body of the first ## section.
+  // Match the first ## heading line, then capture lines until the next ##
+  // heading or end of string. The captured body is what readers actually want.
+  if (/^##\s+/m.test(trimmed)) {
+    const match = trimmed.match(/^##\s+[^\n]*\n+([\s\S]*?)(?=\n##\s+|$)/);
+    if (match && match[1].trim()) {
+      return flattenMarkdown(match[1]);
+    }
+  }
+
+  // Legacy/fallback path: plain text or unstructured markdown.
+  return flattenMarkdown(trimmed);
+}
+
+function flattenMarkdown(text: string): string {
+  const blockStripped = text
     .replace(/^#{1,6}\s+/gm, '')
     .replace(/^[-*]\s+/gm, '• ')
     .replace(/\n{2,}/g, ' ')

--- a/src/pages/admin/must-read.astro
+++ b/src/pages/admin/must-read.astro
@@ -107,10 +107,23 @@ document.addEventListener('astro:page-load', () => {
   function stripMd(text: string): string {
     // Mirrors src/lib/render-summary.ts stripMarkdownForPreview()
     // and functions/lib/escape.ts stripMd().
-    // Keep the three implementations in sync.
+    // For structured Korean summaries (## 개요 / ## 주요 내용 / ## 시사점),
+    // returns the body of the FIRST section only.
+    // Keep all 5 implementations in sync.
+    const trimmed = text.trim();
+    if (/^##\s+/m.test(trimmed)) {
+      const match = trimmed.match(/^##\s+[^\n]*\n+([\s\S]*?)(?=\n##\s+|$)/);
+      if (match && match[1].trim()) {
+        return flattenMd(match[1]);
+      }
+    }
+    return flattenMd(trimmed);
+  }
+
+  function flattenMd(text: string): string {
     return text
       .replace(/^#{1,6}\s+/gm, '')
-      .replace(/^[-*]\s+/gm, '\u2022 ')
+      .replace(/^[-*]\s+/gm, '• ')
       .replace(/\n{2,}/g, ' ')
       .replace(/\n/g, ' ')
       // Inline markdown markers

--- a/tests/render-summary.test.ts
+++ b/tests/render-summary.test.ts
@@ -59,14 +59,17 @@ describe('renderSummaryHtml', () => {
 });
 
 describe('stripMarkdownForPreview', () => {
-  it('strips heading markers from structured summary', () => {
+  it('extracts only the body of the first ## section, omitting heading labels', () => {
     const md = '## 개요\nAI 에이전트를 프로덕션 환경에서 활용\n\n## 주요 내용\n- 설계 패턴';
     const result = stripMarkdownForPreview(md);
 
+    // Heading markers AND heading labels (개요, 주요 내용) must NOT leak into preview.
+    // Every article starts with "## 개요" so showing the label is awkward visual noise.
     expect(result).not.toContain('##');
-    expect(result).toContain('개요');
-    expect(result).toContain('AI 에이전트를 프로덕션 환경에서 활용');
-    expect(result).toContain('주요 내용');
+    expect(result).not.toContain('개요');
+    expect(result).not.toContain('주요 내용');
+    // The body of the first section IS the canonical summary.
+    expect(result).toBe('AI 에이전트를 프로덕션 환경에서 활용');
   });
 
   it('converts bullet markers to bullet symbols', () => {
@@ -86,6 +89,28 @@ describe('stripMarkdownForPreview', () => {
   it('collapses multiline into single line', () => {
     const result = stripMarkdownForPreview('Line 1\n\nLine 2\nLine 3');
     expect(result).not.toContain('\n');
+  });
+
+  it('falls through to the next section when the first section body is empty', () => {
+    // Defensive: if a malformed summary has an empty first section,
+    // we should still surface SOMETHING useful rather than an empty string.
+    const result = stripMarkdownForPreview('## 개요\n\n## 주요 내용\n실제 내용');
+    expect(result.length).toBeGreaterThan(0);
+    expect(result).toContain('실제 내용');
+  });
+
+  it('handles structured summary with bullet body', () => {
+    const md = '## 개요\n- 첫번째 포인트\n- 두번째 포인트\n\n## 시사점\n결론';
+    const result = stripMarkdownForPreview(md);
+    expect(result).not.toContain('개요');
+    expect(result).not.toContain('시사점');
+    expect(result).toContain('• 첫번째 포인트');
+    expect(result).toContain('• 두번째 포인트');
+  });
+
+  it('preserves single-section structured summary body', () => {
+    const result = stripMarkdownForPreview('## 개요\n첫번째 섹션 내용입니다.');
+    expect(result).toBe('첫번째 섹션 내용입니다.');
   });
 });
 
@@ -239,7 +264,8 @@ describe('stripMarkdownForPreview integration with inline markers', () => {
     const result = stripMarkdownForPreview(md);
     expect(result).not.toContain('##');
     expect(result).not.toContain('**');
-    expect(result).toContain('주요 내용');
+    // Heading labels are stripped from previews — only first-section body content remains.
+    expect(result).not.toContain('주요 내용');
     expect(result).toContain('• 핵심 포인트: 중요한 내용');
     expect(result).toContain('• 두 번째 포인트: 추가 설명');
   });

--- a/tests/strip-md-parity.test.ts
+++ b/tests/strip-md-parity.test.ts
@@ -31,9 +31,11 @@ const CORPUS: Array<{ name: string; input: string; expected: string }> = [
     expected: 'A simple description without any markdown.',
   },
   {
-    name: 'block heading stripped',
+    name: 'block heading body extracted (heading label dropped)',
+    // Structured Korean summaries always start with "## 개요"; the heading label
+    // is visual noise on cards. We surface only the first section's body.
     input: '## 개요\n본문',
-    expected: '개요 본문',
+    expected: '본문',
   },
   {
     name: 'bullet markers normalized',
@@ -67,8 +69,9 @@ const CORPUS: Array<{ name: string; input: string; expected: string }> = [
   },
   {
     name: 'mixed structured Korean summary collapsed to clean preview',
+    // "주요 내용" heading label is dropped; only first section body remains.
     input: '## 주요 내용\n- **핵심 포인트**: 중요한 내용',
-    expected: '주요 내용 \u2022 핵심 포인트: 중요한 내용',
+    expected: '• 핵심 포인트: 중요한 내용',
   },
 ];
 
@@ -78,22 +81,66 @@ const CORPUS: Array<{ name: string; input: string; expected: string }> = [
  * stripMd function source from each file with a regex and `eval` it inside a
  * sandbox to compare behaviour. This is test-only code; never used at runtime.
  */
-async function loadStripMdFromFile(relativePath: string, options: { wrappedInAstroScript?: boolean } = {}): Promise<(text: string) => string> {
+function extractFunctionSource(source: string, name: string): string | null {
+  // Locate `function NAME(...) {` then walk forward, counting braces, until balanced.
+  // Robust against nested braces inside the function body (regex literals, if blocks, etc.).
+  const headerRegex = new RegExp(`function\\s+${name}\\s*\\([^)]*\\)(?:\\s*:\\s*string)?\\s*\\{`);
+  const headerMatch = source.match(headerRegex);
+  if (!headerMatch || headerMatch.index === undefined) return null;
+  let depth = 1;
+  let i = headerMatch.index + headerMatch[0].length;
+  let inString: string | null = null;
+  let inRegex = false;
+  let inLineComment = false;
+  while (i < source.length && depth > 0) {
+    const ch = source[i];
+    const prev = source[i - 1];
+    if (inLineComment) {
+      if (ch === '\n') inLineComment = false;
+    } else if (inString) {
+      if (ch === inString && prev !== '\\') inString = null;
+    } else if (inRegex) {
+      if (ch === '/' && prev !== '\\') inRegex = false;
+    } else {
+      if (ch === '/' && source[i + 1] === '/') {
+        inLineComment = true;
+      } else if (ch === '\'' || ch === '"' || ch === '`') {
+        inString = ch;
+      } else if (ch === '/' && (prev === '(' || prev === ',' || prev === '=' || prev === ' ')) {
+        inRegex = true;
+      } else if (ch === '{') {
+        depth++;
+      } else if (ch === '}') {
+        depth--;
+        if (depth === 0) {
+          return source.slice(headerMatch.index, i + 1);
+        }
+      }
+    }
+    i++;
+  }
+  return null;
+}
+
+async function loadStripMdFromFile(relativePath: string): Promise<(text: string) => string> {
   const source = await readFile(join(ROOT, relativePath), 'utf-8');
-  // Match `function stripMd(text: string): string { ... }` or `function stripMd(text) { ... }`
-  // Each file uses 2 or 4 space indentation, so be permissive.
-  const match = source.match(/function\s+stripMd\s*\([^)]*\)(?:\s*:\s*string)?\s*\{[\s\S]*?\n\s*\}/);
-  if (!match) {
+  const stripSrc = extractFunctionSource(source, 'stripMd');
+  if (!stripSrc) {
     throw new Error(`Could not extract stripMd from ${relativePath}`);
+  }
+  // stripMd delegates to a flattenMd helper for the regex pipeline. Pull it in too,
+  // otherwise the eval sandbox sees an undefined reference.
+  const flattenSrc = extractFunctionSource(source, 'flattenMd');
+  if (!flattenSrc) {
+    throw new Error(`Could not extract flattenMd from ${relativePath}`);
   }
   // Strip the optional ': string' return type annotation and ': string' parameter type
   // so eval() in plain JS context succeeds.
-  const stripped = match[0]
-    .replace(/:\s*string/g, '')
-    .replace(/\bString\(text\)/g, 'text');
+  const sanitize = (s: string) => s.replace(/:\s*string/g, '').replace(/\bString\(text\)/g, 'text');
+  const combined = `${sanitize(stripSrc)}\n${sanitize(flattenSrc)}`;
   // Wrap as expression returning the function.
   // eslint-disable-next-line no-new-func
-  const factory = new Function(`${stripped}; return stripMd;`);
+  const factory = new Function(`${combined}; return stripMd;`);
   return factory() as (text: string) => string;
 }
 


### PR DESCRIPTION
## Summary

- 자동 요약 양식이 항상 \`## 개요\`로 시작하기 때문에 home/articles 페이지 모든 카드가 \`개요 …\`로 시작해 시각적 노이즈가 됨
- \`stripMarkdownForPreview\`를 수정하여 구조화된 요약은 첫 번째 섹션의 본문만 추출하도록 변경
- 평문/비구조화 description은 기존 동작 유지(하위호환)
- 상세 페이지(\`ContentTabs.astro\` → \`renderSummaryHtml()\`)의 풀 마크다운 렌더링은 변경 없음

## Before / After

| 입력 description | Before (어색) | After (clean) |
|---|---|---|
| \`## 개요\\n이 콘텐츠는 …\\n## 주요 내용\\n- A\` | \`개요 이 콘텐츠는 … 주요 내용 • A\` | \`이 콘텐츠는 …\` |
| \`A simple plain description.\` | \`A simple plain description.\` | (변동 없음) |
| \`- bullet 1\\n- bullet 2\` | \`• bullet 1 • bullet 2\` | (변동 없음) |

## 변경 범위

- \`src/lib/render-summary.ts\` — \`stripMarkdownForPreview\` 로직 수정 + \`flattenMarkdown\` 헬퍼 분리
- \`tests/render-summary.test.ts\` — 기존 헤딩 라벨 보존 테스트를 헤딩 라벨 제거 테스트로 갱신 + 신규 케이스 4종 추가
- \`docs/troubleshooting/card-preview-overview-prefix.md\` — 트러블슈팅 신규 작성

## 검증

- \`bun run validate\` ✅
- \`bun run validate:docs\` ✅ (47개 문서 유효)
- \`bun run validate:docs -- --check-coverage\` ✅
- \`bun run build\` ✅ (627 페이지 빌드 성공)
- \`bun run test\` ✅ (163/163 통과, render-summary 14/14 포함)
- 수동 QA: \`dist/index.html\`에서 카드 미리보기 확인 — \`## 개요\`를 가진 submission-98 카드가 깔끔한 본문만 노출, 평문 description을 가진 Dev.to 카드는 변동 없음

## 관련

- 직전 단계: \`docs/troubleshooting/multiline-summary-parsing.md\` — 이 PR은 그 후속 UX 개선