### PR TITLE
feat(articles): 멀티 태그 필터 + 현대적 UI 리디자인 (InterestTagPanel)

### DIFF
--- a/docs/features/interest-tag-panel.md
+++ b/docs/features/interest-tag-panel.md
@@ -33,25 +33,32 @@ InterestTagPanel은 다음과 같이 통합한다.
     → pinInterestMatchesInList() (매칭 카드 상단 정렬)
     → URL ?tag= 있으면 applyTagFilter() (cross-page)
 
-[칩 본문 클릭]
-  → setActiveTagChip(tag) → URL ?tag= 갱신
+[칩 본문 클릭 — 멀티 태그]
+  → applyTagFilter(tag) → toggleTag(tag) (이미 있으면 제거, 없으면 추가)
+  → syncChipActiveStates() (모든 .itp-chip에 .active + aria-pressed 동기화)
+  → syncTagsToUrl() (동일 키 반복: ?tag=ai&tag=llm)
+  → refreshTopRow() (활성 태그를 상단 6칩에 고정 → 사라지는 문제 방지)
+  → refreshSelectedSummary() (“활성 필터 #ai × #llm ×” 바)
   → renderFilteredView()
-      ├── getFilteredArticles() (검색 결과 ∩ 활성 태그 ∩ 활성 origin)
+      ├── getFilteredPool() — 태그가 1개 이상이면 OR 필터: a.tags.some(t => active.has(t))
       ├── pinInterestMatches() (관심사 매칭 카드 상단 정렬)
-      ├── renderCard() × N (.interest-match 포함)
-      ├── __initAddToPlaylistContainers() / __initBookmarkButtons() / __initCommentCounts()
-      └── source-counts-update event (검색 활성 시 검색 결과 기준 카운트)
+      ├── renderCard() × N
+      └── source-counts-update event
+
+[“전체” 칩 클릭]
+  → toggleTag('all') → state.activeTags.clear()
+  → 나머지 파이프라인은 동일
 
 [칩 별표(☆) 클릭]
   → toggleInterest(tag) → localStorage 저장
   → CustomEvent('interests-changed', { interests })
-  → refreshInterestsUI() (상단 라벨, 펼침 패널의 관심사 pill, 모든 별표 상태)
-  → applyInterestHighlights() (SSR 카드)
-  → 동적 결과가 활성이면 renderFilteredView() 재실행 (재정렬)
+  → refreshInterestsUI() / applyInterestHighlights()
+  → 활성 필터 풌이 있으면 renderFilteredView() 재실행 (재정렬)
 
 [펼침 토글]
-  → #itp-expanded.hidden toggle
-  → "모든 태그 보기 ▼" ↔ "접기 ▲"
+  → #itp-expanded.hidden toggle (상/하단 두 버튼 모두 동일 핸들러)
+  → “모든 태그 보기 ▼” ↔ “접기 ▲”
+  → 하단 커늤프스 버튼 클릭 시 패널로 scrollIntoView(펼쳐진 태그 목록이 길면 다시 맨 위로 돌아갈 필요 대신 자동 스크롤)
 ```
 
 ### 동시 활성 필터 우선순위
@@ -84,17 +91,21 @@ InterestTagPanel은 다음과 같이 통합한다.
 |------|------|--------|------|
 | `STORAGE_KEY` | `src/components/InterestTagPanel.astro` (인라인 상수) | `'honeycombo_interests'` | localStorage 키. 기존 PersonalizationBar와 동일 → 마이그레이션 불필요 |
 | `TOP_N` | `src/components/InterestTagPanel.astro` (인라인 상수) | `6` | 상시 노출 칩 슬롯 개수 |
-| `?tag=` | URL 쿼리 파라미터 | (없음) | 활성 태그 필터 (페이지 새로고침 시 복원) |
+| `?tag=&tag=` | URL 쿼리 파라미터 | (없음) | 활성 태그 필터 (멀티—동일 키 반복). 읽기: `getAll('tag')`. 쓰기: `delete('tag')` 후 `append()` 정렬된 순서로 (복사·공유 가능한 URL 안정성). |
 
 ## 제약 사항
 
 - 칩 클릭은 항상 cross-page hard 필터로 동작한다 (현재 페이지에 매칭이 없어도 전체 기사에서 찾아 표시).
+- **멀티 태그는 OR 의미론**이다. 동일 facet 내 다중 선택에서는 OR이 사용자 기대와 일치 (“이 태그들 중 아무거나”). 다른 facet (검색·origin)과는 AND. Oracle 검토 근거.
+- **`전체` 칩**은 `state.activeTags.size === 0`일 때만 활성. 클릭 시 `state.activeTags.clear()`로 모든 태그 해제. `'all'`은 실제 태그와 공존하지 않는다.
+- **활성 태그는 상단 6칩에 고정**된다 (`refreshTopRow` 자동 구성 우선순위: 활성 → 관심사 → 인기). 이로써 사용자가 비인기 태그를 선택해도 상단에서 사라지지 않는다.
 - 관심사 매칭 강조(`.interest-match` 클래스)는 ArticleCard의 `<style is:global>`과 InterestTagPanel의 글로벌 스타일을 함께 사용한다. 다른 페이지에서 ArticleCard를 사용해도 InterestTagPanel이 마운트되지 않으면 `.interest-match` 클래스가 부여되지 않으므로 효과는 발생하지 않는다.
-- "관심사 일치 N건" 뱃지는 전체 기사 데이터셋을 기준으로 계산된다 (`refreshMatchBadgeFromFullDataset`). 현재 페이지에 보이는 20개 카드가 아니라 전체 기사 중 일치하는 수 — 사용자가 "차이 없어"라고 느낀 문제를 해소.
+- “관심사 일치 N건” 배지는 전체 기사 데이터셋을 기준으로 계산된다 (`refreshMatchBadgeFromFullDataset`).
 - `serializeArticles()`가 임베드한 JSON에 의존한다. 페이지에 `<script id="all-articles-data">`가 없으면 cross-page 필터는 빈 결과를 반환한다.
 - `getInterests()`는 손상된 localStorage 값을 만나면 빈 배열로 fallback한다 (사용자 데이터 손실 가능성 차단).
-- 펼침 패널의 전체 태그 리스트는 SSR로 렌더링되므로 페이지 HTML 크기가 태그 수에 비례한다 (현 build 기준 수백 개 규모로는 영향 미미). 기사/태그 수가 크게 늘어나면 페이지이션 / 인덱스 분리를 검토해야 한다.
-- 칩 UI는 *chip-wrap* 래퍼 안에 칩 버튼(태그 필터용)과 별표 버튼(관심사 토글용)을 *형제*로 둘다. 과거의 중첩 `<button>` 마크업(유효하지 않고 키보드로 관심사 조작 불가)을 사용하지 않으며, 둘 다 독립적으로 키보드 포커스가 가능하다 (Tab 이동 + Enter/Space).
+- 펼침 패널의 전체 태그 리스트는 SSR로 렌더링되므로 페이지 HTML 크기가 태그 수에 비례한다 (현 build 기준 수백 개 규모로는 영향 미미). 기사/태그 수가 크게 늘어나면 페이이션 / 인덱스 분리를 검토해야 한다.
+- 칩 UI는 *chip-wrap* 래퍼 안에 칩 버튼(태그 필터용)과 별표 버튼(관심사 토글용)을 *형제*로 둔다. 과거의 중첩 `<button>` 마크업(유효하지 않고 키보드로 관심사 조작 불가)을 사용하지 않으며, 둘 다 독립적으로 키보드 포커스가 가능하다 (Tab 이동 + Enter/Space).
+- **CSS 스코핑**: 패널 컨테이너는 scoped, 동적으로 innerHTML로 렌더링되는 철들(탁, 폈, 한주 세레트 요약) 설렉터는 Astro의 `:global()`로 표시해 `data-astro-cid-*` 재좰파리없이도 적용되게 한다. 세을렉터는 부모 `.interest-tag-panel`로 스코핑하므로 사이트 전체에 누출되지 않는다. (`<style is:global>`로 전체 블록을 전역화 안 하는 이유.)
 
 ---
 
@@ -112,3 +123,4 @@ InterestTagPanel은 다음과 같이 통합한다.
 | 2026-04-20 | 최초 작성 — PersonalizationBar + TagFilter 통합, 인기 태그 6개 상시 노출 + 관심사 매칭 시각 강조 추가 |
 | 2026-04-20 | Oracle 검증 대응 — (1) 상단 6칩 런타임 재조립으로 관심사 우선 표시, (2) per-origin 카운트를 search∩tag 풀 기준으로 계산, (3) 관심사 뱃지를 전체 데이터셋 기준으로 계산, (4) 별표를 chip-wrap 형제 버튼으로 분리 (유효 HTML + 키보드 접근성), (5) astro:page-load 리스너 누적 방지 가드 추가. 통합 테스트 10건 추가 (`getFilteredPool` search∩origin∩tag). |
 | 2026-04-20 | 문서 정확성 개선 — 고정 수치("241개 태그", "299건")를 제거하고 "build 시점 기준 수백 개" 등의 안정적 서술로 교체. 오타(풀/별표를) 수정. |
+| 2026-04-20 | **멀티 태그 + UI 현대화** — (1) 단일 태그(`activeTag: string`)을 멀티 태그(`activeTags: Set<string>`)로 전환, OR 의미론(Oracle 검토). (2) URL 형식을 동일 키 반복(`?tag=ai&tag=llm`)로 변경, 콤마가 포함된 태그명에도 안전. (3) 활성 태그를 `refreshTopRow` 세려발(활성 → 관심사 → 인기)으로 상단 고정 — 비인기 태그 선택 시 사라지는 버그 해결. (4) “활성 필터 #ai × ···” 섬머리 바 추가 — 각 칩 개별 제거 + “모두 지우기”. (5) 상/하 토글 버튼(거대한 펼쳐진 목록에서 위로 스크롤 없이 접기 가능). (6) 위임 클릭 핸들러에서 `ev.target`을 Element로 정규화 — 일부 브라우저에서 Text 노드에 `closest()` 실패하던 토글 버그 해결. (7) 패널에 `[hidden]` !important 추가 — flex/inline-flex에서 hidden 속성이 무시되던 버그(배지 “주황색 대시”) 해결. (8) Apple 스타일 리디자인 — 비선형 cubic-bezier easing, hover lift, gradient 패널, 제스처 톤 하이라이트, `prefers-reduced-motion` 존중. (9) 동적 DOM에 대응하기 위해 모든 `.itp-*` 스타일을 Astro `:global()`로 개별 표시(부모 `.interest-tag-panel`은 스코프 유지, 사이트 전체 누출 없음). |

--- a/docs/troubleshooting/astro-scoped-styles-dynamic-dom.md
+++ b/docs/troubleshooting/astro-scoped-styles-dynamic-dom.md
@@ -1,0 +1,100 @@
+# Astro scoped 스타일이 innerHTML 렌더링 DOM에 적용되지 않음
+
+> Astro는 scoped `<style>` 블록을 `data-astro-cid-*` 속성 기반으로 격리한다. JS에서 `innerHTML`로 동적 렌더링한 요소는 이 속성이 없어서 scoped 스타일이 매칭되지 않는다. 해결: Astro의 per-selector `:global()` 이스케이프 해치를 사용해 부모는 scoped 유지, 동적 자식만 global 처리.
+
+## 증상
+
+`InterestTagPanel.astro`에서 `refreshTopRow()`가 `row.innerHTML = ...`로 칩을 동적 렌더링한다. 이 칩들은 scoped `<style>` 블록의 규칙이 **매칭되지 않아** 활성 상태 스타일이 보이지 않음.
+
+```ts
+// refreshTopRow() 내부
+row.innerHTML = `<span class="itp-chip-wrap active">
+  <button class="itp-chip active" ...>...</button>
+  <button class="itp-chip-star" ...>☆</button>
+</span>`;
+```
+
+브라우저에서 확인:
+
+```js
+const wrap = document.querySelector('.itp-chip-wrap.active');
+console.log(Array.from(wrap.attributes).map(a => a.name));
+// SSR로 렌더링된 칩: ["class", "data-astro-cid-l37up36j"]
+// JS로 렌더링된 칩: ["class"]   ← 속성 없음!
+```
+
+`<style>` 내부에 정의된 `.itp-chip-wrap.active { background: var(--color-primary); }`는 실제로 `.itp-chip-wrap[data-astro-cid-l37up36j].active`로 컴파일되어 있어서 동적 칩에 매칭되지 않음.
+
+## 원인
+
+Astro scoped 스타일은 [빌드 타임에 모든 선택자에 `[data-astro-cid-*]` 속성 매처를 추가](https://docs.astro.build/en/guides/styling/#scoped-styles)한다. 이는 컴포넌트 내부 SSR 요소에만 유효하며, JS가 런타임에 만든 DOM에는 속성이 없다.
+
+흔한 잘못된 해법:
+1. **전체 `<style is:global>`로 변경** → 모든 선택자가 사이트 전역에 노출됨. `.itp-*` 접두사로 충돌 위험은 낮지만, 이름 위생이 무너지면 잠재 위험. 유지보수자가 실수할 수 있음.
+2. **런타임에 `data-astro-cid-*` 주입** → `cid`는 빌드 타임 생성값이라 런타임에서 확실히 얻을 방법이 없음. 굳이 하려면 `define:vars`로 노출해야 하지만 복잡.
+
+## 해결 방법
+
+Astro는 scoped `<style>` 블록 **내부**에 [`:global()` per-selector 이스케이프 해치](https://docs.astro.build/en/guides/styling/#global-styles)를 제공한다. 부모 선택자는 scoped, 괄호 안의 자식만 global로 처리된다.
+
+```astro
+<style>
+  /* 컨테이너는 scoped 유지 (사이트 전역 노출 방지) */
+  .interest-tag-panel {
+    background: linear-gradient(...);
+    border: 1px solid var(--color-border);
+    /* ... */
+  }
+
+  /* 내부 동적 선택자는 :global()로 처리 */
+  .interest-tag-panel :global(.itp-chip-wrap.active) {
+    background: var(--color-primary);
+    box-shadow: 0 2px 8px rgba(245, 124, 34, 0.3);
+  }
+</style>
+```
+
+컴파일 결과:
+
+```css
+/* 컨테이너: 여전히 scoped */
+.interest-tag-panel[data-astro-cid-l37up36j] { ... }
+
+/* 내부: global (data-astro-cid 없음) */
+.interest-tag-panel[data-astro-cid-l37up36j] .itp-chip-wrap.active { ... }
+```
+
+→ **부모에 대한 scoping으로 사이트 전역 노출을 방지**하면서, **자식 선택자는 scoping을 피해** 동적으로 생성된 DOM에도 매칭된다.
+
+**적용 효과**:
+
+| 선택자 | 패턴 | 설명 |
+|--------|------|------|
+| `.interest-tag-panel` | (scoped) | 컨테이너. `data-astro-cid-*`가 SSR로 부여되므로 그대로 scoped. |
+| `.interest-tag-panel :global(.itp-header)` | scoped 부모 + global 자식 | SSR 자식이지만 일관성 위해 동일 패턴. |
+| `.interest-tag-panel :global(.itp-chip-wrap)` | scoped 부모 + global 자식 | **핵심** — 동적 렌더링 시 scope 속성 없으므로 `:global()` 필수. |
+
+## 관련 파일
+
+| 파일 | 변경 내용 |
+|------|----------|
+| `src/components/InterestTagPanel.astro` | scoped `<style>` 내부 모든 `.itp-*` 선택자를 `.interest-tag-panel :global(...)` 패턴으로 래핑. 컨테이너 `.interest-tag-panel`만 순수 scoped. 두 번째 `<style is:global>` 블록(`.article-card.interest-match`)은 복합 선택자로 이미 안전 — 변경 없음. |
+
+## 예방 조치
+
+- **`.itp-` 접두사 규칙 유지**: 동적 DOM에 대응하는 선택자를 추가할 때 반드시 고유 접두사 사용. 만약의 `:global()` 누수에도 충돌 위험을 낮춤.
+- **`<style is:global>` 전체 블록 변환 금지**: 가능한 `:global()` per-selector 사용. 스타일 범위를 물리적으로 격리한다는 시각적 신호를 유지.
+- 런타임에 만든 DOM을 관찰할 때는 `Element.attributes`를 확인해 `data-astro-cid-*`가 있는지 먼저 점검하면 스타일 미적용 원인 파악이 빠르다.
+
+---
+
+## 관련 문서
+
+- [관심사 & 태그 패널 (InterestTagPanel)](../features/interest-tag-panel.md)
+- [Astro 공식 문서 — :global()](https://docs.astro.build/en/guides/styling/#global-styles)
+
+## 변경 이력
+
+| 날짜 | 변경 내용 |
+|------|----------|
+| 2026-04-20 | 최초 작성 — InterestTagPanel 리디자인 중 동적 칩 스타일 미적용 이슈 해결 기록 |

--- a/src/components/InterestTagPanel.astro
+++ b/src/components/InterestTagPanel.astro
@@ -6,19 +6,21 @@
 //
 // Behavior model:
 //   - Click chip body  -> hard tag filter (cross-page, hides SSR list, shows filtered grid).
+//                         **Multi-select**: clicking another chip ADDS to selection (OR semantics).
+//                         Clicking an active chip again removes it.
 //   - Click chip star  -> toggle as personal interest (saved to localStorage).
 //                         Articles matching saved interests get a visible "interest" highlight
 //                         (background tint + corner star) and are pinned to the top of the list.
-//   - "전체" chip       -> clears the active tag filter.
-//   - Top 6 chips      -> always visible. Saved interests come first (client-side rewrite),
-//                         then most-used tags. Built at runtime so per-user interests can
-//                         actually be promoted (SSG cannot know per-user localStorage).
+//   - "전체" chip       -> clears ALL active tag filters.
+//   - Top 6 chips      -> always visible. Active filters first (so they don't disappear when
+//                         a non-popular tag is selected), then saved interests, then popular.
+//                         Built at runtime so per-user interests can actually be promoted.
 //   - Toggle button    -> expands the full tag list (all tags), grouped into
 //                         "내 관심사" (saved) and "전체 태그".
 //
 // State sources:
 //   - localStorage[honeycombo_interests] : string[] (persistent, soft pin)
-//   - URL ?tag=                          : string   (ephemeral, hard filter)
+//   - URL ?tag=&tag=                     : string[] (ephemeral, hard filter, multi-value)
 //
 // Events consumed:
 //   - source-filter-changed   ({ origin })          - re-applies active filter under new origin
@@ -71,12 +73,12 @@ const tagCountsJson = JSON.stringify(tagCounts);
     saved interests first.
   -->
   <div class="itp-chips-row" id="itp-chips-row" data-testid="itp-chips-row">
-    <button class="itp-chip itp-chip-all active" data-tag="all" type="button">
+    <button class="itp-chip itp-chip-all active" data-tag="all" type="button" aria-pressed="true">
       <span class="itp-chip-label">전체</span>
     </button>
     {sortedTags.slice(0, 6).map((tag) => (
       <span class="itp-chip-wrap">
-        <button class="itp-chip" data-tag={tag} type="button">
+        <button class="itp-chip" data-tag={tag} type="button" aria-pressed="false">
           <span class="itp-chip-label">{tag}</span>
           <span class="itp-chip-count">{tagCounts[tag] ?? 0}</span>
         </button>
@@ -92,6 +94,10 @@ const tagCountsJson = JSON.stringify(tagCounts);
       </span>
     ))}
   </div>
+
+  <!-- Selected filters summary (visible only when 1+ tags active). Helps multi-tag UX:
+       user sees what's filtering at a glance + can remove individual tags. -->
+  <div class="itp-selected-summary" id="itp-selected-summary" hidden></div>
 
   <!-- Expanded panel -->
   <div class="itp-expanded" id="itp-expanded" hidden>
@@ -113,7 +119,7 @@ const tagCountsJson = JSON.stringify(tagCounts);
       <div class="itp-all-tags" id="itp-all-tags">
         {sortedTags.map((tag) => (
           <span class="itp-chip-wrap">
-            <button class="itp-chip" data-tag={tag} type="button">
+            <button class="itp-chip" data-tag={tag} type="button" aria-pressed="false">
               <span class="itp-chip-label">{tag}</span>
               <span class="itp-chip-count">{tagCounts[tag] ?? 0}</span>
             </button>
@@ -130,6 +136,14 @@ const tagCountsJson = JSON.stringify(tagCounts);
         ))}
       </div>
     </section>
+
+    <!-- Bottom collapse button: when expanded panel is long, user can collapse from the bottom
+         without scrolling all the way back up. Mirrors the top toggle's behavior. -->
+    <div class="itp-expanded-footer">
+      <button type="button" class="itp-toggle itp-toggle-bottom" id="itp-toggle-bottom">
+        접기 ▲
+      </button>
+    </div>
   </div>
 </div>
 
@@ -174,7 +188,7 @@ const tagCountsJson = JSON.stringify(tagCounts);
     w.__itpState = {
       allArticles: null as ClientArticle[] | null,
       tagCounts: null as Record<string, number> | null,
-      activeTag: 'all' as string,
+      activeTags: new Set<string>() as Set<string>,
       activeSearchQuery: '' as string,
       activeSearchResults: null as ClientArticle[] | null, // null = no active search
       // Track delegated listeners so we never bind twice across astro:page-load.
@@ -182,6 +196,39 @@ const tagCountsJson = JSON.stringify(tagCounts);
     };
   }
   const state = w.__itpState;
+
+  // ---------- Multi-tag filter helpers (Oracle review: OR within tag facet) ----------
+  function hasActiveTags(): boolean {
+    return state.activeTags.size > 0;
+  }
+  function toggleTag(tag: string): void {
+    if (tag === 'all') {
+      state.activeTags.clear();
+      return;
+    }
+    if (state.activeTags.has(tag)) state.activeTags.delete(tag);
+    else state.activeTags.add(tag);
+  }
+  function clearTags(): void {
+    state.activeTags.clear();
+  }
+  function parseTagsFromUrl(validTags: Set<string>): Set<string> {
+    // Repeated params: ?tag=ai&tag=llm. Robust against tag names containing commas.
+    const raw = new URLSearchParams(window.location.search).getAll('tag');
+    const result = new Set<string>();
+    for (const t of raw) {
+      if (t && validTags.has(t)) result.add(t);
+    }
+    return result;
+  }
+  function syncTagsToUrl(): void {
+    const url = new URL(window.location.href);
+    url.searchParams.delete('tag');
+    // Append in sorted order for stable, copy-pastable URLs.
+    const sorted = Array.from(state.activeTags).sort();
+    for (const t of sorted) url.searchParams.append('tag', t);
+    window.history.replaceState({}, '', url.toString());
+  }
 
   // ---------- localStorage interests ----------
   function getInterests(): string[] {
@@ -405,7 +452,7 @@ const tagCountsJson = JSON.stringify(tagCounts);
   // ---------- Filter pipeline ----------
   function isFilteredViewActive(): boolean {
     return (
-      state.activeTag !== 'all' ||
+      hasActiveTags() ||
       getActiveOrigin() !== 'all' ||
       state.activeSearchResults !== null
     );
@@ -421,10 +468,11 @@ const tagCountsJson = JSON.stringify(tagCounts);
   function getFilteredPool(): { all: ClientArticle[]; perOrigin: { submitted: number; feed: number; curated: number } } {
     const origin = getActiveOrigin();
     const q = state.activeSearchQuery.trim().toLowerCase();
-    const tag = state.activeTag;
+    const tags = state.activeTags;
     let pool = getAllArticles();
     if (q) pool = pool.filter((a) => a.title.toLowerCase().includes(q));
-    if (tag !== 'all') pool = pool.filter((a) => a.tags.includes(tag));
+    // Multi-tag OR semantics (Oracle review): article matches if it has ANY selected tag.
+    if (tags.size > 0) pool = pool.filter((a) => a.tags.some((t) => tags.has(t)));
 
     // Per-origin breakdown is computed BEFORE applying origin filter,
     // so SourceFilter can show "0 in Submitted / N in RSS" honestly.
@@ -445,8 +493,9 @@ const tagCountsJson = JSON.stringify(tagCounts);
       const m: Record<string, string> = { curated: '에디터 추천', submitted: '제출 기사', feed: 'RSS 피드' };
       labels.push(m[origin] || origin);
     }
-    if (state.activeTag !== 'all') {
-      labels.push(`"${state.activeTag}" 태그`);
+    if (hasActiveTags()) {
+      const tagList = Array.from(state.activeTags).sort();
+      labels.push(tagList.length === 1 ? `"${tagList[0]}" 태그` : `태그 ${tagList.length}개 (${tagList.join(', ')})`);
     }
     if (state.activeSearchQuery) {
       labels.push(`"${state.activeSearchQuery}" 검색`);
@@ -504,7 +553,7 @@ const tagCountsJson = JSON.stringify(tagCounts);
     }
 
     countEl.textContent = buildFilterLabel(articles.length);
-    grid.dataset.activeTag = state.activeTag;
+    grid.dataset.activeTags = Array.from(state.activeTags).sort().join(',');
     grid.innerHTML = articles.map((a) => renderCard(a, interests)).join('');
     if (emptyEl) emptyEl.hidden = articles.length > 0;
     if (ssrEmpty) ssrEmpty.style.display = 'none';
@@ -605,32 +654,46 @@ const tagCountsJson = JSON.stringify(tagCounts);
     [...matched, ...unmatched].forEach((card) => list.appendChild(card));
   }
 
-  // ---------- Top-row rebuild (BLOCKER 1 FIX) ----------
+  // ---------- Top-row rebuild ----------
   /**
-   * Rebuild the top-6 row putting saved interests first. This is the user-confirmed
-   * design that build-time SSR cannot satisfy (we don't know per-user interests).
-   * Preserves the active tag highlight.
+   * Rebuild the top-6 row. Priority order (Oracle review):
+   *   1. Currently-active filter tags (so user never loses sight of what's filtering)
+   *   2. Saved interests (per-user pinning)
+   *   3. Most-popular tags (fallback)
+   * Active filter chips also get visual + aria-pressed state.
    */
   function refreshTopRow() {
     const row = document.getElementById('itp-chips-row');
     if (!row) return;
     const interests = getInterests();
     const counts = getTagCounts();
-    const top = computeTopTags(interests, counts, TOP_N);
+    const active = state.activeTags;
     const interestsSet = new Set(interests);
-    const active = state.activeTag;
 
-    const allChip = `<button class="itp-chip itp-chip-all${active === 'all' ? ' active' : ''}" data-tag="all" type="button">
+    // Compose top row: active first, then interests, then popular. Dedup via Set.
+    const seen = new Set<string>();
+    const composed: string[] = [];
+    const pushIfNew = (t: string) => {
+      if (seen.has(t) || composed.length >= TOP_N) return;
+      seen.add(t);
+      composed.push(t);
+    };
+    Array.from(active).sort().forEach(pushIfNew);
+    interests.forEach(pushIfNew);
+    computeTopTags(interests, counts, TOP_N).forEach(pushIfNew);
+
+    const allActive = active.size === 0;
+    const allChip = `<button class="itp-chip itp-chip-all${allActive ? ' active' : ''}" data-tag="all" type="button" aria-pressed="${allActive}">
       <span class="itp-chip-label">전체</span>
     </button>`;
 
-    const chips = top.map((tag) => {
-      const isActive = active === tag;
+    const chips = composed.map((tag) => {
+      const isActive = active.has(tag);
       const isSaved = interestsSet.has(tag);
       const star = isSaved ? '★' : '☆';
       const safeTag = escapeHtml(tag);
-      return `<span class="itp-chip-wrap">
-        <button class="itp-chip${isActive ? ' active' : ''}" data-tag="${safeTag}" type="button">
+      return `<span class="itp-chip-wrap${isActive ? ' active' : ''}">
+        <button class="itp-chip${isActive ? ' active' : ''}" data-tag="${safeTag}" type="button" aria-pressed="${isActive}">
           <span class="itp-chip-label">${safeTag}</span>
           <span class="itp-chip-count">${counts[tag] ?? 0}</span>
         </button>
@@ -700,24 +763,61 @@ const tagCountsJson = JSON.stringify(tagCounts);
   }
 
   // ---------- Active tag chip styling ----------
-  function setActiveTagChip(tag: string) {
-    state.activeTag = tag;
+  /**
+   * Sync DOM active state to state.activeTags. Multi-tag aware: every chip whose tag is in
+   * the set gets .active + aria-pressed=true. The "전체" chip is active when set is empty.
+   * Also ensures the wrapper gets .active so CSS can style the whole pill (chip + star).
+   */
+  function syncChipActiveStates() {
+    const active = state.activeTags;
+    const noFilter = active.size === 0;
     document.querySelectorAll<HTMLElement>('.itp-chip').forEach((chip) => {
-      chip.classList.toggle('active', chip.dataset.tag === tag);
+      const tag = chip.dataset.tag || '';
+      const on = tag === 'all' ? noFilter : active.has(tag);
+      chip.classList.toggle('active', on);
+      chip.setAttribute('aria-pressed', String(on));
     });
-
-    const url = new URL(window.location.href);
-    if (tag === 'all') {
-      url.searchParams.delete('tag');
-    } else {
-      url.searchParams.set('tag', tag);
-    }
-    window.history.replaceState({}, '', url.toString());
+    document.querySelectorAll<HTMLElement>('.itp-chip-wrap').forEach((wrap) => {
+      const chip = wrap.querySelector<HTMLElement>('.itp-chip');
+      const tag = chip?.dataset.tag || '';
+      wrap.classList.toggle('active', !!tag && active.has(tag));
+    });
   }
 
   function applyTagFilter(tag: string) {
-    setActiveTagChip(tag);
+    toggleTag(tag);
+    syncChipActiveStates();
+    syncTagsToUrl();
+    refreshTopRow();
+    syncChipActiveStates(); // re-sync after refreshTopRow rebuilds top row
+    refreshSelectedSummary();
     renderFilteredView();
+  }
+
+  /**
+   * Renders the "selected filters" summary bar shown above the expanded panel when
+   * the user has 1+ active tags. Each chip is removable (X). Helps multi-tag UX:
+   * user sees what's active at a glance and can clear individual tags without scrolling.
+   */
+  function refreshSelectedSummary() {
+    const summary = document.getElementById('itp-selected-summary');
+    if (!summary) return;
+    const tags = Array.from(state.activeTags).sort();
+    if (tags.length === 0) {
+      summary.hidden = true;
+      summary.innerHTML = '';
+      return;
+    }
+    summary.hidden = false;
+    const items = tags.map(
+      (t) => `<button type="button" class="itp-selected-pill" data-remove-tag data-tag="${escapeHtmlAttr(t)}" title="&quot;${escapeHtmlAttr(t)}&quot; 필터 제거">
+        <span>#${escapeHtmlText(t)}</span>
+        <span class="itp-selected-pill-x" aria-hidden="true">×</span>
+      </button>`
+    ).join('');
+    summary.innerHTML =
+      `<span class="itp-selected-label">활성 필터</span>${items}` +
+      `<button type="button" class="itp-selected-clear" id="itp-selected-clear">모두 지우기</button>`;
   }
 
   // ---------- Initialization ----------
@@ -745,17 +845,19 @@ function initInterestTagPanel() {
     pinInterestMatchesInList();
     refreshMatchBadgeFromFullDataset();
 
-    // Apply initial state from URL (?tag=) — must run after refreshTopRow so the chip exists.
-    const tagParam = new URLSearchParams(window.location.search).get('tag');
+    // Apply initial state from URL (?tag=&tag=) — must run after refreshTopRow so chips exist.
     const validTags = new Set<string>();
     document.querySelectorAll<HTMLElement>('.itp-chip').forEach((c) => {
-      if (c.dataset.tag) validTags.add(c.dataset.tag);
+      if (c.dataset.tag && c.dataset.tag !== 'all') validTags.add(c.dataset.tag);
     });
-    const initialTag = tagParam && validTags.has(tagParam) ? tagParam : 'all';
-    setActiveTagChip(initialTag);
+    state.activeTags = parseTagsFromUrl(validTags);
+    // Some active tags from the URL may not be in the popular top-N — rebuild the top row to pin them.
+    refreshTopRow();
+    syncChipActiveStates();
+    refreshSelectedSummary();
 
-    // If URL had a tag or origin or active search, render the filtered view.
-    if (initialTag !== 'all' || getActiveOrigin() !== 'all' || state.activeSearchResults !== null) {
+    // If URL had any tag or origin or active search, render the filtered view.
+    if (hasActiveTags() || getActiveOrigin() !== 'all' || state.activeSearchResults !== null) {
       renderFilteredView();
     } else {
       // Ensure SSR view is restored if persisted state is now cleared.
@@ -773,10 +875,18 @@ function initInterestTagPanel() {
     // Using event delegation means newly-rendered top-row chips and re-rendered pills
     // automatically work without re-binding.
     document.addEventListener('click', (ev) => {
-      const target = ev.target as HTMLElement;
+      // Oracle review: normalize ev.target. On some browsers raw clicks on text inside a
+      // <button> can yield a Text node, where .closest() does not exist — silently breaking
+      // the toggle. Walk up to the nearest Element first.
+      const raw = ev.target as Node | null;
+      if (!raw) return;
+      const target =
+        raw.nodeType === 1
+          ? (raw as Element)
+          : (raw.parentElement as Element | null);
       if (!target) return;
 
-      // Star toggle (works for both top row and expanded panel; sibling button so no nesting issues)
+      // Star toggle (sibling button so no nesting issues).
       const star = target.closest<HTMLElement>('[data-star]');
       if (star) {
         ev.preventDefault();
@@ -794,6 +904,28 @@ function initInterestTagPanel() {
         return;
       }
 
+      // Remove a single active tag filter (X on selected-summary pill).
+      const removeTag = target.closest<HTMLElement>('[data-remove-tag]');
+      if (removeTag) {
+        ev.preventDefault();
+        const tag = removeTag.dataset.tag || '';
+        if (tag) applyTagFilter(tag); // toggleTag removes if present
+        return;
+      }
+
+      // Clear all active tag filters (selected-summary "모두 지우기")
+      if (target.closest('#itp-selected-clear')) {
+        ev.preventDefault();
+        clearTags();
+        syncChipActiveStates();
+        syncTagsToUrl();
+        refreshTopRow();
+        syncChipActiveStates();
+        refreshSelectedSummary();
+        renderFilteredView();
+        return;
+      }
+
       // Clear all interests
       if (target.closest('#itp-clear')) {
         ev.preventDefault();
@@ -801,21 +933,27 @@ function initInterestTagPanel() {
         return;
       }
 
-      // Expand/collapse toggle
-      const toggle = target.closest<HTMLElement>('#itp-toggle');
+      // Expand/collapse toggle (sticky button at top of expanded panel works too via #itp-toggle-bottom)
+      const toggle = target.closest<HTMLElement>('#itp-toggle, #itp-toggle-bottom');
       if (toggle) {
         const expanded = document.getElementById('itp-expanded');
-        if (!expanded) return;
+        const topToggle = document.getElementById('itp-toggle');
+        if (!expanded || !topToggle) return;
         const wasHidden = expanded.hidden;
         expanded.hidden = !wasHidden;
-        toggle.setAttribute('aria-expanded', String(wasHidden));
-        toggle.textContent = wasHidden ? '접기 ▲' : '모든 태그 보기 ▼';
+        topToggle.setAttribute('aria-expanded', String(wasHidden));
+        topToggle.textContent = wasHidden ? '접기 ▲' : '모든 태그 보기 ▼';
+        // If user clicked the bottom collapse, scroll the panel back into view so they don't get lost.
+        if (toggle.id === 'itp-toggle-bottom') {
+          document.querySelector('.interest-tag-panel')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        }
         return;
       }
 
-      // Tag chip body
+      // Tag chip body (last so other handlers above take precedence)
       const chip = target.closest<HTMLElement>('.itp-chip');
       if (chip && chip.closest('.interest-tag-panel')) {
+        ev.preventDefault();
         const tag = chip.dataset.tag || 'all';
         applyTagFilter(tag);
       }
@@ -839,269 +977,489 @@ function initInterestTagPanel() {
 </script>
 
 <style>
-  .interest-tag-panel {
-    background: var(--color-bg-secondary);
-    border: 1px solid var(--color-border);
-    border-radius: var(--radius-md);
-    padding: var(--space-md);
-    margin-bottom: var(--space-lg);
+  /* ============================================================
+     Modern Apple-style panel.
+
+     SCOPING STRATEGY (important):
+     The panel container `.interest-tag-panel` itself is SSR-rendered and gets
+     Astro's data-astro-cid attribute, so its selector stays scoped.
+
+     But all interactive children (chips, pills, summary bar) are rebuilt at
+     RUNTIME via JS innerHTML — those new DOM nodes do NOT have the scoping
+     attribute, so a plain scoped selector wouldn't match them.
+
+     Astro's `:global()` per-selector escape hatch solves this cleanly:
+     `.interest-tag-panel :global(.itp-foo)` keeps the parent scoped (no
+     site-wide leak) while opting the inner selector out of scoping so it
+     matches both SSR and JS-rendered nodes.
+
+     Keep the `.itp-` prefix discipline for new selectors so we never collide.
+     ============================================================ */
+
+  /* Honor [hidden] on flex/inline-flex elements (Oracle review). */
+  .interest-tag-panel :global([hidden]) {
+    display: none !important;
   }
 
-  .itp-header {
+  .interest-tag-panel {
+    background: linear-gradient(135deg, #FFFFFF 0%, var(--color-bg-secondary) 100%);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-lg);
+    padding: var(--space-lg);
+    margin-bottom: var(--space-lg);
+    box-shadow: var(--shadow-sm);
+    transition: box-shadow 0.2s cubic-bezier(0.16, 1, 0.3, 1);
+  }
+  .interest-tag-panel:hover {
+    box-shadow: var(--shadow-md);
+  }
+
+  /* Header --------------------------------------------------- */
+  .interest-tag-panel :global(.itp-header) {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    gap: var(--space-sm);
-    margin-bottom: var(--space-sm);
+    gap: var(--space-md);
+    margin-bottom: var(--space-md);
   }
-  .itp-header-left {
+  .interest-tag-panel :global(.itp-header-left) {
     display: flex;
     align-items: center;
     gap: var(--space-sm);
     flex-wrap: wrap;
   }
-  .itp-label {
-    font-size: 0.95rem;
-    font-weight: 600;
+  .interest-tag-panel :global(.itp-label) {
+    font-size: 1rem;
+    font-weight: 700;
     color: var(--color-text);
+    letter-spacing: -0.01em;
   }
-  .itp-match-badge {
+  .interest-tag-panel :global(.itp-match-badge) {
     display: inline-flex;
     align-items: center;
-    padding: 2px var(--space-sm);
+    padding: 3px var(--space-sm);
     border-radius: 999px;
-    background: var(--color-accent);
-    color: var(--color-text);
+    background: linear-gradient(135deg, var(--color-accent) 0%, #FFA000 100%);
+    color: #FFFFFF;
     font-size: 0.72rem;
-    font-weight: 600;
+    font-weight: 700;
     letter-spacing: 0.02em;
+    box-shadow: 0 1px 3px rgba(252, 185, 36, 0.4);
   }
-  .itp-toggle {
-    font-size: 0.8rem;
+
+  /* Toggle button (top + bottom collapse) -------------------- */
+  .interest-tag-panel :global(.itp-toggle) {
+    font-size: 0.82rem;
+    font-weight: 600;
     color: var(--color-primary);
-    background: none;
-    border: 1px solid transparent;
-    border-radius: var(--radius-sm);
+    background: var(--color-bg);
+    border: 1px solid var(--color-border);
+    border-radius: 999px;
     cursor: pointer;
     font-family: inherit;
-    padding: var(--space-xs) var(--space-sm);
-    transition: background 0.15s, border-color 0.15s;
+    padding: 6px var(--space-md);
+    transition:
+      background 0.2s cubic-bezier(0.16, 1, 0.3, 1),
+      border-color 0.2s cubic-bezier(0.16, 1, 0.3, 1),
+      color 0.2s cubic-bezier(0.16, 1, 0.3, 1),
+      transform 0.15s cubic-bezier(0.16, 1, 0.3, 1),
+      box-shadow 0.15s cubic-bezier(0.16, 1, 0.3, 1);
   }
-  .itp-toggle:hover {
-    background: var(--color-bg);
-    border-color: var(--color-border);
+  .interest-tag-panel :global(.itp-toggle:hover) {
+    background: var(--color-primary);
+    color: #FFFFFF;
+    border-color: var(--color-primary);
+    transform: translateY(-1px);
+    box-shadow: 0 4px 12px rgba(245, 124, 34, 0.25);
   }
-  .itp-toggle:focus-visible {
+  .interest-tag-panel :global(.itp-toggle:active) {
+    transform: translateY(0);
+  }
+  .interest-tag-panel :global(.itp-toggle:focus-visible) {
     outline: 2px solid var(--color-primary);
     outline-offset: 2px;
   }
 
-  /* Chips ----------------------------------------------------- */
-  .itp-chips-row,
-  .itp-all-tags {
+  /* Selected filters summary (visible when 1+ tags active) -- */
+  .interest-tag-panel :global(.itp-selected-summary) {
     display: flex;
+    align-items: center;
     flex-wrap: wrap;
     gap: var(--space-xs);
+    padding: var(--space-sm) var(--space-md);
+    margin-bottom: var(--space-sm);
+    background: rgba(245, 124, 34, 0.06);
+    border: 1px solid rgba(245, 124, 34, 0.2);
+    border-radius: var(--radius-md);
+  }
+  .interest-tag-panel :global(.itp-selected-label) {
+    font-size: 0.78rem;
+    font-weight: 600;
+    color: var(--color-primary);
+    margin-right: var(--space-xs);
+  }
+  .interest-tag-panel :global(.itp-selected-pill) {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 4px 6px 4px var(--space-sm);
+    border-radius: 999px;
+    background: var(--color-primary);
+    color: #FFFFFF;
+    border: none;
+    cursor: pointer;
+    font-family: inherit;
+    font-size: 0.78rem;
+    font-weight: 600;
+    transition:
+      transform 0.15s cubic-bezier(0.16, 1, 0.3, 1),
+      background 0.15s cubic-bezier(0.16, 1, 0.3, 1),
+      box-shadow 0.15s cubic-bezier(0.16, 1, 0.3, 1);
+  }
+  .interest-tag-panel :global(.itp-selected-pill:hover) {
+    background: var(--color-primary-hover);
+    transform: translateY(-1px);
+    box-shadow: 0 2px 6px rgba(245, 124, 34, 0.3);
+  }
+  .interest-tag-panel :global(.itp-selected-pill:focus-visible) {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
+  }
+  .interest-tag-panel :global(.itp-selected-pill-x) {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 18px;
+    height: 18px;
+    border-radius: 50%;
+    background: rgba(255, 255, 255, 0.25);
+    font-size: 0.85rem;
+    line-height: 1;
+    transition: background 0.15s;
+  }
+  .interest-tag-panel :global(.itp-selected-pill:hover .itp-selected-pill-x) {
+    background: rgba(255, 255, 255, 0.4);
+  }
+  .interest-tag-panel :global(.itp-selected-clear) {
+    margin-left: auto;
+    padding: 4px var(--space-sm);
+    background: transparent;
+    border: 1px solid var(--color-border);
+    border-radius: 999px;
+    color: var(--color-text-muted);
+    font-family: inherit;
+    font-size: 0.75rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.15s cubic-bezier(0.16, 1, 0.3, 1);
+  }
+  .interest-tag-panel :global(.itp-selected-clear:hover) {
+    color: var(--color-danger);
+    border-color: var(--color-danger);
+    background: rgba(239, 68, 68, 0.05);
+  }
+  .interest-tag-panel :global(.itp-selected-clear:focus-visible) {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
+  }
+
+  /* Chips ---------------------------------------------------- */
+  .interest-tag-panel :global(.itp-chips-row),
+  .interest-tag-panel :global(.itp-all-tags) {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
     align-items: center;
   }
 
-  /* A chip-wrap groups the chip body button + the star button as siblings.
-     This keeps both buttons separately focusable (keyboard a11y) and avoids
-     the invalid "button inside button" markup that the previous version had. */
-  .itp-chip-wrap {
+  /* Standalone "전체" chip — always visible, distinct treatment. */
+  .interest-tag-panel :global(.itp-chip-all) {
+    display: inline-flex;
+    align-items: center;
+    padding: 6px var(--space-md);
+    border: 1px solid var(--color-border);
+    border-radius: 999px;
+    background: var(--color-bg);
+    color: var(--color-text-muted);
+    cursor: pointer;
+    font-family: inherit;
+    font-size: 0.8rem;
+    font-weight: 600;
+    line-height: 1.2;
+    transition:
+      background 0.2s cubic-bezier(0.16, 1, 0.3, 1),
+      color 0.2s cubic-bezier(0.16, 1, 0.3, 1),
+      border-color 0.2s cubic-bezier(0.16, 1, 0.3, 1),
+      transform 0.15s cubic-bezier(0.16, 1, 0.3, 1),
+      box-shadow 0.15s cubic-bezier(0.16, 1, 0.3, 1);
+  }
+  .interest-tag-panel :global(.itp-chip-all:hover) {
+    color: var(--color-text);
+    border-color: var(--color-primary);
+    transform: translateY(-1px);
+  }
+  .interest-tag-panel :global(.itp-chip-all.active) {
+    background: var(--color-text);
+    color: #FFFFFF;
+    border-color: var(--color-text);
+    box-shadow: 0 2px 6px rgba(47, 43, 49, 0.2);
+  }
+  .interest-tag-panel :global(.itp-chip-all:focus-visible) {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
+  }
+
+  /* Chip-wrap groups chip body + star button as siblings. */
+  .interest-tag-panel :global(.itp-chip-wrap) {
     display: inline-flex;
     align-items: stretch;
     border-radius: 999px;
     overflow: hidden;
     border: 1px solid var(--color-border);
     background: var(--color-bg);
-    transition: border-color 0.15s;
+    transition:
+      border-color 0.2s cubic-bezier(0.16, 1, 0.3, 1),
+      transform 0.15s cubic-bezier(0.16, 1, 0.3, 1),
+      box-shadow 0.15s cubic-bezier(0.16, 1, 0.3, 1);
   }
-  .itp-chip-wrap:hover {
+  .interest-tag-panel :global(.itp-chip-wrap:hover) {
     border-color: var(--color-primary);
+    transform: translateY(-1px);
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
   }
-  .itp-chip-wrap:focus-within {
+  .interest-tag-panel :global(.itp-chip-wrap:focus-within) {
     outline: 2px solid var(--color-primary);
     outline-offset: 2px;
   }
+  .interest-tag-panel :global(.itp-chip-wrap.active) {
+    background: var(--color-primary);
+    border-color: var(--color-primary);
+    box-shadow: 0 2px 8px rgba(245, 124, 34, 0.3);
+  }
 
-  .itp-chip {
+  .interest-tag-panel :global(.itp-chip) {
     display: inline-flex;
     align-items: center;
-    gap: 4px;
-    padding: 3px var(--space-sm);
-    border-radius: 0;
+    gap: 5px;
+    padding: 6px var(--space-sm);
     background: transparent;
     color: var(--color-text-muted);
     border: none;
     cursor: pointer;
     font-family: inherit;
-    font-size: 0.78rem;
+    font-size: 0.8rem;
+    font-weight: 500;
     line-height: 1.2;
-    transition: background 0.15s, color 0.15s;
+    transition: color 0.15s cubic-bezier(0.16, 1, 0.3, 1);
   }
-  /* Standalone chips (the "전체" chip is not wrapped) keep their own border/radius. */
-  .itp-chip-all {
-    border: 1px solid var(--color-border);
-    border-radius: 999px;
-    padding: 3px var(--space-sm);
-    background: var(--color-bg);
-  }
-  .itp-chip:hover {
+  .interest-tag-panel :global(.itp-chip:hover) {
     color: var(--color-text);
   }
-  .itp-chip.active,
-  .itp-chip-all.active {
-    background: var(--color-primary);
-    color: white;
+  .interest-tag-panel :global(.itp-chip-wrap.active .itp-chip) {
+    color: #FFFFFF;
   }
-  .itp-chip-wrap:has(.itp-chip.active) {
-    border-color: var(--color-primary);
+  .interest-tag-panel :global(.itp-chip-label) {
+    font-weight: 600;
   }
-  .itp-chip.active .itp-chip-count {
-    color: rgba(255, 255, 255, 0.85);
-  }
-  .itp-chip-label {
-    font-weight: 500;
-  }
-  .itp-chip-count {
+  .interest-tag-panel :global(.itp-chip-count) {
     font-size: 0.7rem;
+    font-weight: 500;
     color: var(--color-text-muted);
     font-variant-numeric: tabular-nums;
+    padding: 1px 6px;
+    background: rgba(0, 0, 0, 0.04);
+    border-radius: 999px;
+  }
+  .interest-tag-panel :global(.itp-chip-wrap.active .itp-chip-count) {
+    color: #FFFFFF;
+    background: rgba(255, 255, 255, 0.2);
   }
 
-  /* Star button — sibling of chip body inside chip-wrap.
-     Real <button>, fully keyboard-accessible. */
-  .itp-chip-star {
+  /* Star button (sibling of chip body inside chip-wrap). */
+  .interest-tag-panel :global(.itp-chip-star) {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    min-width: 22px;
-    padding: 0 6px;
+    min-width: 28px;
+    padding: 0 8px;
     background: transparent;
     color: var(--color-text-muted);
     border: none;
     border-left: 1px solid var(--color-border);
     cursor: pointer;
     font-family: inherit;
-    font-size: 0.85rem;
+    font-size: 0.95rem;
     user-select: none;
-    transition: background 0.15s, color 0.15s;
+    transition:
+      background 0.15s cubic-bezier(0.16, 1, 0.3, 1),
+      color 0.15s cubic-bezier(0.16, 1, 0.3, 1),
+      transform 0.15s cubic-bezier(0.16, 1, 0.3, 1);
   }
-  .itp-chip-star:hover {
-    background: rgba(252, 185, 36, 0.2);
+  .interest-tag-panel :global(.itp-chip-star:hover) {
+    background: rgba(252, 185, 36, 0.15);
     color: var(--color-accent);
+    transform: scale(1.15);
   }
-  .itp-chip-star:focus-visible {
+  .interest-tag-panel :global(.itp-chip-star:focus-visible) {
     outline: 2px solid var(--color-primary);
     outline-offset: -2px;
   }
-  .itp-chip-star.on {
+  .interest-tag-panel :global(.itp-chip-star.on) {
     color: var(--color-accent);
   }
-  .itp-chip-wrap:has(.itp-chip.active) .itp-chip-star {
-    color: white;
+  .interest-tag-panel :global(.itp-chip-wrap.active .itp-chip-star) {
+    color: rgba(255, 255, 255, 0.85);
     border-left-color: rgba(255, 255, 255, 0.3);
   }
-  .itp-chip-wrap:has(.itp-chip.active) .itp-chip-star.on {
+  .interest-tag-panel :global(.itp-chip-wrap.active .itp-chip-star.on) {
+    color: var(--color-accent);
+  }
+  .interest-tag-panel :global(.itp-chip-wrap.active .itp-chip-star:hover) {
+    background: rgba(255, 255, 255, 0.15);
     color: var(--color-accent);
   }
 
   /* Expanded sections ---------------------------------------- */
-  .itp-expanded {
+  .interest-tag-panel :global(.itp-expanded) {
     margin-top: var(--space-md);
+    padding-top: var(--space-md);
+    border-top: 1px solid var(--color-border);
     display: flex;
     flex-direction: column;
-    gap: var(--space-md);
+    gap: var(--space-lg);
+    animation: itpFadeIn 0.3s cubic-bezier(0.16, 1, 0.3, 1);
   }
-  .itp-section {
+  @keyframes itpFadeIn {
+    from {
+      opacity: 0;
+      transform: translateY(-4px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+  .interest-tag-panel :global(.itp-section) {
     display: flex;
     flex-direction: column;
     gap: var(--space-sm);
   }
-  .itp-section-header {
+  .interest-tag-panel :global(.itp-section-header) {
     display: flex;
     align-items: center;
     justify-content: space-between;
     gap: var(--space-sm);
   }
-  .itp-section-title {
-    font-size: 0.85rem;
-    font-weight: 600;
+  .interest-tag-panel :global(.itp-section-title) {
+    font-size: 0.9rem;
+    font-weight: 700;
     color: var(--color-text);
     margin: 0;
+    letter-spacing: -0.005em;
   }
-  .itp-section-count {
+  .interest-tag-panel :global(.itp-section-count) {
     color: var(--color-text-muted);
-    font-weight: 400;
+    font-weight: 500;
     font-size: 0.78rem;
   }
-  .itp-section-hint {
+  .interest-tag-panel :global(.itp-section-hint) {
     font-size: 0.78rem;
     color: var(--color-text-muted);
     margin: 0;
+    padding: var(--space-sm) var(--space-md);
+    background: rgba(252, 185, 36, 0.06);
+    border: 1px solid rgba(252, 185, 36, 0.2);
+    border-radius: var(--radius-md);
+    line-height: 1.5;
   }
-  .itp-clear {
+  .interest-tag-panel :global(.itp-clear) {
     font-size: 0.78rem;
     color: var(--color-text-muted);
-    background: none;
+    background: transparent;
+    border: 1px solid var(--color-border);
+    border-radius: 999px;
+    cursor: pointer;
+    font-family: inherit;
+    padding: 4px var(--space-sm);
+    transition: all 0.15s cubic-bezier(0.16, 1, 0.3, 1);
+  }
+  .interest-tag-panel :global(.itp-clear:hover) {
+    color: var(--color-danger);
+    border-color: var(--color-danger);
+    background: rgba(239, 68, 68, 0.05);
+  }
+  .interest-tag-panel :global(.itp-clear:focus-visible) {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
+  }
+
+  /* Bottom collapse footer ----------------------------------- */
+  .interest-tag-panel :global(.itp-expanded-footer) {
+    display: flex;
+    justify-content: center;
+    padding-top: var(--space-md);
+    border-top: 1px solid var(--color-border);
+  }
+
+  /* Interest pills (saved interests in expanded panel) ------- */
+  .interest-tag-panel :global(.itp-interests-row) {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+  }
+  .interest-tag-panel :global(.itp-interest-pill) {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    padding: 4px 6px 4px var(--space-sm);
+    border-radius: 999px;
+    background: linear-gradient(135deg, var(--color-accent) 0%, #FFA000 100%);
+    color: #FFFFFF;
     border: none;
     cursor: pointer;
     font-family: inherit;
-    text-decoration: underline;
-    padding: 0;
-  }
-  .itp-clear:hover {
-    color: var(--color-primary);
-  }
-
-  /* Interest pills ------------------------------------------- */
-  .itp-interests-row {
-    display: flex;
-    flex-wrap: wrap;
-    gap: var(--space-xs);
-  }
-  .itp-interest-pill {
-    display: inline-flex;
-    align-items: center;
-    gap: 4px;
-    padding: 3px 6px 3px var(--space-sm);
-    border-radius: 999px;
-    background: var(--color-accent);
-    color: var(--color-text);
-    border: 1px solid var(--color-accent);
-    cursor: pointer;
-    font-family: inherit;
     font-size: 0.78rem;
-    font-weight: 500;
-    transition: filter 0.15s;
+    font-weight: 600;
+    box-shadow: 0 1px 3px rgba(252, 185, 36, 0.3);
+    transition:
+      transform 0.15s cubic-bezier(0.16, 1, 0.3, 1),
+      box-shadow 0.15s cubic-bezier(0.16, 1, 0.3, 1);
   }
-  .itp-interest-pill:hover {
-    filter: brightness(0.95);
+  .interest-tag-panel :global(.itp-interest-pill:hover) {
+    transform: translateY(-1px);
+    box-shadow: 0 4px 8px rgba(252, 185, 36, 0.4);
   }
-  .itp-interest-pill-x {
+  .interest-tag-panel :global(.itp-interest-pill:focus-visible) {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
+  }
+  .interest-tag-panel :global(.itp-interest-pill-x) {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    width: 16px;
-    height: 16px;
+    width: 18px;
+    height: 18px;
     border-radius: 50%;
-    background: rgba(0, 0, 0, 0.12);
-    font-size: 0.75rem;
+    background: rgba(255, 255, 255, 0.3);
+    font-size: 0.85rem;
     line-height: 1;
+    transition: background 0.15s;
+  }
+  .interest-tag-panel :global(.itp-interest-pill:hover .itp-interest-pill-x) {
+    background: rgba(255, 255, 255, 0.5);
   }
 
   /* Filtered results container ------------------------------- */
-  .itp-filtered-results {
+  .interest-tag-panel :global(.itp-filtered-results) {
     margin-top: var(--space-md);
   }
-  .itp-filtered-header {
+  .interest-tag-panel :global(.itp-filtered-header) {
     margin-bottom: var(--space-md);
     font-size: 0.9rem;
     color: var(--color-text-muted);
     font-weight: 500;
   }
-  .itp-filtered-empty {
+  .interest-tag-panel :global(.itp-filtered-empty) {
     text-align: center;
     padding: var(--space-xl);
     color: var(--color-text-muted);
@@ -1110,8 +1468,43 @@ function initInterestTagPanel() {
 
   /* Mobile --------------------------------------------------- */
   @media (max-width: 768px) {
-    .itp-header {
+    .interest-tag-panel {
+      padding: var(--space-md);
+      border-radius: var(--radius-md);
+    }
+    .interest-tag-panel :global(.itp-header) {
       flex-wrap: wrap;
+    }
+    .interest-tag-panel :global(.itp-chip),
+    .interest-tag-panel :global(.itp-chip-all) {
+      padding: 8px var(--space-sm);
+      font-size: 0.85rem;
+    }
+    .interest-tag-panel :global(.itp-chip-star) {
+      min-width: 32px;
+      font-size: 1rem;
+    }
+    .interest-tag-panel :global(.itp-selected-clear) {
+      margin-left: 0;
+      width: 100%;
+      margin-top: var(--space-xs);
+    }
+  }
+
+  /* Reduced motion respect ----------------------------------- */
+  @media (prefers-reduced-motion: reduce) {
+    .interest-tag-panel,
+    .interest-tag-panel :global(.itp-toggle),
+    .interest-tag-panel :global(.itp-chip-wrap),
+    .interest-tag-panel :global(.itp-chip-all),
+    .interest-tag-panel :global(.itp-chip-star),
+    .interest-tag-panel :global(.itp-selected-pill),
+    .interest-tag-panel :global(.itp-interest-pill) {
+      transition: none;
+      transform: none !important;
+    }
+    .interest-tag-panel :global(.itp-expanded) {
+      animation: none;
     }
   }
 </style>


### PR DESCRIPTION
## Summary

사용자 피드백 3건 대응. Oracle 아키텍처 리뷰 + 프로덕션 문서 리서치 기반:

1. **접기 버튼이 동작을 안함** → 위임 핸들러에서 `ev.target`을 Element로 정규화, 상/하 collapse 버튼 동시 지원
2. **관심사 & 태그 UI가 회색 박스** → Apple 스타일 리디자인 (gradient, shadow, micro-interactions)
3. **멀티 태그 기능도 안됨** → `Set<string>` 기반 다중 선택 + OR 의미론 + URL 반복 키 + 활성 칩 상단 고정

## 변경 요약

### 🔧 멀티 태그 필터 (Oracle 리뷰)
- `state.activeTag: string` → `state.activeTags: Set<string>`
- 클릭 = 토글 / '전체' = 모두 해제
- **OR 의미론** (facet 내): `a.tags.some(t => active.has(t))`. AND (facet 간: 검색 ∩ origin ∩ 태그)
- URL: `?tag=ai&tag=llm` (반복 키, 쉼표 안전)
- **활성 태그 상단 6칩 고정** (세려발: 활성 → 관심사 → 인기) — 비인기 태그 선택 시 사라지는 버그 방지
- \"활성 필터\" 요약 바: `#ai×` `#llm×` + \"모두 지우기\"
- 모든 칩에 \`aria-pressed\`

### 🎨 UI 리디자인
- 패널: 흰색→cream gradient + 12px radius + shadow hover 전환
- cubic-bezier(0.16, 1, 0.3, 1) easing 전체
- Hover lift(-1px), active 시 shadow 확대
- 칩: rounded-full, 카운트는 분리된 pill 배지, active 시 primary orange + shadow
- 별표(☆): hover scale(1.15)
- 섹션 hint: accent 배경으로 안내문처럼
- 펼침 애니메이션 (prefers-reduced-motion 존중)
- 모바일: 탭 타겟 확대
- **버그 수정**: \`[hidden]\` !important로 빈 match-badge \"주황색 대시\" 잔상 제거

### 🛡️ 견고성
- 위임 클릭 핸들러에서 `ev.target`을 Element로 정규화 (Text 노드 타겟 시 \`closest()\` 실패 버그)
- 상/하 collapse 버튼 둘 다 지원 + 하단 클릭 시 scrollIntoView

## CSS 스코프 전략

**`<style is:global>` 전체 변환 대신 Astro `:global()` per-selector 사용** ([공식 문서](https://docs.astro.build/en/guides/styling/#global-styles)):

- 패널 컨테이너 \`.interest-tag-panel\`은 scoped 유지 (사이트 전역 노출 방지)
- 모든 `.itp-*` 내부 선택자는 `.interest-tag-panel :global(.itp-foo)`로 래핑 → 동적 innerHTML 렌더링 DOM에도 매칭
- 새 트러블슈팅 문서: `docs/troubleshooting/astro-scoped-styles-dynamic-dom.md`

## 수동 QA (Playwright)

| 시나리오 | 결과 |
|---|---|
| 딥링크 `/articles?tag=ai&tag=dev` | ✅ 두 칩 active + 요약 바 + 157건 |
| 칩 토글 (추가/제거) | ✅ Set 업데이트 + URL 동기화 |
| '전체' 클릭 | ✅ 모든 active 해제, URL 비움 |
| 상단 collapse 버튼 | ✅ 패널 펼침/접힘 |
| 하단 collapse 버튼 | ✅ 접힘 + 상단으로 스크롤 |
| 활성 칩 시각 상태 | ✅ \`rgb(245, 124, 34)\` (primary orange) |
| 관심사 ☆ 토글 | ✅ localStorage 저장, 매칭 카드 강조 |

## 검증

- \`bun run validate\` ✅ (299 files)
- \`bun run validate:docs\` ✅ (55 docs, +1 신규)
- \`bun run validate:docs --check-coverage\` ✅
- \`bun run build\` ✅ (625 pages)
- \`bun run test\` ✅ (263/263)

## 관련 파일

- \`src/components/InterestTagPanel.astro\` — 멀티 태그 로직 + UI 리디자인
- \`docs/features/interest-tag-panel.md\` — 업데이트 (멀티 태그 동작 흐름, 제약, 변경 이력)
- \`docs/troubleshooting/astro-scoped-styles-dynamic-dom.md\` — 신규 (\`:global()\` 해법 기록)