### PR TITLE
fix(summarize): backfill existing self-referential summaries and add integration tests

### DIFF
--- a/docs/troubleshooting/rss-summary-self-referential-opening.md
+++ b/docs/troubleshooting/rss-summary-self-referential-opening.md
@@ -140,15 +140,15 @@ if (hasSelfReferentialOpening(summary)) {
 
 | 파일 | 변경 내용 |
 |------|----------|
-| `scripts/summarize-articles.ts` | `SUMMARIZE_PROMPT` 개정 (자기 지시적 서두 금지 규칙 + 주제 중심 섹션 가이드 추가), `hasSelfReferentialOpening` validator 함수 신규 export, `summarizeArticles` 루프에 Step 2.5 검증 추가 |
-| `tests/summarize-articles.test.ts` | `hasSelfReferentialOpening` describe 블록 신규 추가 (positive/negative 케이스, 섹션 구조 내부 검증, 헤딩·불릿 무시 확인) |
+| `scripts/summarize-articles.ts` | `SUMMARIZE_PROMPT` 개정(자기 지시적 서두 금지 규칙 + 주제 중심 섹션 가이드), `hasSelfReferentialOpening` validator 함수 신규 export, `summarizeArticles` 루프에 Step 2.5 검증 추가, `findArticlesNeedingSummary`가 기존 자기 지시적 서두를 가진 feed description을 자동 재요약 대상으로 pick up하도록 조건 확장 (백필) |
+| `tests/summarize-articles.test.ts` | `hasSelfReferentialOpening` 단위 테스트(positive/negative/섹션 내부/헤딩·불릿 무시), `findArticlesNeedingSummary` 백필 테스트(feed 재큐·curated 보호), `summarizeArticles` integration 테스트(mock된 Gemini 응답 reject·수용 검증) |
 
 ## 예방 조치
 
 - **Producer/Consumer 이중 가드 유지**: Gemini 프롬프트 수정만으로 안주하지 않는다. AI는 때때로 규칙을 잊으므로 runtime validator가 필요하다.
 - **새 자기 지시적 변형 감지 시**: 사용자가 새 형태 ("이 다큐멘터리는" 등)를 지적하면, 명사 리스트를 확장하기보다 **regex 패턴 자체를 확장**하는 방향으로 대응한다. 명사 리스트는 필연적으로 불완전하다.
 - **요약 품질 회귀 감시**: `Article Summarization` 워크플로우 로그에서 `Rejected self-referential opening` 경고 빈도를 모니터링한다. 빈도가 높으면 프롬프트 약화 또는 모델 변경 신호.
-- **기존 feed 데이터 백필**: 과거 저장된 description에 자기 지시적 서두가 남아 있어도 `looksLikeKoreanStructuredSummary` 가드를 통과하므로 자동 재요약되지 않는다. 필요 시 `description` 필드를 검사해 `hasSelfReferentialOpening`이 true인 항목을 `clearStaleDescription`으로 비워두는 일회성 백필 스크립트가 필요할 수 있다.
+- **기존 feed 데이터 백필**: `findArticlesNeedingSummary`가 `hasSelfReferentialOpening(description)`이 true인 feed 항목도 다음 run에 자동으로 pick up하므로, 과거 저장된 193개 선약 데이터도 추가 작업 없이 재요약된다. `MAX_ARTICLES_PER_RUN=100`이므로 2회 run에 완전 백필.
 - **Curated는 영향 없음**: curated/ 내 사용자 직접 입력 description은 `allowResummarize=false`로 보호되며 Gemini가 건드리지 않는다. 이 규칙은 유지된다.
 
 ---

--- a/scripts/summarize-articles.ts
+++ b/scripts/summarize-articles.ts
@@ -207,9 +207,14 @@ export async function findArticlesNeedingSummary(
   //
   // - feeds/ (RSS 자동 수집)
   //   description은 Gemini가 생성한 한국어 구조화 요약 전용이다.
-  //   비어 있거나 RSS 원문이 누수된 경우(구조화 형식 아님) 모두 재요약한다.
+  //   비어 있거나, RSS 원문이 누수된 경우(구조화 형식 아님)
+  //   또는 자기 지시적 서두("이 콘텐츠는", "본 기사는" 등)로 시작하는 경우
+  //   모두 재요약한다. 자기 지시적 서두 검사는 고집들인 기존 선약 데이터도
+  //   다음 run에서 자동으로 재요약되도록 하는 백필 장치 역할을 격한다.
   //
-  // 자세한 배경: docs/troubleshooting/rss-summary-english-fallback.md
+  // 자세한 배경:
+  // - docs/troubleshooting/rss-summary-english-fallback.md (구조 검증 배경)
+  // - docs/troubleshooting/rss-summary-self-referential-opening.md (스타일 검증 배경)
   const targets: Array<{ dir: string; allowResummarize: boolean }> = [
     { dir: curatedDir, allowResummarize: false },
     { dir: feedsDir, allowResummarize: true },
@@ -230,7 +235,9 @@ export async function findArticlesNeedingSummary(
         const description = typeof data.description === 'string' ? data.description : '';
 
         const needsSummary = allowResummarize
-          ? !description || !looksLikeKoreanStructuredSummary(description)
+          ? !description ||
+            !looksLikeKoreanStructuredSummary(description) ||
+            hasSelfReferentialOpening(description)
           : !description;
 
         if (needsSummary) {

--- a/tests/summarize-articles.test.ts
+++ b/tests/summarize-articles.test.ts
@@ -6,6 +6,7 @@ import {
   findArticlesNeedingSummary,
   hasSelfReferentialOpening,
   looksLikeKoreanStructuredSummary,
+  summarizeArticles,
 } from '../scripts/summarize-articles';
 import { readFile } from 'fs/promises';
 
@@ -399,4 +400,245 @@ describe('clearStaleDescription', () => {
     expect(updated.description).toBeUndefined();
     expect(updated.id).toBe('empty');
   });
+});
+
+describe('findArticlesNeedingSummary (self-referential backfill)', () => {
+  // Separate describe block to verify feed articles with existing
+  // self-referential openings are re-queued for re-summarization.
+  const BACKFILL_TEST_DIR = join(ROOT, 'tests/tmp-backfill-test');
+  const BACKFILL_CURATED_DIR = join(BACKFILL_TEST_DIR, 'curated');
+  const BACKFILL_FEEDS_DIR = join(BACKFILL_TEST_DIR, 'feeds');
+
+  beforeEach(async () => {
+    await rm(BACKFILL_TEST_DIR, { recursive: true, force: true });
+    await mkdir(BACKFILL_CURATED_DIR, { recursive: true });
+    await mkdir(BACKFILL_FEEDS_DIR, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(BACKFILL_TEST_DIR, { recursive: true, force: true });
+  });
+
+  async function writeArticle(dir: string, name: string, data: Record<string, unknown>): Promise<void> {
+    await writeFile(join(dir, name), JSON.stringify(data, null, 2));
+  }
+
+  it('picks up feed articles with self-referential opening (backfill existing bad summaries)', async () => {
+    // Existing feed summaries already containing "이 콘텐츠는" must be re-queued
+    // so the fix applies retroactively, not only to new articles.
+    await writeArticle(BACKFILL_FEEDS_DIR, 'self-ref.json', {
+      id: 'self-ref',
+      title: 'Article with self-referential opening',
+      url: 'https://example.com/self-ref',
+      description: [
+        '## 개요',
+        '',
+        '이 콘텐츠는 AI 도구를 소개한다',
+        '',
+        '## 주요 내용',
+        '- 포인트 1',
+        '',
+        '## 시사점',
+        '중요한 통찰을 제공한다',
+      ].join('\n'),
+    });
+
+    const result = await findArticlesNeedingSummary(BACKFILL_CURATED_DIR, BACKFILL_FEEDS_DIR);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].data.id).toBe('self-ref');
+  });
+
+  it('picks up feed articles when ONLY the 시사점 section has a self-referential opening', async () => {
+    // Validates the regex catches openings in any section body, not only 개요
+    await writeArticle(BACKFILL_FEEDS_DIR, 'sijachom-ref.json', {
+      id: 'sijachom-ref',
+      title: 'Only 시사점 is self-referential',
+      url: 'https://example.com/sijachom-ref',
+      description: [
+        '## 개요',
+        '',
+        'Vercel이 발표한 실험',
+        '',
+        '## 주요 내용',
+        '- 포인트 1',
+        '',
+        '## 시사점',
+        '본 기사는 중요한 통찰을 제공한다',
+      ].join('\n'),
+    });
+
+    const result = await findArticlesNeedingSummary(BACKFILL_CURATED_DIR, BACKFILL_FEEDS_DIR);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].data.id).toBe('sijachom-ref');
+  });
+
+  it('NEVER picks up curated articles with self-referential opening (user-authored preserved)', async () => {
+    // Even if a curated description starts with "이 기사는", it is user input.
+    // allowResummarize=false protects it from any Gemini overwrite.
+    await writeArticle(BACKFILL_CURATED_DIR, 'user-self-ref.json', {
+      id: 'user-self-ref',
+      title: 'User wrote self-referential intentionally',
+      url: 'https://example.com/user-self-ref',
+      description: '이 기사는 사용자가 직접 적은 내용이다',
+    });
+
+    const result = await findArticlesNeedingSummary(BACKFILL_CURATED_DIR, BACKFILL_FEEDS_DIR);
+
+    expect(result).toHaveLength(0);
+  });
+
+  it('does NOT pick up feed articles with clean subject-first opening', async () => {
+    // Regression guard: clean summaries must not be re-queued
+    await writeArticle(BACKFILL_FEEDS_DIR, 'clean.json', {
+      id: 'clean',
+      title: 'Clean article',
+      url: 'https://example.com/clean',
+      description: [
+        '## 개요',
+        '',
+        'Vercel이 발표한 실험은 AGENTS.md 구조의 우수성을 입증했다',
+        '',
+        '## 주요 내용',
+        '- 포인트 1',
+        '',
+        '## 시사점',
+        '문서 기반 접근의 실용성을 검증',
+      ].join('\n'),
+    });
+
+    const result = await findArticlesNeedingSummary(BACKFILL_CURATED_DIR, BACKFILL_FEEDS_DIR);
+
+    expect(result).toHaveLength(0);
+  });
+});
+
+describe('summarizeArticles (integration)', () => {
+  const INT_TEST_DIR = join(ROOT, 'tests/tmp-integration');
+  const INT_CURATED_DIR = join(INT_TEST_DIR, 'curated');
+  const INT_FEEDS_DIR = join(INT_TEST_DIR, 'feeds');
+
+  beforeEach(async () => {
+    await rm(INT_TEST_DIR, { recursive: true, force: true });
+    await mkdir(INT_CURATED_DIR, { recursive: true });
+    await mkdir(INT_FEEDS_DIR, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(INT_TEST_DIR, { recursive: true, force: true });
+  });
+
+  it('rejects Gemini response starting with self-referential opening and clears stale description', async () => {
+    const filePath = join(INT_FEEDS_DIR, 'test.json');
+    await writeFile(
+      filePath,
+      JSON.stringify({ id: 'test', title: 'Test Article', url: 'https://example.com/test' }, null, 2),
+    );
+
+    const mockFetch = async () => 'A'.repeat(500);
+    const mockGenerate = async () =>
+      [
+        '## 개요',
+        '이 기사는 중요한 내용을 다룬다',
+        '',
+        '## 주요 내용',
+        '- 포인트 1',
+        '',
+        '## 시사점',
+        '결론',
+      ].join('\n');
+
+    const result = await summarizeArticles({
+      curatedDir: INT_CURATED_DIR,
+      feedsDir: INT_FEEDS_DIR,
+      apiKey: 'fake-key',
+      fetchContentFn: mockFetch,
+      generateSummaryFn: mockGenerate,
+      maxArticles: 1,
+    });
+
+    expect(result.updated).toBe(0);
+    expect(result.errors.length).toBeGreaterThanOrEqual(1);
+    expect(result.errors.some((e) => e.includes('Rejected self-referential opening'))).toBe(true);
+
+    // File description should be cleared so it gets re-queued next run
+    const updated = JSON.parse(await readFile(filePath, 'utf-8'));
+    expect(updated.description).toBeUndefined();
+  }, 30_000);
+
+  it('accepts Gemini response with subject-first opening and writes summary', async () => {
+    const filePath = join(INT_FEEDS_DIR, 'test.json');
+    await writeFile(
+      filePath,
+      JSON.stringify({ id: 'test', title: 'Test Article', url: 'https://example.com/test' }, null, 2),
+    );
+
+    const cleanSummary = [
+      '## 개요',
+      'Vercel이 발표한 실험은 AGENTS.md 구조가 높은 정확도를 보였음을 입증했다',
+      '',
+      '## 주요 내용',
+      '- AGENTS.md 접근법은 70% 통과율',
+      '',
+      '## 시사점',
+      '항상 보이는 문서가 성능을 높인다',
+    ].join('\n');
+
+    const result = await summarizeArticles({
+      curatedDir: INT_CURATED_DIR,
+      feedsDir: INT_FEEDS_DIR,
+      apiKey: 'fake-key',
+      fetchContentFn: async () => 'A'.repeat(500),
+      generateSummaryFn: async () => cleanSummary,
+      maxArticles: 1,
+    });
+
+    expect(result.updated).toBe(1);
+    expect(result.errors).toHaveLength(0);
+
+    const updated = JSON.parse(await readFile(filePath, 'utf-8'));
+    expect(updated.description).toBe(cleanSummary);
+  }, 30_000);
+
+  it('skips curated articles with non-empty description even when self-referential', async () => {
+    // Defense: even though user-written curated description has "이 기사는",
+    // allowResummarize=false means summarizeArticles never touches it.
+    const filePath = join(INT_CURATED_DIR, 'user.json');
+    await writeFile(
+      filePath,
+      JSON.stringify(
+        {
+          id: 'user',
+          title: 'User authored',
+          url: 'https://example.com/user',
+          description: '이 기사는 사용자가 적은 설명',
+        },
+        null,
+        2,
+      ),
+    );
+
+    let generateCallCount = 0;
+    const result = await summarizeArticles({
+      curatedDir: INT_CURATED_DIR,
+      feedsDir: INT_FEEDS_DIR,
+      apiKey: 'fake-key',
+      fetchContentFn: async () => 'A'.repeat(500),
+      generateSummaryFn: async () => {
+        generateCallCount += 1;
+        return 'never called';
+      },
+      maxArticles: 1,
+    });
+
+    expect(result.updated).toBe(0);
+    expect(result.skipped).toBe(0);
+    expect(result.errors).toHaveLength(0);
+    expect(generateCallCount).toBe(0); // Gemini never invoked for curated with description
+
+    // User's description must remain untouched
+    const preserved = JSON.parse(await readFile(filePath, 'utf-8'));
+    expect(preserved.description).toBe('이 기사는 사용자가 적은 설명');
+  }, 30_000);
 });


### PR DESCRIPTION
## Summary

- PR #158 후속 조치: 기존 feed JSON 파일에 이미 저장된 **자기 지시적 서두 요약을 자동 백필**
- `summarizeArticles()` 루프 자체의 reject/accept 동작을 **integration test**로 검증 (Oracle 리뷰 피드백)

## Why

PR #158은 **미래 생성물**만 보호했다. Oracle이 지적한 대로:
- `src/data/feeds/`에 이미 저장된 요약 중 **193개가 여전히 "이 콘텐츠는~", "본 기사는~" 등으로 시작**
- `looksLikeKoreanStructuredSummary()`는 구조만 검증하므로 이들은 자동 재요약 대상이 아님 → 사용자에게 계속 노출
- Regex 단위 테스트만 있고 실제 `summarizeArticles()` 루프의 reject 동작은 검증되지 않았음

## Changes

### `scripts/summarize-articles.ts`

**`findArticlesNeedingSummary` 조건 확장**:
```diff
 const needsSummary = allowResummarize
-  ? !description || !looksLikeKoreanStructuredSummary(description)
+  ? !description ||
+    !looksLikeKoreanStructuredSummary(description) ||
+    hasSelfReferentialOpening(description)
   : !description;
```

다음 요약 run부터 기존 193개 파일이 자동으로 pick up되어 재요약됨. `MAX_ARTICLES_PER_RUN=100` 기준 **2회 run**이면 완전 백필.

### `tests/summarize-articles.test.ts`

**신규 describe 블록 2개 (7 tests 추가)**:

1. `findArticlesNeedingSummary (self-referential backfill)` — 4 tests
   - feed article with self-referential in `## 개요` → picked up
   - feed article with self-referential in `## 시사점` → picked up (섹션 무관)
   - curated article with self-referential → **NEVER picked up** (user-authored 보호)
   - feed article with clean subject-first opening → NOT picked up

2. `summarizeArticles (integration)` — 3 tests
   - Mocked Gemini가 `이 기사는~`으로 응답 → `result.updated=0`, errors에 `Rejected self-referential opening` 기록, description cleared
   - Mocked Gemini가 subject-first로 응답 → `result.updated=1`, description 저장됨
   - Curated article (already has description) → Gemini 호출 수=0, user description 보존

### `docs/troubleshooting/rss-summary-self-referential-opening.md`

관련 파일 테이블 + 예방 조치 섹션 업데이트 (백필 메커니즘 명시).

## Test Results

```
Test Files  16 passed (16)
     Tests  309 passed (309)  ← 전체 통과 (PR #158 대비 +7)
```

- ✅ `bun run validate`
- ✅ `bun run validate:docs`
- ✅ `bun run validate:docs -- --check-coverage`
- ✅ `bun run build` (712 pages, 8.44s)
- ✅ `bun run test` (309 passed)

## Design Notes

**왜 일회성 백필 스크립트 대신 `findArticlesNeedingSummary` 확장인가?**

별도 스크립트는 한 번 실행되고 사라진다. 미래에 regression이 발생하거나 Gemini가 새 변형을 만들어내면 다시 백필 스크립트가 필요해진다. `findArticlesNeedingSummary`를 영구 확장하면:

- 별도 실행 필요 없음 (다음 summarize workflow run에서 자동 처리)
- 미래 regression도 자동 복구
- 새 자기 지시적 변형 추가 시 regex만 확장하면 검출 + 재요약 모두 자동

**Curated 불변성**: `allowResummarize=false` 분기는 건드리지 않았다. 사용자가 직접 적은 curated description은 영원히 보호된다 (Gemini가 덮어쓰지 않음).

## Related

- PR #158 (merged): 프롬프트 개정 + runtime validator 도입 (future-only)
- [docs/troubleshooting/rss-summary-self-referential-opening.md](docs/troubleshooting/rss-summary-self-referential-opening.md)
