### PR TITLE
fix(summarize): reject self-referential openings in RSS summaries

### DIFF
--- a/docs/troubleshooting/rss-summary-self-referential-opening.md
+++ b/docs/troubleshooting/rss-summary-self-referential-opening.md
@@ -1,0 +1,166 @@
+# RSS 요약이 "이 콘텐츠는" 같은 자기 지시적 서두로 시작되는 문제
+
+> Gemini가 생성한 한국어 구조화 요약의 각 섹션 첫 문장이 "이 콘텐츠는", "본 콘텐츠는", "이 기사는" 등 불필요한 자기 지시적 표현으로 시작되어 본문 가독성을 해치던 문제
+
+## 증상
+
+`src/data/feeds/YYYY/MM/{id}.json`의 `description` 필드에 저장되는 한국어 구조화 요약이 각 섹션(`## 개요`, `## 주요 내용`, `## 시사점`)의 첫 문장을 자기 지시적 표현으로 시작한다. 본문이 주제를 곧바로 설명하지 못하고 "이 기사는 ~을 다룬다"처럼 메타-서술로 한 번 감싸져 나온다.
+
+**대표 사례**:
+
+```
+## 개요
+
+이 콘텐츠는 Vercel 블로그가 공개한 AGENTS.md 실험을 다룬다. ...
+
+## 시사점
+
+이 기사는 프로젝트 루트의 단일 문서 전략이 효과적임을 시사한다.
+```
+
+**기대 형식** — 주제(주어)로 바로 시작:
+
+```
+## 개요
+
+Vercel 블로그가 공개한 AGENTS.md 실험은 Next.js 16 API 평가에서 Skills 기반 접근보다 높은 정확도(70% vs 53%)를 기록했다.
+
+## 시사점
+
+프로젝트 루트의 단일 "항상 보이는" 문서가 "찾아야 하는" Skills보다 실질 성능이 높다.
+```
+
+**재현 환경**: GitHub Actions(`summarize.yml`), Bun 런타임, Gemini 2.5 Flash-Lite. 축적된 feed article에서 다수 발견됨. 사용자가 명시적으로 불필요하다고 지적.
+
+## 원인
+
+두 가지 요인이 겹쳤다.
+
+**원인 1 — 프롬프트가 직접 자기 지시적 서두를 유도했다.**
+
+`scripts/summarize-articles.ts`의 `SUMMARIZE_PROMPT`가 각 섹션 예시에서 "이 콘텐츠"를 명시적으로 사용했다:
+
+```ts
+## 개요
+(1~2문장으로 이 콘텐츠가 무엇인지 설명)
+
+## 시사점
+(이 콘텐츠의 의의, 결론, 또는 실무 적용 가능성을 1~2문장으로 정리)
+```
+
+Gemini는 지시 안의 명사 표현을 출력에도 그대로 반영하는 경향이 있다. "이 콘텐츠가 무엇인지"를 설명하라고 하니 실제 생성물에서 "이 콘텐츠는 ~을 설명한다"로 시작해버렸다.
+
+**원인 2 — 요약 품질 가드가 구조만 검증하고 스타일은 검증하지 않았다.**
+
+기존 `looksLikeKoreanStructuredSummary()`는 `## 주요 내용` 또는 `## 시사점` 헤딩 유무만 확인한다. 따라서 `## 개요\n이 콘텐츠는...`처럼 자기 지시적 서두가 포함된 요약도 "정상"으로 통과해서 feeds JSON에 그대로 저장됐다.
+
+## 해결 방법
+
+**Producer 측(프롬프트)에서 예방**하고, **Consumer 측(runtime validator)에서 방어**하는 이중 가드를 적용한다.
+
+### 1. 프롬프트에서 자기 지시적 서두 금지 명시
+
+```diff
+ 규칙:
+ - 아래 형식을 반드시 따를 것
+ - 전문 용어는 원문 그대로 유지 (예: API, SDK, LLM, React 등)
+ - 주관적 평가 없이 사실만 전달
+ - 최대 ${MAX_DESCRIPTION_LENGTH}자 이내
++- **자기 지시적 서두 절대 금지.** 각 섹션의 첫 문장을 "이 콘텐츠는", "본 콘텐츠는",
++  "이 기사는", "본 기사는", "해당 기사는", "이 글은", "본 글은", "해당 글은",
++  "이 아티클은", "본 아티클은", "이 영상은", "본 영상은", "이 포스트는", "본 포스트는",
++  "이 내용은", "본 내용은" 등 자기 지시적 표현으로 시작하지 마시오.
++  기사·영상이 다루는 **주제·대상(주어)**으로 바로 시작하시오.
++  - ✅ 올바른 예: "Vercel이 발표한 새 실험은 ...", "OpenAI의 o1 모델은 ..."
++  - ❌ 잘못된 예: "이 기사는 Vercel 실험을 다룬다"
+
+ 형식:
+ ## 개요
+
+-(1~2문장으로 이 콘텐츠가 무엇인지 설명)
++(1~2문장. 주제·대상을 주어로 하여 핵심 내용 요약. 주제로 바로 시작.)
+ ...
+ ## 시사점
+
+-(이 콘텐츠의 의의, 결론, 또는 실무 적용 가능성을 1~2문장으로 정리)
++(1~2문장. 주제·대상이 갖는 의의, 결론, 실무 적용 가능성. 주어로 바로 시작.)
+```
+
+### 2. Runtime validator로 regression 방어
+
+프롬프트만으로는 모델이 때때로 regress한다. 구조 검증(`looksLikeKoreanStructuredSummary`)과 별개로 **스타일 검증(`hasSelfReferentialOpening`)**을 추가해 regex로 패턴을 차단한다.
+
+**규칙**:
+- `(이|본|해당) + (콘텐츠|기사|글|아티클|포스트|영상|문서|뉴스|내용|자료|텍스트) + (은|는|이|가|을|를|의|에서)`
+- 본문 산문 라인에만 적용 (마크다운 헤딩 `##`, 불릿 `-` 은 대상 외)
+- 명사 리스트 기반이 아닌 **regex 패턴**이므로 새로운 변형(`본 기사는` → `해당 포스트는` 등)이 등장해도 바로 걸러낸다
+
+```ts
+const SELF_REFERENTIAL_PATTERN = /^\s*(이|본|해당)\s*(콘텐츠|기사|글|아티클|포스트|영상|문서|뉴스|내용|자료|텍스트)\s*(은|는|이|가|을|를|의|에서)/;
+
+export function hasSelfReferentialOpening(text: string): boolean {
+  const lines = text.split(/\r?\n/);
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    if (/^#+\s/.test(trimmed)) continue; // skip markdown headings
+    if (/^[-*]\s/.test(trimmed)) continue; // skip bullet items
+    if (SELF_REFERENTIAL_PATTERN.test(trimmed)) {
+      return true;
+    }
+  }
+  return false;
+}
+```
+
+**명사(주제) 기반 비교 — 오탐 방지**:
+- ✅ 걸림 — "이 기사는 AI를 다룬다" (기사 = 자기 지시적)
+- ✅ 걸림 — "본 콘텐츠는 중요하다" (콘텐츠 = 자기 지시적)
+- ❌ 안 걸림 — "이 기술은 혁신적이다" (기술 = 본문의 주제)
+- ❌ 안 걸림 — "본 프레임워크는 구성 요소가 많다" (프레임워크 = 본문의 주제)
+
+### 3. 검증 실패 시 stale clear 후 재시도
+
+`summarizeArticles` 루프에서 Gemini 응답을 받은 직후 `hasSelfReferentialOpening`을 통과시킨다. 실패 시 stale description을 clear하고 `errors`에 기록한 뒤 continue. 다음 run에서 가드가 다시 해당 article을 픽업해 재요약한다 (기존 fetch/API 실패 폴백과 동일한 패턴).
+
+```ts
+// Step 2.5: Validate no self-referential openings (user preference).
+if (hasSelfReferentialOpening(summary)) {
+  const message = `Rejected self-referential opening for: ${title}`;
+  console.warn(`  ⚠️  ${message}`);
+  if (!dryRun) {
+    await clearStaleDescription(filePath, data);
+  }
+  errors.push(message);
+  continue;
+}
+```
+
+## 관련 파일
+
+| 파일 | 변경 내용 |
+|------|----------|
+| `scripts/summarize-articles.ts` | `SUMMARIZE_PROMPT` 개정 (자기 지시적 서두 금지 규칙 + 주제 중심 섹션 가이드 추가), `hasSelfReferentialOpening` validator 함수 신규 export, `summarizeArticles` 루프에 Step 2.5 검증 추가 |
+| `tests/summarize-articles.test.ts` | `hasSelfReferentialOpening` describe 블록 신규 추가 (positive/negative 케이스, 섹션 구조 내부 검증, 헤딩·불릿 무시 확인) |
+
+## 예방 조치
+
+- **Producer/Consumer 이중 가드 유지**: Gemini 프롬프트 수정만으로 안주하지 않는다. AI는 때때로 규칙을 잊으므로 runtime validator가 필요하다.
+- **새 자기 지시적 변형 감지 시**: 사용자가 새 형태 ("이 다큐멘터리는" 등)를 지적하면, 명사 리스트를 확장하기보다 **regex 패턴 자체를 확장**하는 방향으로 대응한다. 명사 리스트는 필연적으로 불완전하다.
+- **요약 품질 회귀 감시**: `Article Summarization` 워크플로우 로그에서 `Rejected self-referential opening` 경고 빈도를 모니터링한다. 빈도가 높으면 프롬프트 약화 또는 모델 변경 신호.
+- **기존 feed 데이터 백필**: 과거 저장된 description에 자기 지시적 서두가 남아 있어도 `looksLikeKoreanStructuredSummary` 가드를 통과하므로 자동 재요약되지 않는다. 필요 시 `description` 필드를 검사해 `hasSelfReferentialOpening`이 true인 항목을 `clearStaleDescription`으로 비워두는 일회성 백필 스크립트가 필요할 수 있다.
+- **Curated는 영향 없음**: curated/ 내 사용자 직접 입력 description은 `allowResummarize=false`로 보호되며 Gemini가 건드리지 않는다. 이 규칙은 유지된다.
+
+---
+
+## 관련 문서
+
+- [RSS 수집 article의 description이 영문 원문으로 노출되는 문제](./rss-summary-english-fallback.md) — 구조 검증 가드 `looksLikeKoreanStructuredSummary` 도입 배경
+- [scripts/summarize-articles.ts](../../scripts/summarize-articles.ts)
+- [tests/summarize-articles.test.ts](../../tests/summarize-articles.test.ts)
+
+## 변경 이력
+
+| 날짜 | 변경 내용 |
+|------|----------|
+| 2026-04-21 | 최초 작성 — 프롬프트 개정 + `hasSelfReferentialOpening` runtime validator 도입으로 자기 지시적 서두 차단 |

