### PR TITLE
fix: 빈 첫 섹션 폴백 헤딩 라벨 누출 + nested bold parity 수정 (PR #121 Oracle 후속)

### DIFF
--- a/docs/troubleshooting/card-preview-empty-section-leak.md
+++ b/docs/troubleshooting/card-preview-empty-section-leak.md
@@ -1,0 +1,145 @@
+# 카드 미리보기 — 빈 첫 섹션 폴백이 헤딩 라벨 누출 + nested bold parity 깨짐
+
+> [card-preview-overview-prefix](./card-preview-overview-prefix.md) 후속 수정. Oracle 리뷰에서 발견된 두 가지 잔여 이슈 해결: (1) `## 개요` 첫 섹션이 비어있으면 전체 평탄화로 폴백되어 `주요 내용` 같은 헤딩 라벨이 카드에 다시 노출됨. (2) 5개 stripMd 구현이 평면 케이스에서만 일치하고 nested `**outer *inner* outer**`에서는 분기됨(parity 주장 부분적으로 거짓).
+
+## 증상
+
+### 이슈 1: 빈 첫 섹션 → 헤딩 라벨 노출
+
+```
+입력 description: "## 개요\n\n## 주요 내용\n실제 내용"
+이전 출력 (PR #121): "주요 내용 실제 내용"   ← "주요 내용" 헤딩 라벨 노출
+기대 출력           : "실제 내용"            ← 본문만
+```
+
+### 이슈 2: nested bold+italic parity 분기
+
+```
+입력: "**outer *inner* outer**"
+src/lib/render-summary.ts (stripMarkdownForPreview): "outer inner outer"   ← 정상
+functions/lib/escape.ts (stripMd)                  : "**outer inner outer**" ← 외곽 ** 잔존
+public/scripts/must-read-page.js (stripMd)         : "**outer inner outer**" ← 동일
+src/components/InterestTagPanel.astro (stripMd)    : "**outer inner outer**" ← 동일
+src/pages/admin/must-read.astro (stripMd)          : "**outer inner outer**" ← 동일
+```
+
+**재현 환경**: PR #121 머지 직후 모든 환경. parity 코퍼스에 nested 케이스가 없어서 CI 통과했지만 실제 동작은 분기됨.
+
+## 원인
+
+### 이슈 1: 폴백 로직이 잘못됨
+
+PR #121 코드:
+
+```ts
+if (/^##\s+/m.test(trimmed)) {
+  const match = trimmed.match(/^##\s+[^\n]*\n+([\s\S]*?)(?=\n##\s+|$)/);
+  if (match && match[1].trim()) {
+    return flattenMarkdown(match[1]);
+  }
+}
+return flattenMarkdown(trimmed);  // ← 빈 첫 섹션이면 여기로 폴백, 전체를 평탄화하면서 헤딩 라벨 누출
+```
+
+첫 섹션이 비어있으면(`## 개요\n\n## 주요 내용\n…`) `match[1].trim()`이 false → `flattenMarkdown(trimmed)` 실행 → `^##\s+` 마커는 제거되지만 `개요`/`주요 내용` 텍스트는 남음.
+
+### 이슈 2: 4개 sibling이 nested * 차단하는 regex 사용
+
+`render-summary.ts`는 `stripInlineMarkdown`에서 placeholder 패턴(`\u0000BOLD0\u0001`)으로 outer bold를 먼저 격리한 후 inner italic 처리. 4개 sibling은 단순 chained `.replace()`이므로:
+
+```ts
+.replace(/\*\*([^*\n]+?)\*\*/g, '$1')   // [^*\n]+? — 본문에 * 포함 불가 → '**outer *inner* outer**' 매칭 실패
+.replace(/(^|[^*A-Za-z0-9_])\*(?!\s)([^*\n]+?)(?<!\s)\*(?![A-Za-z0-9_])/g, '$1$2')  // 내부 *inner* 만 제거
+// 결과: '**outer inner outer**' (외곽 ** 잔존)
+```
+
+PR #121의 parity 테스트는 이 분기를 `BOLD_PATTERN_OPTIONS` 배열로 명시적 허용했지만, 실제로 같은 입력에 대한 출력이 달라지므로 "5개 구현 동작 일치"라는 contract는 거짓이었음.
+
+## 해결 방법
+
+### 1. `stripMd`/`stripMarkdownForPreview` — 섹션 단위 iteration
+
+`match()` (첫 매칭만 잡음) 대신 `split()`으로 섹션 분해 후 첫 비어있지 않은 섹션 본문 반환:
+
+```diff
+ export function stripMarkdownForPreview(markdown: string): string {
+   if (!markdown) return '';
+-  const trimmed = markdown.trim();
+-  if (/^##\s+/m.test(trimmed)) {
+-    const match = trimmed.match(/^##\s+[^\n]*\n+([\s\S]*?)(?=\n##\s+|$)/);
+-    if (match && match[1].trim()) {
+-      return flattenMarkdown(match[1]);
+-    }
+-  }
+-  return flattenMarkdown(trimmed);
++  if (/^##\s+/m.test(markdown)) {
++    const sections = markdown.split(/(?:^|\n)##\s+[^\n]*\n?/);
++    for (const section of sections) {
++      if (section.trim()) {
++        return flattenMarkdown(section);
++      }
++    }
++    // All sections empty — return empty rather than leaking heading labels.
++    return '';
++  }
++  return flattenMarkdown(markdown);
+ }
+```
+
+### 2. 4개 sibling: bold regex `[^*\n]+?` → `[^\n]+?`
+
+내부 `*` 허용으로 변경하면 lazy `+?` 덕분에 nested bold도 한 번에 매칭됨. 두 번째 inner italic regex가 캡처 그룹의 `*inner*`를 처리.
+
+```diff
+-.replace(/\*\*([^*\n]+?)\*\*/g, '$1')
++.replace(/\*\*([^\n]+?)\*\*/g, '$1')
+```
+
+검증: `'**outer *inner* outer**'`
+1. `/\*\*([^\n]+?)\*\*/g` 매칭 → outer ** 제거 → `'outer *inner* outer'`
+2. `/(^|[^*A-Za-z0-9_])\*(?!\s)([^*\n]+?)(?<!\s)\*(?![A-Za-z0-9_])/g` 매칭 → inner * 제거 → `'outer inner outer'` ✅
+
+### 3. parity 테스트 corpus +4 케이스
+
+```ts
+{ name: 'first section empty falls through to next non-empty section body', ... },
+{ name: 'nested **outer *inner* outer** bold-with-italic strips fully', ... },
+{ name: 'nested bold+italic inside structured summary first section', ... },
+{ name: 'all sections empty returns empty string', ... },
+```
+
+### 4. parity 테스트 byte-parity 단순화
+
+- `BOLD_PATTERN_OPTIONS` 제거(분기 허용 종료) — `/\*\*([^\n]+?)\*\*/g` 토큰을 `REQUIRED_TOKENS_ALL`에 추가
+- `SECTION_SPLIT_TOKEN` 신규 — `/(?:^|\n)##\s+[^\n]*\n?/`이 5개 파일 모두에 존재해야 통과
+
+## 관련 파일
+
+| 파일 | 변경 내용 |
+|------|----------|
+| `src/lib/render-summary.ts` | `stripMarkdownForPreview` 섹션 iteration으로 재작성. all-empty면 `''` 반환. |
+| `functions/lib/escape.ts` | `stripMd` 동일 변경 + bold regex `[^*\n]+?` → `[^\n]+?`. |
+| `public/scripts/must-read-page.js` | 동일. |
+| `src/components/InterestTagPanel.astro` | 동일. |
+| `src/pages/admin/must-read.astro` | 동일. |
+| `tests/render-summary.test.ts` | 빈 첫 섹션 테스트를 `toBe('실제 내용')`으로 strict화 + multi-empty iteration + all-empty 케이스 추가. |
+| `tests/strip-md-parity.test.ts` | 코퍼스 +4종(빈 섹션, nested, nested in 첫 섹션, all-empty). `BOLD_PATTERN_OPTIONS` 제거, `SECTION_SPLIT_TOKEN` 신규. |
+
+## 예방 조치
+
+- nested bold/italic 같은 edge case는 corpus에 명시적으로 추가해야 parity가 깨지지 않음. 단순 케이스만 테스트하면 분기 가능.
+- 폴백 동작은 항상 "사용자 의도 위반 가능성"을 먼저 검토. 이 케이스에서는 헤딩 라벨 노출 = 원래 사용자가 제거하고 싶었던 것이므로 폴백은 `''`이어야 함.
+- Oracle 등 외부 리뷰어에게 자기 검증 요청 시 corpus의 완전성도 함께 검토 요청.
+
+---
+
+## 관련 문서
+
+- [card-preview-overview-prefix](./card-preview-overview-prefix.md) — 본 수정의 직전 단계 (PR #121).
+- [멀티라인 Summary 파싱 오류](./multiline-summary-parsing.md) — 마크다운 마커 제거 도입.
+
+## 변경 이력
+
+| 날짜 | 변경 내용 |
+|------|----------|
+| 2026-04-20 | 최초 작성 (Oracle 리뷰 피드백 반영) |

--- a/functions/lib/escape.ts
+++ b/functions/lib/escape.ts
@@ -25,14 +25,18 @@ export function escapeAttr(s: string): string {
  * src/lib/render-summary.ts stripMarkdownForPreview().
  */
 export function stripMd(text: string): string {
-  const trimmed = text.trim();
-  if (/^##\s+/m.test(trimmed)) {
-    const match = trimmed.match(/^##\s+[^\n]*\n+([\s\S]*?)(?=\n##\s+|$)/);
-    if (match && match[1].trim()) {
-      return flattenMd(match[1]);
+  if (!text) return '';
+  // Structured summary path: split on ## boundaries, return first non-empty body.
+  if (/^##\s+/m.test(text)) {
+    const sections = text.split(/(?:^|\n)##\s+[^\n]*\n?/);
+    for (const section of sections) {
+      if (section.trim()) {
+        return flattenMd(section);
+      }
     }
+    return '';
   }
-  return flattenMd(trimmed);
+  return flattenMd(text);
 }
 
 function flattenMd(text: string): string {
@@ -44,7 +48,9 @@ function flattenMd(text: string): string {
     // Inline markdown markers — keep for plain-text consistency with src/lib/render-summary.ts.
     // Order: code first, then **bold**, then *italic* / _italic_, then [text](url).
     .replace(/`([^`\n]+)`/g, '$1')
-    .replace(/\*\*([^*\n]+?)\*\*/g, '$1')
+    // Bold uses [^\n]+? (allows internal *) so nested **outer *inner* outer** strips fully
+    // — all 5 implementations must use this form for parity.
+    .replace(/\*\*([^\n]+?)\*\*/g, '$1')
     .replace(/(^|[^*A-Za-z0-9_])\*(?!\s)([^*\n]+?)(?<!\s)\*(?![A-Za-z0-9_])/g, '$1$2')
     .replace(/(^|[^A-Za-z0-9_])_([^_\n]+?)_(?![A-Za-z0-9_])/g, '$1$2')
     .replace(/\[([^\]\n]+)\]\([^)\s]+\)/g, '$1')

--- a/public/scripts/must-read-page.js
+++ b/public/scripts/must-read-page.js
@@ -20,14 +20,19 @@ document.addEventListener('astro:page-load', () => {
   // For structured Korean summaries (## 개요 / ## 주요 내용 / ## 시사점), returns the body of the FIRST
   // section only — the heading label is visual noise on cards.
   function stripMd(text) {
-    var trimmed = String(text).trim();
-    if (/^##\s+/m.test(trimmed)) {
-      var match = trimmed.match(/^##\s+[^\n]*\n+([\s\S]*?)(?=\n##\s+|$)/);
-      if (match && match[1].trim()) {
-        return flattenMd(match[1]);
+    if (!text) return '';
+    var s = String(text);
+    // Structured summary path: split on ## boundaries, return first non-empty body.
+    if (/^##\s+/m.test(s)) {
+      var sections = s.split(/(?:^|\n)##\s+[^\n]*\n?/);
+      for (var i = 0; i < sections.length; i++) {
+        if (sections[i].trim()) {
+          return flattenMd(sections[i]);
+        }
       }
+      return '';
     }
-    return flattenMd(trimmed);
+    return flattenMd(s);
   }
 
   function flattenMd(text) {
@@ -38,7 +43,8 @@ document.addEventListener('astro:page-load', () => {
       .replace(/\n/g, ' ')
       // Inline markdown markers — mirror src/lib/render-summary.ts and functions/lib/escape.ts.
       .replace(/`([^`\n]+)`/g, '$1')
-      .replace(/\*\*([^*\n]+?)\*\*/g, '$1')
+      // Bold uses [^\n]+? (allows internal *) so nested **outer *inner* outer** strips fully.
+      .replace(/\*\*([^\n]+?)\*\*/g, '$1')
       .replace(/(^|[^*A-Za-z0-9_])\*(?!\s)([^*\n]+?)(?<!\s)\*(?![A-Za-z0-9_])/g, '$1$2')
       .replace(/(^|[^A-Za-z0-9_])_([^_\n]+?)_(?![A-Za-z0-9_])/g, '$1$2')
       .replace(/\[([^\]\n]+)\]\([^)\s]+\)/g, '$1')

--- a/src/components/InterestTagPanel.astro
+++ b/src/components/InterestTagPanel.astro
@@ -294,14 +294,18 @@ const tagCountsJson = JSON.stringify(tagCounts);
   // For structured Korean summaries (## 개요 / ## 주요 내용 / ## 시사점), returns the body of the FIRST
   // section only — the heading label is visual noise on cards.
   function stripMd(text: string): string {
-    const trimmed = text.trim();
-    if (/^##\s+/m.test(trimmed)) {
-      const match = trimmed.match(/^##\s+[^\n]*\n+([\s\S]*?)(?=\n##\s+|$)/);
-      if (match && match[1].trim()) {
-        return flattenMd(match[1]);
+    if (!text) return '';
+    // Structured summary path: split on ## boundaries, return first non-empty body.
+    if (/^##\s+/m.test(text)) {
+      const sections = text.split(/(?:^|\n)##\s+[^\n]*\n?/);
+      for (const section of sections) {
+        if (section.trim()) {
+          return flattenMd(section);
+        }
       }
+      return '';
     }
-    return flattenMd(trimmed);
+    return flattenMd(text);
   }
 
   function flattenMd(text: string): string {
@@ -311,7 +315,8 @@ const tagCountsJson = JSON.stringify(tagCounts);
       .replace(/\n{2,}/g, ' ')
       .replace(/\n/g, ' ')
       .replace(/`([^`\n]+)`/g, '$1')
-      .replace(/\*\*([^*\n]+?)\*\*/g, '$1')
+      // Bold uses [^\n]+? (allows internal *) so nested **outer *inner* outer** strips fully.
+      .replace(/\*\*([^\n]+?)\*\*/g, '$1')
       .replace(/(^|[^*A-Za-z0-9_])\*(?!\s)([^*\n]+?)(?<!\s)\*(?![A-Za-z0-9_])/g, '$1$2')
       .replace(/(^|[^A-Za-z0-9_])_([^_\n]+?)_(?![A-Za-z0-9_])/g, '$1$2')
       .replace(/\[([^\]\n]+)\]\([^)\s]+\)/g, '$1')

--- a/src/lib/render-summary.ts
+++ b/src/lib/render-summary.ts
@@ -203,30 +203,36 @@ export function renderSummaryHtml(markdown: string): string {
  *
  * For structured summaries that follow the agent-submission spec
  * (## 개요 / ## 주요 내용 / ## 시사점), this returns the body of the FIRST
- * section only — the heading label itself (e.g., "개요") is omitted because
+ * NON-EMPTY section — the heading label itself (e.g., "개요") is omitted because
  * every article shares the same overview heading, making it visual noise on
  * cards. The first section's body is the canonical summary by design.
  *
- * Falls back to the legacy header-strip behavior for plain-text descriptions
- * or summaries whose first section has no body.
+ * Iterates through ## sections to handle malformed inputs where the first
+ * section has no body (e.g., `## 개요\n\n## 주요 내용\n…`); in that case
+ * the body of the first non-empty section is returned, never the heading label.
+ * If ALL sections are empty, returns empty string rather than leaking labels.
+ *
+ * Falls back to legacy header-strip behavior for plain-text descriptions.
  */
 export function stripMarkdownForPreview(markdown: string): string {
   if (!markdown) return '';
 
-  const trimmed = markdown.trim();
-
-  // Structured summary path: extract body of the first ## section.
-  // Match the first ## heading line, then capture lines until the next ##
-  // heading or end of string. The captured body is what readers actually want.
-  if (/^##\s+/m.test(trimmed)) {
-    const match = trimmed.match(/^##\s+[^\n]*\n+([\s\S]*?)(?=\n##\s+|$)/);
-    if (match && match[1].trim()) {
-      return flattenMarkdown(match[1]);
+  // Structured summary path: split on ## boundaries, return first non-empty body.
+  // Heading labels are dropped intentionally so cards don't all start with "개요".
+  if (/^##\s+/m.test(markdown)) {
+    const sections = markdown.split(/(?:^|\n)##\s+[^\n]*\n?/);
+    for (const section of sections) {
+      if (section.trim()) {
+        return flattenMarkdown(section);
+      }
     }
+    // All sections empty — nothing useful to surface; return empty rather
+    // than leaking heading labels.
+    return '';
   }
 
   // Legacy/fallback path: plain text or unstructured markdown.
-  return flattenMarkdown(trimmed);
+  return flattenMarkdown(markdown);
 }
 
 function flattenMarkdown(text: string): string {

--- a/src/pages/admin/must-read.astro
+++ b/src/pages/admin/must-read.astro
@@ -108,16 +108,19 @@ document.addEventListener('astro:page-load', () => {
     // Mirrors src/lib/render-summary.ts stripMarkdownForPreview()
     // and functions/lib/escape.ts stripMd().
     // For structured Korean summaries (## 개요 / ## 주요 내용 / ## 시사점),
-    // returns the body of the FIRST section only.
+    // returns the body of the FIRST NON-EMPTY section. Heading labels are dropped.
     // Keep all 5 implementations in sync.
-    const trimmed = text.trim();
-    if (/^##\s+/m.test(trimmed)) {
-      const match = trimmed.match(/^##\s+[^\n]*\n+([\s\S]*?)(?=\n##\s+|$)/);
-      if (match && match[1].trim()) {
-        return flattenMd(match[1]);
+    if (!text) return '';
+    if (/^##\s+/m.test(text)) {
+      const sections = text.split(/(?:^|\n)##\s+[^\n]*\n?/);
+      for (const section of sections) {
+        if (section.trim()) {
+          return flattenMd(section);
+        }
       }
+      return '';
     }
-    return flattenMd(trimmed);
+    return flattenMd(text);
   }
 
   function flattenMd(text: string): string {
@@ -128,7 +131,8 @@ document.addEventListener('astro:page-load', () => {
       .replace(/\n/g, ' ')
       // Inline markdown markers
       .replace(/`([^`\n]+)`/g, '$1')
-      .replace(/\*\*([^*\n]+?)\*\*/g, '$1')
+      // Bold uses [^\n]+? (allows internal *) so nested **outer *inner* outer** strips fully.
+      .replace(/\*\*([^\n]+?)\*\*/g, '$1')
       .replace(/(^|[^*A-Za-z0-9_])\*(?!\s)([^*\n]+?)(?<!\s)\*(?![A-Za-z0-9_])/g, '$1$2')
       .replace(/(^|[^A-Za-z0-9_])_([^_\n]+?)_(?![A-Za-z0-9_])/g, '$1$2')
       .replace(/\[([^\]\n]+)\]\([^)\s]+\)/g, '$1')

--- a/tests/render-summary.test.ts
+++ b/tests/render-summary.test.ts
@@ -91,12 +91,23 @@ describe('stripMarkdownForPreview', () => {
     expect(result).not.toContain('\n');
   });
 
-  it('falls through to the next section when the first section body is empty', () => {
-    // Defensive: if a malformed summary has an empty first section,
-    // we should still surface SOMETHING useful rather than an empty string.
+  it('falls through to the next non-empty section when the first section body is empty', () => {
+    // Per Oracle review: must NOT leak heading labels (e.g., "주요 내용") into preview.
+    // Should return ONLY the body of the first non-empty section.
     const result = stripMarkdownForPreview('## 개요\n\n## 주요 내용\n실제 내용');
-    expect(result.length).toBeGreaterThan(0);
-    expect(result).toContain('실제 내용');
+    expect(result).toBe('실제 내용');
+    expect(result).not.toContain('개요');
+    expect(result).not.toContain('주요 내용');
+  });
+
+  it('iterates past multiple empty sections to find first non-empty body', () => {
+    const result = stripMarkdownForPreview('## 개요\n\n## 주요 내용\n\n## 시사점\n결론');
+    expect(result).toBe('결론');
+  });
+
+  it('returns empty string when ALL sections are empty (no heading-label leak)', () => {
+    const result = stripMarkdownForPreview('## 개요\n\n## 주요 내용\n\n');
+    expect(result).toBe('');
   });
 
   it('handles structured summary with bullet body', () => {

--- a/tests/strip-md-parity.test.ts
+++ b/tests/strip-md-parity.test.ts
@@ -73,6 +73,29 @@ const CORPUS: Array<{ name: string; input: string; expected: string }> = [
     input: '## 주요 내용\n- **핵심 포인트**: 중요한 내용',
     expected: '• 핵심 포인트: 중요한 내용',
   },
+  {
+    name: 'first section empty falls through to next non-empty section body',
+    // Defensive: malformed summaries with empty 개요 must still surface SOMETHING useful.
+    // The body of the next non-empty section is returned, never the heading label.
+    input: '## 개요\n\n## 주요 내용\n실제 내용',
+    expected: '실제 내용',
+  },
+  {
+    name: 'nested **outer *inner* outer** bold-with-italic strips fully',
+    // All 5 implementations must agree: both outer bold AND inner italic markers go away.
+    input: '**outer *inner* outer**',
+    expected: 'outer inner outer',
+  },
+  {
+    name: 'nested bold+italic inside structured summary first section',
+    input: '## 개요\n**핵심 *개념* 설명**: 본문',
+    expected: '핵심 개념 설명: 본문',
+  },
+  {
+    name: 'all sections empty returns empty string',
+    input: '## 개요\n\n## 주요 내용\n\n',
+    expected: '',
+  },
 ];
 
 /**
@@ -205,21 +228,18 @@ describe('stripMd source-regex byte parity (catches drift before runtime)', () =
     String.raw`/^[-*]\s+/gm`,
     String.raw`/\n{2,}/g`,
     '/`([^`\\n]+)`/g',
+    // Bold uses [^\n]+? (allows internal *) so nested **outer *inner* outer** strips fully.
+    // ALL 5 implementations now use this form — no divergence.
+    String.raw`/\*\*([^\n]+?)\*\*/g`,
     String.raw`/(^|[^*A-Za-z0-9_])\*(?!\s)([^*\n]+?)(?<!\s)\*(?![A-Za-z0-9_])/g`,
     String.raw`/(^|[^A-Za-z0-9_])_([^_\n]+?)_(?![A-Za-z0-9_])/g`,
     String.raw`/\[([^\]\n]+)\]\([^)\s]+\)/g`,
   ];
 
-  // Bold pattern intentionally diverges:
-  //   render-summary.ts uses /\*\*([^\n]+?)\*\*/g (allows internal *) for nested bold support
-  //     via two-pass placeholder strategy.
-  //   Other 4 files use /\*\*([^*\n]+?)\*\*/g (single-line strict) because they don't
-  //     run a placeholder pass; nested bold passes through to plain text via stripMarkdownForPreview.
-  // Both are accepted, but each file must use exactly one of these forms.
-  const BOLD_PATTERN_OPTIONS = [
-    String.raw`/\*\*([^\n]+?)\*\*/g`,         // render-summary.ts only
-    String.raw`/\*\*([^*\n]+?)\*\*/g`,        // simple form for the other 4 files
-  ];
+  // Section-split token — must appear in all 5 implementations to enforce the
+  // first-non-empty-section extraction logic. If a runtime forgets this, cards
+  // will start showing the "개요" heading label again.
+  const SECTION_SPLIT_TOKEN = String.raw`/(?:^|\n)##\s+[^\n]*\n?/`;
 
   const FILES = [
     'src/lib/render-summary.ts',
@@ -233,7 +253,7 @@ describe('stripMd source-regex byte parity (catches drift before runtime)', () =
     it(`${file} contains all required regex tokens (byte parity)`, async () => {
       const source = await readFile(join(ROOT, file), 'utf-8');
       const missing = REQUIRED_TOKENS_ALL.filter((token) => !source.includes(token));
-      const hasSomeBold = BOLD_PATTERN_OPTIONS.some((token) => source.includes(token));
+      const hasSectionSplit = source.includes(SECTION_SPLIT_TOKEN);
 
       const errors: string[] = [];
       if (missing.length > 0) {
@@ -242,10 +262,9 @@ describe('stripMd source-regex byte parity (catches drift before runtime)', () =
             missing.map((t) => `  - ${t}`).join('\n'),
         );
       }
-      if (!hasSomeBold) {
+      if (!hasSectionSplit) {
         errors.push(
-          `Missing a recognized bold-strip pattern. Must contain ONE of:\n` +
-            BOLD_PATTERN_OPTIONS.map((t) => `  - ${t}`).join('\n'),
+          `Missing the section-split token. Must contain:\n  - ${SECTION_SPLIT_TOKEN}`,
         );
       }
       if (errors.length > 0) {
@@ -256,7 +275,7 @@ describe('stripMd source-regex byte parity (catches drift before runtime)', () =
         );
       }
       expect(missing).toEqual([]);
-      expect(hasSomeBold).toBe(true);
+      expect(hasSectionSplit).toBe(true);
     });
   }
 });


### PR DESCRIPTION
## Summary

PR #121 머지 직후 Oracle 리뷰에서 발견된 두 가지 잔여 이슈 해결:

### 이슈 1: 빈 첫 섹션 → 헤딩 라벨 노출

PR #121은 `match()` 단일 매칭으로 첫 섹션 본문만 추출하고, 첫 섹션이 비어있으면 \`flattenMarkdown(trimmed)\` (전체 평탄화)로 폴백. 이때 헤딩 라벨('주요 내용', '시사점' 등)이 다시 카드에 노출됨.

| 입력 | PR #121 출력 | 본 PR 출력 |
|---|---|---|
| \`## 개요\\n\\n## 주요 내용\\n실제\` | \`주요 내용 실제\` ❌ | \`실제\` ✅ |
| \`## 개요\\n\\n## 주요 내용\\n\\n\` (모두 빈 섹션) | \`개요 주요 내용\` ❌ | \`\"\"\` ✅ |

### 이슈 2: 5개 stripMd 구현 nested bold parity 분기

PR #121의 4개 sibling은 \`/\\*\\*([^*\\n]+?)\\*\\*/g\` regex 사용 → 본문에 \`*\` 차단 → nested \`**outer *inner* outer**\` 매칭 실패. \`render-summary.ts\`만 placeholder strategy로 정상 처리.

| 입력 | render-summary.ts | 4개 sibling (PR #121) | 본 PR (모두) |
|---|---|---|---|
| \`**outer *inner* outer**\` | \`outer inner outer\` | \`**outer inner outer**\` ❌ | \`outer inner outer\` ✅ |

PR #121의 \`BOLD_PATTERN_OPTIONS\` 배열이 분기를 명시적 허용했지만, 같은 입력에 출력이 다르면 "5개 구현 동작 일치"라는 contract는 거짓.

## 변경 사항

### 1. `stripMarkdownForPreview` / `stripMd` — 섹션 단위 iteration

\`match()\` 대신 \`split(/(?:^|\\n)##\\s+[^\\n]*\\n?/)\`로 섹션 분해 후 첫 비어있지 않은 섹션 본문 반환. 모든 섹션 비어있으면 \`''\` 반환 (헤딩 라벨 절대 노출 안 함).

### 2. 4개 sibling의 bold regex 통일

\`[^*\\n]+?\` → \`[^\\n]+?\` (lazy match로 nested * 허용). 이제 5개 모두 동일 동작.

### 3. parity 테스트 강화

- 코퍼스 +4 케이스: 빈 섹션, nested bold+italic, nested in 첫 섹션, all-empty
- byte-parity: \`BOLD_PATTERN_OPTIONS\` 제거, \`SECTION_SPLIT_TOKEN\` 신규로 첫-섹션-iteration 강제

## 5개 stripMd 구현 동기화

- \`src/lib/render-summary.ts\` (Astro SSG)
- \`functions/lib/escape.ts\` (Cloudflare Functions)
- \`public/scripts/must-read-page.js\` (browser must-read)
- \`src/components/InterestTagPanel.astro\` (browser articles page)
- \`src/pages/admin/must-read.astro\` (browser admin)

## 검증

- \`bun run validate\` ✅
- \`bun run validate:docs\` ✅ (54개 문서 유효)
- \`bun run validate:docs -- --check-coverage\` ✅
- \`bun run build\` ✅ (625 페이지)
- \`bun run test\` ✅ **263/263** (PR #121 261에서 +2)
- 수동 QA: \`dist/index.html\`에서 'Chain of Custody' 카드 확인 — 깔끔한 한국어 요약 본문만 노출, "개요" prefix 없음

## 관련 문서

- \`docs/troubleshooting/card-preview-empty-section-leak.md\` (신규)
- \`docs/troubleshooting/card-preview-overview-prefix.md\` (PR #121, 직전 단계)