--- a/scripts/summarize-articles.ts
+++ b/scripts/summarize-articles.ts
@@ -59,6 +59,38 @@ export function looksLikeKoreanStructuredSummary(text: string): boolean {
   return /##\s*주요\s*내용|##\s*시사점/.test(text);
 }
 
+const SELF_REFERENTIAL_PATTERN = /^\s*(이|본|해당)\s*(콘텐츠|기사|글|아티클|포스트|영상|문서|뉴스|내용|자료|텍스트)\s*(은|는|이|가|을|를|의|에서)/;
+
+/**
+ * Detects self-referential openings like "이 콘텐츠는", "본 기사는", "해당 글은".
+ *
+ * Uses a regex pattern (not a brittle phrase list) to catch the article-like
+ * noun family: 이/본/해당 + 콘텐츠/기사/글/아티클/포스트/영상/문서/뉴스/내용/자료/텍스트 + 조사.
+ *
+ * Scans prose lines only — markdown headings (##) and bullet items (-) are
+ * ignored because they describe structure/sub-points, not the article itself.
+ *
+ * The user explicitly marked these openings as unwanted filler. The Gemini
+ * prompt already instructs the model to avoid them, but this validator acts
+ * as defense-in-depth: regressed prompt outputs are rejected at runtime and
+ * the article is re-queued for summarization on the next run.
+ *
+ * Related: docs/troubleshooting/rss-summary-self-referential-opening.md
+ */
+export function hasSelfReferentialOpening(text: string): boolean {
+  const lines = text.split(/\r?\n/);
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    if (/^#+\s/.test(trimmed)) continue; // skip markdown headings
+    if (/^[-*]\s/.test(trimmed)) continue; // skip bullet items
+    if (SELF_REFERENTIAL_PATTERN.test(trimmed)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 const SUMMARIZE_PROMPT = `당신은 기술 콘텐츠 요약 전문가입니다. 아래 기사/영상의 핵심 내용을 한국어로 구조화된 요약을 작성해주세요.
 
 규칙:
@@ -66,11 +98,14 @@ const SUMMARIZE_PROMPT = `당신은 기술 콘텐츠 요약 전문가입니다. 
 - 전문 용어는 원문 그대로 유지 (예: API, SDK, LLM, React 등)
 - 주관적 평가 없이 사실만 전달
 - 최대 ${MAX_DESCRIPTION_LENGTH}자 이내
+- **자기 지시적 서두 절대 금지.** 각 섹션의 첫 문장을 "이 콘텐츠는", "본 콘텐츠는", "이 기사는", "본 기사는", "해당 기사는", "이 글은", "본 글은", "해당 글은", "이 아티클은", "본 아티클은", "이 영상은", "본 영상은", "이 포스트는", "본 포스트는", "이 내용은", "본 내용은" 등 자기 지시적 표현으로 시작하지 마시오. 기사·영상이 다루는 **주제·대상(주어)**으로 바로 시작하시오.
+  - ✅ 올바른 예: "Vercel이 발표한 새 실험은 ...", "OpenAI의 o1 모델은 ...", "AGENTS.md 문서는 ..."
+  - ❌ 잘못된 예: "이 기사는 Vercel 실험을 다룬다", "본 콘텐츠는 o1 모델을 소개한다"
 
 형식:
 ## 개요
 
-(1~2문장으로 이 콘텐츠가 무엇인지 설명)
+(1~2문장. 주제·대상을 주어로 하여 핵심 내용을 요약. 주제로 바로 시작하고, 자기 지시적 서두 사용 금지.)
 
 ## 주요 내용
 
@@ -81,7 +116,7 @@ const SUMMARIZE_PROMPT = `당신은 기술 콘텐츠 요약 전문가입니다. 
 
 ## 시사점
 
-(이 콘텐츠의 의의, 결론, 또는 실무 적용 가능성을 1~2문장으로 정리)
+(1~2문장. 주제·대상이 갖는 의의, 결론, 또는 실무 적용 가능성. 주어로 바로 시작하고, 자기 지시적 서두 사용 금지.)
 
 기사 제목: {title}
 
@@ -291,6 +326,19 @@ export async function summarizeArticles(options: SummarizeOptions = {}): Promise
         console.error(`  ${message}`);
         // Same fallback as the fetch-failure branch: clear stale description so it
         // does not linger in the UI between summarize runs.
+        if (!dryRun) {
+          await clearStaleDescription(filePath, data);
+        }
+        errors.push(message);
+        continue;
+      }
+
+      // Step 2.5: Validate no self-referential openings (user preference).
+      // Even though the prompt explicitly forbids them, Gemini sometimes regresses.
+      // Reject and re-queue for re-summarization on next run.
+      if (hasSelfReferentialOpening(summary)) {
+        const message = `Rejected self-referential opening for: ${title}`;
+        console.warn(`  ⚠️  ${message}`);
         if (!dryRun) {
           await clearStaleDescription(filePath, data);
         }

--- a/tests/summarize-articles.test.ts
+++ b/tests/summarize-articles.test.ts
@@ -4,6 +4,7 @@ import { join } from 'path';
 import {
   clearStaleDescription,
   findArticlesNeedingSummary,
+  hasSelfReferentialOpening,
   looksLikeKoreanStructuredSummary,
 } from '../scripts/summarize-articles';
 import { readFile } from 'fs/promises';
@@ -79,6 +80,119 @@ describe('looksLikeKoreanStructuredSummary', () => {
   it('returns false for plain Korean prose without structured headings', () => {
     const text = 'AI 기술이 빠르게 발전하고 있습니다. 다양한 분야에서 응용되고 있습니다.';
     expect(looksLikeKoreanStructuredSummary(text)).toBe(false);
+  });
+});
+
+describe('hasSelfReferentialOpening', () => {
+  // Positive cases: these MUST be detected as self-referential
+  it.each([
+    ['이 콘텐츠는 AI 기술을 다룬다'],
+    ['본 콘텐츠는 새로운 도구를 소개한다'],
+    ['이 기사는 중요한 내용이다'],
+    ['본 기사는 핵심 기술을 소개한다'],
+    ['해당 기사는 분석 내용입니다'],
+    ['이 글은 LLM을 설명한다'],
+    ['본 글은 분석입니다'],
+    ['해당 글은 추첵할 만한 내용이다'],
+    ['이 아티클은 새 도구를 다룬다'],
+    ['본 아티클은 핵심을 설명한다'],
+    ['이 영상은 튜토리얼이다'],
+    ['본 영상은 핵심을 다룬다'],
+    ['이 포스트는 가이드다'],
+    ['본 포스트는 가이드입니다'],
+    ['이 뉴스는 놓칠 수 없다'],
+    ['이 내용은 중요하다'],
+    ['본 문서는 정리된 내용을 담는다'],
+    // whitespace variations
+    ['이  콘텐츠는 마지막 문장'], // double space
+    ['이콘텐츠는 없으므로'], // no space at all
+    // adjacent to leading whitespace
+    ['   이 기사는 서부러 공백'],
+  ])('detects self-referential opening in "%s"', (text) => {
+    expect(hasSelfReferentialOpening(text)).toBe(true);
+  });
+
+  // Negative cases: these MUST NOT be flagged
+  it.each([
+    ['Vercel 블로그가 발표한 새 실험은 Next.js 16 API 대상 평가에서 높은 정확도를 기록했다'],
+    ['AI 에이전트를 프로덕션 환경에서 활용하는 실전 분석'],
+    ['OpenAI의 새 API는 중요한 변화를 가져온다'],
+    ['2026년 AI 동향을 살펴본다'],
+    // "이" / "본" + non-article noun (not self-referential)
+    ['이 기술은 혁신적이다'], // 기술 is the TOPIC, not the article
+    ['본 프레임워크는 구성 요소가 많다'], // 프레임워크 is the topic
+    ['이 제품은 출시되었다'], // 제품 is the topic
+    ['이 회사는 생성형 AI에 집중한다'], // 회사 is the topic
+    ['해당 연구는 새로운 방법론을 제시한다'], // 연구 is the topic
+    // word boundary edge cases
+    ['글자가 큰 폰트를 사용한다'], // 글자 starts with 글 but is different word
+    ['자료산이 풍부한 국가의 경제 전략'], // 자료산 starts with 자료 but different word
+    // empty/whitespace
+    [''],
+    ['   '],
+    ['\n\n'],
+  ])('does not flag non-self-referential text "%s"', (text) => {
+    expect(hasSelfReferentialOpening(text)).toBe(false);
+  });
+
+  it('ignores markdown headings even if they contain the pattern', () => {
+    // "## 이 기사" as a heading is unusual but not prose; ignored by rule
+    const text = [
+      '## 이 기사의 핵심',
+      '',
+      '주제에 대한 내용',
+    ].join('\n');
+    expect(hasSelfReferentialOpening(text)).toBe(false);
+  });
+
+  it('ignores bullet items even if they start with the pattern', () => {
+    const text = [
+      '## 주요 내용',
+      '- 이 기사에서 언급된 포인트',
+    ].join('\n');
+    expect(hasSelfReferentialOpening(text)).toBe(false);
+  });
+
+  it('detects self-referential opening inside a ## 개요 section body', () => {
+    const text = [
+      '## 개요',
+      '',
+      '이 콘텐츠는 AI 도구를 소개한다',
+      '',
+      '## 주요 내용',
+      '- 포인트',
+    ].join('\n');
+    expect(hasSelfReferentialOpening(text)).toBe(true);
+  });
+
+  it('detects self-referential opening inside a ## 시사점 section body', () => {
+    const text = [
+      '## 개요',
+      '저자가 발표한 실험',
+      '',
+      '## 주요 내용',
+      '- 포인트 1',
+      '',
+      '## 시사점',
+      '본 기사는 중요한 통찰을 제공한다',
+    ].join('\n');
+    expect(hasSelfReferentialOpening(text)).toBe(true);
+  });
+
+  it('passes a clean structured summary with subject-first openings', () => {
+    const text = [
+      '## 개요',
+      '',
+      'Vercel이 발표한 새 실험은 AGENTS.md 구조가 Skills보다 높은 정확도를 보였음을 입증했다.',
+      '',
+      '## 주요 내용',
+      '- AGENTS.md 접근법은 70% 통과율을 기록',
+      '- Skills 접근법은 53% 통과율',
+      '',
+      '## 시사점',
+      '예측 가능한 문서가 에이전트 성능을 높인다는 점에서 설계 관점을 제시한다.',
+    ].join('\n');
+    expect(hasSelfReferentialOpening(text)).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

- RSS 요약이 **"이 콘텐츠는"**, **"본 콘텐츠는"**, **"이 기사는"** 등 자기 지시적 서두로 시작되던 문제 해결
- `SUMMARIZE_PROMPT`에 금지 규칙 명시 + regex 기반 runtime validator `hasSelfReferentialOpening` 신규 도입
- Producer(프롬프트)/Consumer(validator) **이중 가드**로 defense-in-depth 확보

## Why

사용자가 RSS 기사 요약을 읽을 때 "이 콘텐츠는 ~을 다룬다"처럼 주제를 메타-서술로 한 번 감싸서 나오는 서두가 불필요하다고 명시적으로 지적. 본문은 주제(주어)로 바로 시작해야 가독성이 높다.

## Root Cause

**원인 1**: `SUMMARIZE_PROMPT`가 섹션 예시에서 직접 "이 콘텐츠"를 사용해 Gemini가 그대로 따라함.

```diff
- (1~2문장으로 이 콘텐츠가 무엇인지 설명)
+ (1~2문장. 주제·대상을 주어로 하여 핵심 내용 요약. 주제로 바로 시작.)
```

**원인 2**: `looksLikeKoreanStructuredSummary()`가 구조(헤딩 유무)만 검증하고 스타일은 검증하지 않아 "이 콘텐츠는 ~" 요약도 정상으로 통과.

## Changes

### Modified

- `scripts/summarize-articles.ts`
  - `SUMMARIZE_PROMPT` 개정: 자기 지시적 서두 금지 규칙 + ✅/❌ 예시 추가, 섹션 가이드에서 "이 콘텐츠" 제거
  - `hasSelfReferentialOpening` export 신규: regex 기반 패턴 매칭 (`이|본|해당` + `콘텐츠|기사|글|아티클|포스트|영상|문서|뉴스|내용|자료|텍스트` + 조사)
  - `summarizeArticles` 루프에 Step 2.5 검증 추가: regression 감지 시 `clearStaleDescription` 후 continue → 다음 run에서 자동 재시도

- `tests/summarize-articles.test.ts`
  - `hasSelfReferentialOpening` describe 블록 신규 (positive 20+ / negative 14+ / 섹션 내부 검증 / 헤딩·불릿 무시)

### Added

- `docs/troubleshooting/rss-summary-self-referential-opening.md`

## Design Notes

**왜 regex 기반인가?**: Oracle 리뷰에서 지적된 대로 명사 리스트는 필연적으로 불완전함 ("이 다큐멘터리는", "본 블로그는" 등 새 변형 계속 등장). 패턴 매칭이 확장성과 유지보수성 면에서 우월.

**False positive 방지**: `이 기술은`, `본 프레임워크는` 같은 본문 주제 서술은 catch하지 않음 (기술/프레임워크는 article-like noun 리스트에 없음). 오직 article·content 계열 명사만 차단.

**왜 이중 가드인가?**: 프롬프트만으로는 모델이 때때로 regress. Runtime validator가 방어선.

**Curated 영향 없음**: `allowResummarize=false`로 보호된 사용자 직접 입력은 이 규칙이 적용되지 않음.

## Test Results

```
Test Files  16 passed (16)
     Tests  302 passed (302)
```

- ✅ `bun run validate` (341 files)
- ✅ `bun run validate:docs` (63 docs)
- ✅ `bun run validate:docs -- --check-coverage`
- ✅ `bun run build` (712 pages, 7.92s)
- ✅ `bun run test` (302 passed)

## Related

- [docs/troubleshooting/rss-summary-english-fallback.md](docs/troubleshooting/rss-summary-english-fallback.md) — 구조 검증 가드 도입 배경 (이번 PR은 스타일 검증을 추가)
