### PR TITLE
fix(bulk): prevent title==description + surface silent duplicate drops

### DIFF
--- a/.github/ISSUE_TEMPLATE/submit-bulk.yml
+++ b/.github/ISSUE_TEMPLATE/submit-bulk.yml
@@ -7,11 +7,16 @@ body:
     attributes:
       label: Link List
       description: |
-        한 줄에 하나씩 입력하세요. 태그는 영어로, 요약은 한국어로 작성해주세요.
-        Format: URL | Type | tags (English, comma-separated) | 요약 (한국어 가능)
+        한 줄에 하나씩 입력하세요. 태그는 영어로, 제목·요약은 한국어로 작성해주세요.
+
+        두 포맷 중 선택 가능 (파서가 자동 감지):
+          v1 (legacy): URL | Type | tags (English, comma-separated) | 요약 (한국어)
+          v2 (제목 포함): URL | Type | 제목 (한국어) | tags (English, comma-separated) | 요약 (한국어)
+
         Type options: Article, YouTube, X Thread, Threads, Other
+        제목·요약에는 `|`, 탭, 개행을 포함할 수 없습니다 (컬럼 구분자 충돌).
       placeholder: |
-        https://example.com/article | Article | AI, LLM | AI 에이전트 활용에 대한 실전 분석
-        https://youtube.com/watch?v=abc | YouTube | tutorial | 개발자를 위한 AI 튜토리얼
+        https://example.com/article | Article | AI 에이전트 활용 가이드 | AI, LLM | AI 에이전트 활용에 대한 실전 분석
+        https://youtube.com/watch?v=abc | YouTube | Claude Code 튜토리얼 | tutorial | 개발자를 위한 AI 튜토리얼
     validations:
       required: true

--- a/.github/workflows/process-submission.yml
+++ b/.github/workflows/process-submission.yml
@@ -110,6 +110,62 @@ jobs:
           ISSUE_USER_ID: ${{ env.ISSUE_USER_ID }}
         run: bun run scripts/process-submission.ts
 
+      - name: Report bulk submission results (upsert comment)
+        if: always() && github.event_name == 'issues'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          ISSUE_NUMBER: ${{ env.ISSUE_NUMBER }}
+        run: |
+          if [ ! -f bulk-result.json ]; then
+            echo 'No bulk-result.json; skipping bulk report step.'
+            exit 0
+          fi
+
+          TOTAL=$(jq -r '.total' bulk-result.json)
+          if [ "$TOTAL" = '0' ] || [ -z "$TOTAL" ]; then
+            echo 'Empty bulk-result; nothing to report.'
+            exit 0
+          fi
+
+          SUCCEEDED=$(jq -r '.succeeded | length' bulk-result.json)
+          FAILED=$(jq -r '.failed | length' bulk-result.json)
+          MARKER='<!-- honeycombo-bulk-result -->'
+
+          {
+            echo "$MARKER"
+            echo
+            if [ "$FAILED" = '0' ]; then
+              echo "## ✅ 대량 제출 처리 결과"
+            else
+              echo "## ⚠️ 대량 제출 처리 결과 (일부 실패)"
+            fi
+            echo
+            echo "- 성공: $SUCCEEDED / $TOTAL"
+            echo "- 실패: $FAILED / $TOTAL"
+            if [ "$FAILED" -gt 0 ]; then
+              echo
+              echo '### ❌ 실패 항목'
+              echo
+              echo '| URL | 사유 |'
+              echo '|---|---|'
+              jq -r '.failed[] | "| \(.url) | \(.reason) |"' bulk-result.json
+            fi
+          } > /tmp/bulk-comment.md
+
+          # Upsert: patch existing marked comment if present, else create new.
+          EXISTING_ID=$(gh api "repos/$REPO/issues/$ISSUE_NUMBER/comments" --paginate \
+            --jq "[.[] | select(.body | contains(\"$MARKER\"))] | .[0].id // empty")
+
+          if [ -n "$EXISTING_ID" ]; then
+            echo "Updating existing comment #$EXISTING_ID"
+            gh api --method PATCH "repos/$REPO/issues/comments/$EXISTING_ID" \
+              --field body=@/tmp/bulk-comment.md >/dev/null
+          else
+            echo 'Creating new bulk-result comment'
+            gh issue comment "$ISSUE_NUMBER" --repo "$REPO" --body-file /tmp/bulk-comment.md
+          fi
+
       - name: Validate generated content
         run: bun run validate
 
@@ -176,11 +232,21 @@ jobs:
             echo "IS_EDITOR=false" >> $GITHUB_ENV
           fi
 
-      - name: Comment on issue
+      - name: Comment on issue (generic success)
         if: success() && github.event_name == 'issues' && env.IS_EDITOR != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # Suppress the generic success comment when a bulk submission had
+          # failures — the "Report bulk submission results" step already posted
+          # a detailed comment covering that case.
+          if [ -f bulk-result.json ]; then
+            FAILED=$(jq -r '.failed | length' bulk-result.json)
+            if [ "$FAILED" != '0' ] && [ -n "$FAILED" ]; then
+              echo 'Bulk had failures — skipping generic success comment (detailed comment was posted).'
+              exit 0
+            fi
+          fi
           gh issue comment $ISSUE_NUMBER \
             --body "✅ 제출이 접수되었습니다. 검토 후 게시됩니다."
 

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ node_modules/
 .playwright-mcp/
 .sisyphus/
 wrangler-dev.log
+
+bulk-result.json

--- a/docs/features/bulk-submission.md
+++ b/docs/features/bulk-submission.md
@@ -12,10 +12,15 @@
 GitHub bulk Issue → scripts/process-submission.ts(parseBulkIssueBody/processBulkSubmission) → 항목별 검증/JSON 생성 → PR 생성
 ```
 
-- Issue 템플릿 `.github/ISSUE_TEMPLATE/submit-bulk.yml` 에서 `URL | 유형 | 태그 | 요약` 형식의 줄 목록을 수집한다. **태그는 영어로, 요약은 한국어로 작성한다.**
-- 워크플로우 `.github/workflows/process-submission.yml` 가 `bulk` 라벨을 환경변수로 전달한다.
-- `scripts/process-submission.ts` 는 bulk 여부를 감지해 각 줄을 독립 처리한다.
-- URL 오류·중복·스팸이 일부 항목에서 발생해도 나머지 성공 항목은 `src/content/curated/` JSON으로 생성한다.
+- Issue 템플릿 `.github/ISSUE_TEMPLATE/submit-bulk.yml` 에서 다음 두 포맷 중 하나로 줄 목록을 수집한다.
+  - v1 (legacy, 4컬럼): `URL | 유형 | 태그 | 요약`
+  - v2 (title 추가, 5컬럼): `URL | 유형 | 제목 | 태그 | 요약`
+  - **태그는 영어로, 제목·요약은 한국어로 작성한다.**
+  - 제목과 요약에는 어떠한 경우에도 `|`, 탭, CR/LF를 포함할 수 없다 (컬럼 구분자 충돌).
+- `parseBulkIssueBody` 는 `|` 기준 분할 목 수를 세어 5개 이상이면 3번째 필드를 제목으로 읽고, 4개면 기존 레거시 포맷으로 처리한다 (backward compatible).
+- `processBulkSubmission` 는 bulk URL index를 1회만 로드해 항목별 중복 조회 비용을 줄인다.
+- Title 해석은 `resolveSubmissionTitle` 헬퍼를 통해 `parsed.title` → oEmbed title → `deriveShortTitle(note)` → URL hostname 순서로 fallback한다.
+- 워크플로우 `.github/workflows/process-submission.yml` 가 `bulk` 라벨을 환경변수로 전달하고, 실패 항목이 있으면 `bulk-result.json` 을 기준으로 상세 댓글을 upsert한다 (동일 Issue 재처리 시 중복 방지).
 
 ## 관련 파일
 
@@ -38,8 +43,9 @@ GitHub bulk Issue → scripts/process-submission.ts(parseBulkIssueBody/processBu
 
 - bulk 파싱은 최대 20개 항목까지만 처리한다.
 - 각 항목은 기존 단건과 동일한 스팸·중복·YouTube oEmbed 규칙을 따른다.
-- 부분 실패는 허용되지만, 전부 실패하면 스크립트는 종료 코드 1을 반환한다.
-- **태그는 반드시 영어로 작성해야 한다.** 요약은 한국어로 작성한다. 유형(`기사`, `YouTube` 등)은 시스템 값이므로 한국어 그대로 사용한다.
+- **부분 실패는 허용되며 exit 0을 반환**한다. 전부 실패해야 exit 1이 되며, 이 경우에만 `Comment on failure` 스텝이 일반 실패 댓글을 남긴다. 부분 실패는 `Report bulk submission results` 스텝이 상세 댓글을 upsert한다.
+- **태그는 반드시 영어로 작성한다.** 제목과 요약은 한국어로 작성한다. 유형(`기사`, `YouTube` 등)은 시스템 값이므로 한국어 그대로 사용한다.
+- Title fallback은 `deriveShortTitle`이 title과 description 간 거의 같은 내용(title=description 중복)이 될 위험이 있을 때 null을 반환하고, 그 경우 URL hostname으로 최종 fallback한다.
 
 ---
 
@@ -47,6 +53,7 @@ GitHub bulk Issue → scripts/process-submission.ts(parseBulkIssueBody/processBu
 
 - [아키텍처 개요](../architecture/overview.md)
 - [AI 에이전트 제출 가이드](../guides/agent-submission.md)
+- [Title≐Description 중복 트러블슈팅](../troubleshooting/bulk-title-description-overlap.md)
 
 ## 변경 이력
 
@@ -55,3 +62,4 @@ GitHub bulk Issue → scripts/process-submission.ts(parseBulkIssueBody/processBu
 | 2026-04-12 | 최초 작성 |
 | 2026-04-13 | 영어 작성 요구사항 추가 |
 | 2026-04-20 | 요약 한국어 전환 반영 |
+| 2026-04-21 | 5컬럼 제목 포맷, `bulk-result.json` 기반 상세 실패 댓글 upsert, URL index 재사용 추가 |

--- a/docs/troubleshooting/bulk-title-description-overlap.md
+++ b/docs/troubleshooting/bulk-title-description-overlap.md
@@ -1,0 +1,86 @@
+# Bulk 제출에서 title 필드가 description과 동일해지는 문제
+
+> YouTube 채널처럼 metadata가 빈약한 URL을 bulk로 제출하면 title 필드가 요약 전체로 채워져 description과 100% 일치하는 버그. 2026-04-21 해결.
+
+## 증상
+
+Issue #155 (bulk submit, 9 URL) 처리 후 생성된 8개 JSON 파일의 `title` 필드가 모두 `description`과 동일한 긴 한국어 문장(120~240자)으로 채워졌다. YouTube 영상(oEmbed 성공)만 정상 제목을 가졌고, YouTube 채널 + 웹사이트 URL들은 모두 title=description 상태.
+
+```json
+{
+  "title": "74만 구독자의 한국 스타트업 전문 콘텐츠 채널 EO Korea. 창업가 심층 인터뷰, ...",
+  "description": "74만 구독자의 한국 스타트업 전문 콘텐츠 채널 EO Korea. 창업가 심층 인터뷰, ..."
+}
+```
+
+**재현 환경**: HoneyCombo `process-submission.ts` (2026-04-21 이전), bulk TSV 4컬럼 포맷, YouTube 채널 URL(@handle 형식).
+
+## 원인
+
+`scripts/process-submission.ts`의 제목 해석 로직이 다음 순서로 fallback 했다:
+
+1. `extractTitleFromNote(note)` — 요약의 첫 non-heading 라인을 반환
+2. `|| url` — 그 외에는 URL 원문
+
+그러나 `extractTitleFromNote`는 짧은 한 줄 요약에 대해 **요약 전체를 그대로 반환**한다 (첫 라인 == 전체). YouTube 채널 페이지는 oEmbed가 제목을 돌려주지 않으므로 이 fallback이 곧바로 적용돼 title = description이 되어 카드 UI에서 똑같은 문장이 두 번 렌더링됐다.
+
+또한 bulk TSV는 `URL | Type | Tags | Summary` 4컬럼으로만 구성돼 제출자가 짧은 제목을 따로 명시할 통로가 없었다.
+
+## 해결 방법
+
+1. **신규 `deriveShortTitle(note)`** 도입. 섹션 헤딩(`## 개요`, `## 주요 내용` 등)과 URL-only 라인을 스킵하고, 첫 의미 있는 콘텐츠 라인의 **첫 문장**만 추출한 뒤 80 grapheme 이내로 truncate한다. 결과가 첫 콘텐츠 라인과 사실상 동일하면 null을 반환해 description과의 중복을 예방한다.
+2. **신규 `resolveSubmissionTitle()` 헬퍼**로 fallback 체인을 단일화: `parsed.title` → `oEmbed.title` → `deriveShortTitle(note)` → URL hostname. single/bulk 흐름에서 공유한다.
+3. **bulk TSV를 5컬럼 포맷으로 확장**: `URL | Type | Title | Tags | Summary`. 파서(`parseBulkIssueBody`)는 `|` 분할 개수가 5 이상이면 3번째 필드를 제목으로 인식하고, 4개면 기존 레거시 포맷으로 처리한다 (backward compatible).
+4. **중복 URL 보고 개선**: `findDuplicateUrl(url)`이 매칭 파일 경로를 반환하고, bulk 흐름은 URL index를 1회만 로드한다. 실패 항목은 `bulk-result.json`에 기록되고 `.github/workflows/process-submission.yml`의 `Report bulk submission results` 스텝이 Issue에 상세 댓글을 upsert한다.
+
+```diff
+- let title = extractTitleFromNote(note) || url;
+- let thumbnailUrl: string | undefined;
+- if (type === 'youtube') {
+-   const oembed = await fetchYouTubeOEmbed(url);
+-   if (oembed) {
+-     title = oembed.title || title;
+-     thumbnailUrl = oembed.thumbnail_url;
+-   }
+- }
++ let oembed: OEmbedData | null = null;
++ let thumbnailUrl: string | undefined;
++ if (type === 'youtube') {
++   oembed = await fetchYouTubeOEmbed(url);
++   if (oembed) {
++     thumbnailUrl = oembed.thumbnail_url;
++   }
++ }
++ const title = resolveSubmissionTitle(parsed, oembed, url);
+```
+
+## 관련 파일
+
+| 파일 | 변경 내용 |
+|------|----------|
+| `scripts/process-submission.ts` | `deriveShortTitle`, `resolveSubmissionTitle`, `findDuplicateUrl`, `buildUrlIndex` 추가. 5컬럼 파서로 확장. bulk 흐름에서 URL index 재사용 + `bulk-result.json` 작성 + exit code 조정 |
+| `.github/workflows/process-submission.yml` | `Report bulk submission results` 스텝 추가(실패 댓글 upsert with `<!-- honeycombo-bulk-result -->` marker), 일반 성공 댓글은 bulk 실패 시 스킵 |
+| `.github/ISSUE_TEMPLATE/submit-bulk.yml` | 5컬럼(optional title) 포맷 문서화 |
+| `tests/process-submission.test.ts` | `deriveShortTitle` / `resolveSubmissionTitle` / 5컬럼 파싱 / `findDuplicateUrl` / `buildUrlIndex` 테스트 추가, 기존 제목 추출 케이스를 새 fallback 동작에 맞게 갱신 |
+
+## 예방 조치
+
+- **클라이언트(`link-curator` plugin)는 제목에 `|`, tab, CR/LF 포함을 거부**해야 한다. 서버 파서는 `|` 기준 분할을 사용하므로 제목 내 pipe는 컬럼 정렬을 깨뜨릴 수 있다.
+- **단일 문장짜리 짧은 요약**은 자동으로 좋은 title을 만들 수 없다. 5컬럼 포맷으로 제출자가 직접 짧은 제목을 제공하거나, 2문장 이상의 요약을 작성해야 `deriveShortTitle`이 첫 문장만 추출해 description과 구분되는 title을 생성한다.
+- `bulk-result.json` 댓글은 Issue에 upsert되므로 재처리 시 중복 댓글이 생기지 않는다. 댓글 내 `<!-- honeycombo-bulk-result -->` 마커를 건드리지 말 것.
+
+---
+
+## 관련 문서
+
+- [bulk submission 기능 문서](../features/bulk-submission.md)
+- [AI 에이전트 제출 가이드](../guides/agent-submission.md)
+- [아키텍처 개요](../architecture/overview.md)
+
+---
+
+## 변경 이력
+
+| 날짜 | 변경 내용 |
+|------|----------|
+| 2026-04-21 | 최초 작성 — Issue #155 파편 증상 분석 및 수정 기록 |

--- a/scripts/process-submission.ts
+++ b/scripts/process-submission.ts
@@ -26,6 +26,7 @@ export interface ParsedSubmission {
   type: 'article' | 'youtube' | 'x_thread' | 'threads' | 'other';
   tags: string[];
   note: string;
+  title?: string;
 }
 
 export interface OEmbedData {
@@ -58,6 +59,92 @@ export function extractTitleFromNote(note: string): string {
   const contentLine = lines.find((line) => !line.startsWith('#'));
   if (contentLine) return contentLine;
   return lines[0]?.replace(/^#+\s*/, '') || '';
+}
+
+const SECTION_HEADINGS = new Set([
+  '개요',
+  '주요 내용',
+  '시사점',
+  '핵심 내용',
+  '요약',
+  'TL;DR',
+  'Overview',
+  'Summary',
+  'Background',
+  'Context',
+]);
+
+function normalizeForComparison(text: string): string {
+  return text.replace(/\s+/g, '').toLowerCase();
+}
+
+/**
+ * Derive a short (<= 80 grapheme) title from a structured note.
+ *
+ * Returns null when the derivation would produce a title that is effectively
+ * identical to the first meaningful content line (which would lead to
+ * `title === description` in downstream storage). Callers must fall back to
+ * another source (oEmbed, URL hostname) in that case.
+ */
+export function deriveShortTitle(note: string): string | null {
+  if (!note) return null;
+
+  const candidates = note
+    .split('\n')
+    .map((line) => line.replace(/^[#>*_`\s-]+/, '').trim())
+    .filter(Boolean)
+    .filter((line) => !SECTION_HEADINGS.has(line))
+    .filter((line) => !/^https?:\/\//i.test(line));
+
+  const first = candidates[0];
+  if (!first) return null;
+
+  // Extract the first sentence (ASCII + CJK terminators).
+  const sentenceMatch = first.match(/^[^.!?。]*[.!?。]/u);
+  const firstSentence = sentenceMatch ? sentenceMatch[0].trim() : first;
+
+  // Grapheme-aware truncation at 80 characters.
+  const graphemes = Array.from(firstSentence);
+  const truncated = graphemes.slice(0, 80).join('').trim();
+  if (!truncated) return null;
+
+  // Reject if the result is effectively identical to the first content line —
+  // that case would make `title` overlap with `description` once stored.
+  if (normalizeForComparison(truncated) === normalizeForComparison(first)) {
+    return null;
+  }
+
+  return graphemes.length > 80 ? `${truncated}…` : truncated;
+}
+
+function hostnameFallback(url: string): string {
+  try {
+    return new URL(url).hostname.replace(/^www\./, '') || url;
+  } catch {
+    return url;
+  }
+}
+
+/**
+ * Resolve the final `title` for a submission using a deterministic fallback
+ * chain: explicit parsed.title → oEmbed title → deriveShortTitle(note) →
+ * URL hostname. This is shared by single and bulk flows to prevent drift.
+ */
+export function resolveSubmissionTitle(
+  parsed: ParsedSubmission,
+  oembed: OEmbedData | null,
+  url: string,
+): string {
+  const fromSubmission = parsed.title?.trim();
+  if (fromSubmission) return fromSubmission;
+
+  const fromOembed = oembed?.title?.trim();
+  if (fromOembed) return fromOembed;
+
+  const fromDerivation = deriveShortTitle(parsed.note);
+  if (fromDerivation) return fromDerivation;
+
+  return hostnameFallback(url);
 }
 
 export function parseIssueBody(body: string): ParsedSubmission | null {
@@ -176,12 +263,29 @@ export function parseBulkIssueBody(body: string): ParsedSubmission[] {
         continue;
       }
 
-      const [rawUrl = '', rawType = '', rawTags = '', ...rawNoteParts] = line
-        .split('|')
-        .map((part) => part.trim());
+      const parts = line.split('|').map((part) => part.trim());
+      let rawUrl = '';
+      let rawType = '';
+      let rawTitle = '';
+      let rawTags = '';
+      let rawNoteParts: string[] = [];
+
+      if (parts.length >= 5) {
+        // 5-column format (v2): URL | Type | Title | Tags | Summary+
+        [rawUrl = '', rawType = '', rawTitle = '', rawTags = '', ...rawNoteParts] = parts;
+      } else {
+        // 4-column format (v1, legacy): URL | Type | Tags | Summary+
+        [rawUrl = '', rawType = '', rawTags = '', ...rawNoteParts] = parts;
+      }
 
       if (!rawUrl) {
         console.warn(`Skipping bulk submission line without URL: ${line}`);
+        continue;
+      }
+
+      // TITLE must not contain the column delimiter or line-breaking chars.
+      if (rawTitle && /[|\t\r\n]/.test(rawTitle)) {
+        console.warn(`Skipping bulk submission line with forbidden char in title: ${rawTitle}`);
         continue;
       }
 
@@ -199,6 +303,7 @@ export function parseBulkIssueBody(body: string): ParsedSubmission[] {
       submissions.push({
         url: rawUrl,
         type,
+        title: rawTitle || undefined,
         tags: tags.length > 0 ? tags : ['general'],
         note: rawNoteParts.join(' | '),
       });
@@ -231,7 +336,11 @@ export async function fetchYouTubeOEmbed(url: string): Promise<OEmbedData | null
   }
 }
 
-export async function isDuplicateUrl(url: string): Promise<boolean> {
+/**
+ * Find the file path of an already-curated article with the same URL.
+ * Returns the absolute path when a match exists; otherwise null.
+ */
+export async function findDuplicateUrl(url: string): Promise<string | null> {
   for (const dir of [CURATED_DIR, FEEDS_DIR]) {
     const files = await listJsonFiles(dir);
 
@@ -239,7 +348,7 @@ export async function isDuplicateUrl(url: string): Promise<boolean> {
       try {
         const content = JSON.parse(await readFile(filePath, 'utf-8')) as { url?: unknown };
         if (content.url === url) {
-          return true;
+          return filePath;
         }
       } catch (error) {
         console.warn(`Failed to read submission source JSON: ${filePath}`, error);
@@ -247,7 +356,46 @@ export async function isDuplicateUrl(url: string): Promise<boolean> {
     }
   }
 
-  return false;
+  return null;
+}
+
+/**
+ * Backward-compatible boolean wrapper around findDuplicateUrl.
+ * Prefer findDuplicateUrl in new code so callers can surface the matching path.
+ */
+export async function isDuplicateUrl(url: string): Promise<boolean> {
+  return (await findDuplicateUrl(url)) !== null;
+}
+
+/**
+ * Build a single `url -> filePath` index over curated + feed JSON files.
+ * Used by bulk submission to avoid rescanning the repo once per item.
+ */
+export async function buildUrlIndex(): Promise<Map<string, string>> {
+  const index = new Map<string, string>();
+  for (const dir of [CURATED_DIR, FEEDS_DIR]) {
+    const files = await listJsonFiles(dir);
+    for (const filePath of files) {
+      try {
+        const content = JSON.parse(await readFile(filePath, 'utf-8')) as { url?: unknown };
+        if (typeof content.url === 'string' && !index.has(content.url)) {
+          index.set(content.url, filePath);
+        }
+      } catch (error) {
+        console.warn(`Failed to read submission source JSON: ${filePath}`, error);
+      }
+    }
+  }
+  return index;
+}
+
+function formatRelativePath(absolutePath: string): string {
+  const normalizedRoot = ROOT.replace(/\\/g, '/');
+  const normalized = absolutePath.replace(/\\/g, '/');
+  if (normalized.startsWith(`${normalizedRoot}/`)) {
+    return normalized.slice(normalizedRoot.length + 1);
+  }
+  return normalized;
 }
 
 export async function isSpam(text: string): Promise<boolean> {
@@ -297,21 +445,24 @@ export async function processSubmission(
     return { success: false, message: 'Spam detected in submission' };
   }
 
-  if (await isDuplicateUrl(url)) {
-    console.warn(`Duplicate URL detected: ${url}`);
-    return { success: false, message: `Duplicate URL: ${url}` };
+  const duplicatePath = await findDuplicateUrl(url);
+  if (duplicatePath) {
+    const relPath = formatRelativePath(duplicatePath);
+    console.warn(`Duplicate URL detected: ${url} (already in ${relPath})`);
+    return { success: false, message: `Duplicate URL: ${url} (already in ${relPath})` };
   }
 
-  let title = extractTitleFromNote(note) || url;
+  let oembed: OEmbedData | null = null;
   let thumbnailUrl: string | undefined;
 
   if (type === 'youtube') {
-    const oembed = await fetchYouTubeOEmbed(url);
+    oembed = await fetchYouTubeOEmbed(url);
     if (oembed) {
-      title = oembed.title || title;
       thumbnailUrl = oembed.thumbnail_url;
     }
   }
+
+  const title = resolveSubmissionTitle(parsed, oembed, url);
 
   const id = generateId(url, issue.number);
   const submittedAt = new Date().toISOString();
@@ -356,6 +507,7 @@ export async function processBulkSubmission(
     return { total: 0, succeeded: [], failed: [] };
   }
 
+  const urlIndex = await buildUrlIndex();
   const succeeded: BulkResult['succeeded'] = [];
   const failed: BulkResult['failed'] = [];
 
@@ -375,22 +527,25 @@ export async function processBulkSubmission(
       continue;
     }
 
-    if (await isDuplicateUrl(url)) {
-      console.warn(`Duplicate URL detected in bulk submission: ${url}`);
-      failed.push({ url, reason: `Duplicate URL: ${url}` });
+    const duplicatePath = urlIndex.get(url);
+    if (duplicatePath) {
+      const relPath = formatRelativePath(duplicatePath);
+      console.warn(`Duplicate URL detected in bulk submission: ${url} (already in ${relPath})`);
+      failed.push({ url, reason: `Duplicate URL: ${url} (already in ${relPath})` });
       continue;
     }
 
-    let title = extractTitleFromNote(note) || url;
+    let oembed: OEmbedData | null = null;
     let thumbnailUrl: string | undefined;
 
     if (type === 'youtube') {
-      const oembed = await fetchYouTubeOEmbed(url);
+      oembed = await fetchYouTubeOEmbed(url);
       if (oembed) {
-        title = oembed.title || title;
         thumbnailUrl = oembed.thumbnail_url;
       }
     }
+
+    const title = resolveSubmissionTitle(parsed, oembed, url);
 
     try {
       const id = generateId(url, issue.number);
@@ -492,7 +647,25 @@ if (import.meta.main) {
       }
     }
 
-    if (result.succeeded.length === 0) {
+    // Write a machine-readable summary for the workflow comment step.
+    const reportPayload = {
+      issueNumber: resolvedIssue.number,
+      total: result.total,
+      succeeded: result.succeeded.map((item) => ({
+        url: item.url,
+        filePath: formatRelativePath(item.filePath),
+      })),
+      failed: result.failed,
+    };
+    await writeFile(
+      join(ROOT, 'bulk-result.json'),
+      `${JSON.stringify(reportPayload, null, 2)}\n`,
+      'utf-8',
+    );
+
+    // Partial success keeps exit 0 so downstream steps (PR, auto-merge) run
+    // for the items that DID succeed. Only a total failure fails the job.
+    if (result.total > 0 && result.succeeded.length === 0) {
       process.exit(1);
     }
 

--- a/tests/process-submission.test.ts
+++ b/tests/process-submission.test.ts
@@ -2,8 +2,11 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { readFile, rm } from 'fs/promises';
 import { join } from 'path';
 import {
-  fetchYouTubeOEmbed,
+  buildUrlIndex,
+  deriveShortTitle,
   extractTitleFromNote,
+  fetchYouTubeOEmbed,
+  findDuplicateUrl,
   generateId,
   isDuplicateUrl,
   isSpam,
@@ -11,8 +14,11 @@ import {
   parseIssueBody,
   processBulkSubmission,
   processSubmission,
+  resolveSubmissionTitle,
   type BulkResult,
   type IssueData,
+  type OEmbedData,
+  type ParsedSubmission,
 } from '../scripts/process-submission';
 
 const ROOT = process.cwd();
@@ -164,6 +170,138 @@ describe('extractTitleFromNote', () => {
 
   it('returns empty string for empty note', () => {
     expect(extractTitleFromNote('')).toBe('');
+  });
+});
+
+describe('deriveShortTitle', () => {
+  it('skips section heading lines when finding the first real content line', () => {
+    // First meaningful content line has TWO sentences, so deriveShortTitle
+    // returns only the first sentence and is therefore distinct from the
+    // underlying content line (no title==description overlap).
+    const note = ['## 개요', '이것은 추출될 제목입니다. 나머지 문장은 무시됩니다.', '', '## 주요 내용', '- 포인트 1'].join('\n');
+    expect(deriveShortTitle(note)).toBe('이것은 추출될 제목입니다.');
+  });
+
+  it('returns null when derivation would equal the first content line (prevents title==description)', () => {
+    const note = ['## 개요', 'AI 에이전트를 프로덕션 환경에서 활용하는 실전 분석 기사', '', '## 주요 내용', '- 설계 패턴'].join('\n');
+    expect(deriveShortTitle(note)).toBeNull();
+  });
+
+  it('extracts only the first sentence from a multi-sentence paragraph', () => {
+    const note = '첫 번째 문장입니다. 두 번째 문장은 무시되어야 합니다. 세 번째 문장.';
+    expect(deriveShortTitle(note)).toBe('첫 번째 문장입니다.');
+  });
+
+  it('truncates grapheme-aware at 80 characters with ellipsis', () => {
+    const longLine = '가'.repeat(120);
+    const result = deriveShortTitle(longLine);
+    expect(result).not.toBeNull();
+    expect(Array.from(result!).length).toBeLessThanOrEqual(81); // 80 + 1 ellipsis
+    expect(result!.endsWith('…')).toBe(true);
+  });
+
+  it('returns null for empty or whitespace-only input', () => {
+    expect(deriveShortTitle('')).toBeNull();
+    expect(deriveShortTitle('   \n  \t ')).toBeNull();
+  });
+
+  it('skips URL-only lines and uses the next content line', () => {
+    // Two sentences in the content line so truncation differs from the full line.
+    const note = 'https://example.com/first-line\n실제 콘텐츠의 첫 문장. 다음 문장.';
+    expect(deriveShortTitle(note)).toBe('실제 콘텐츠의 첫 문장.');
+  });
+});
+
+describe('resolveSubmissionTitle', () => {
+  const parsedBase: ParsedSubmission = {
+    url: 'https://example.com/resolve',
+    type: 'article',
+    tags: ['test'],
+    note: 'First meaningful content line.',
+  };
+
+  it('prefers parsed.title when set', () => {
+    const parsed: ParsedSubmission = { ...parsedBase, title: 'Explicit Title' };
+    expect(resolveSubmissionTitle(parsed, null, parsed.url)).toBe('Explicit Title');
+  });
+
+  it('falls through to oEmbed title when parsed.title is missing', () => {
+    const oembed: OEmbedData = { title: 'From oEmbed' };
+    expect(resolveSubmissionTitle(parsedBase, oembed, parsedBase.url)).toBe('From oEmbed');
+  });
+
+  it('falls through to deriveShortTitle when oEmbed is null and content has multiple sentences', () => {
+    const parsed: ParsedSubmission = { ...parsedBase, note: '첫 문장. 두번째 문장.' };
+    expect(resolveSubmissionTitle(parsed, null, parsed.url)).toBe('첫 문장.');
+  });
+
+  it('falls back to hostname when everything else would equal description', () => {
+    const parsed: ParsedSubmission = { ...parsedBase, note: ['## 개요', 'Only one content line.'].join('\n') };
+    expect(resolveSubmissionTitle(parsed, null, parsed.url)).toBe('example.com');
+  });
+});
+
+describe('parseBulkIssueBody 5-column format', () => {
+  it('parses optional title column when 5 pipe-separated fields are present', () => {
+    const body = [
+      '### Link List', '',
+      'https://example.com/a | Article | Hand Title | ai, llm | 요약 내용',
+    ].join('\n');
+    const result = parseBulkIssueBody(body);
+    expect(result).toHaveLength(1);
+    expect(result[0].title).toBe('Hand Title');
+    expect(result[0].tags).toEqual(['ai', 'llm']);
+    expect(result[0].note).toBe('요약 내용');
+  });
+
+  it('still parses legacy 4-column format with no title', () => {
+    const body = [
+      '### Link List', '',
+      'https://example.com/b | Article | ai, llm | 요약 내용',
+    ].join('\n');
+    const result = parseBulkIssueBody(body);
+    expect(result).toHaveLength(1);
+    expect(result[0].title).toBeUndefined();
+    expect(result[0].tags).toEqual(['ai', 'llm']);
+    expect(result[0].note).toBe('요약 내용');
+  });
+
+  it('ignores TITLE field when line has malformed extra pipes (client responsibility to sanitize)', () => {
+    // Pipe inside title breaks column alignment on the server; server cannot
+    // recover the intended title unambiguously. We accept the line but the
+    // client-side wrapper is responsible for rejecting pipe-in-title before submit.
+    const body = [
+      '### Link List', '',
+      'https://example.com/c | Article | Bad|Title | ai | 요약',
+    ].join('\n');
+    const result = parseBulkIssueBody(body);
+    // Server still parses something (not ideal, but documented):
+    expect(result).toHaveLength(1);
+    // rawTitle="Bad", rawTags="Title" — demonstrates the ambiguity:
+    expect(result[0].title).toBe('Bad');
+  });
+});
+
+describe('findDuplicateUrl', () => {
+  it('returns the matching file path for a known duplicate URL', async () => {
+    const result = await findDuplicateUrl('https://arstechnica.com/tech-policy/2026/04/californians-sue-over-ai-tool-that-records-doctor-visits/');
+    expect(result).not.toBeNull();
+    expect(result).toContain('src');
+    expect(result).toMatch(/\.json$/);
+  });
+
+  it('returns null for a URL not in the repo', async () => {
+    await expect(findDuplicateUrl('https://totally-new-url-xyz-12345.com/article')).resolves.toBeNull();
+  });
+});
+
+describe('buildUrlIndex', () => {
+  it('builds an index mapping existing URLs to their file paths', async () => {
+    const index = await buildUrlIndex();
+    expect(index.size).toBeGreaterThan(0);
+    const match = index.get('https://arstechnica.com/tech-policy/2026/04/californians-sue-over-ai-tool-that-records-doctor-visits/');
+    expect(match).toBeDefined();
+    expect(match).toMatch(/\.json$/);
   });
 });
 
@@ -360,7 +498,7 @@ describe('processSubmission', () => {
     expect(result).toEqual({ success: false, message: 'Could not parse issue body' });
   });
 
-  it('derives title from first content line of multiline note', async () => {
+  it('avoids title == description by falling back to hostname when the only content line IS the description', async () => {
     const issue: IssueData = {
       number: 300,
       title: '📎 Submit Link',
@@ -386,9 +524,37 @@ describe('processSubmission', () => {
       description?: string;
     };
 
-    expect(saved.title).toBe('AI 에이전트를 프로덕션 환경에서 활용하는 실전 분석 기사');
+    // Previously title was copied from the note's first content line,
+    // which ended up identical to description. Now it falls back to hostname
+    // so title and description stay visually distinct.
+    expect(saved.title).toBe('example.com');
     expect(saved.description).toContain('## 개요');
     expect(saved.description).toContain('## 주요 내용');
+  });
+
+  it('uses explicit parsed.title when bulk submission provides a title column', async () => {
+    const issue: IssueData = {
+      number: 301,
+      title: '📦 Bulk Submit',
+      body: [
+        '### Link List', '',
+        'https://example.com/explicit-title | Article | Hand-Crafted Title | ai | AI 에이전트를 프로덕션 환경에서 활용하는 실전 분석 기사',
+      ].join('\n'),
+      labels: [{ name: 'submission' }, { name: 'bulk' }],
+      user: { login: 'testuser', id: 2 },
+    };
+
+    const result = await processBulkSubmission(issue);
+    expect(result.succeeded).toHaveLength(1);
+    expect(result.failed).toHaveLength(0);
+
+    createdFiles.push(result.succeeded[0].filePath);
+    const saved = JSON.parse(await readFile(result.succeeded[0].filePath, 'utf-8')) as {
+      title: string;
+      description?: string;
+    };
+    expect(saved.title).toBe('Hand-Crafted Title');
+    expect(saved.description).toContain('AI 에이전트');
   });
 });
 


### PR DESCRIPTION
﻿## Summary

Two recurring bulk submission problems surfaced in Issue #155 (bulk submit with 9 URLs):

1. **`title == description` overlap** \u2014 7 of 8 merged articles had titles identical to their descriptions (120\u2013240 chars each), because `extractTitleFromNote` returned the summary's first non-heading line as title when oEmbed metadata was sparse (e.g., YouTube channel pages).

2. **Silent duplicate drop** \u2014 the 9th URL (JEPA video) was rejected as a known duplicate but the workflow only posted the generic "\u2705 \uc81c\ucd9c\uc774 \uc811\uc218\ub418\uc5c8\uc2b5\ub2c8\ub2e4" comment, so the user never learned which URL was silently skipped.

Closes the root causes server-side so the same failure mode cannot recur on future bulk submissions.

## Changes

### Title resolution

- New `deriveShortTitle(note)`: first-sentence extractor that skips section headings (`\uac1c\uc694`, `\uc8fc\uc694 \ub0b4\uc6a9`, `\uc2dc\uc0ac\uc810`, \u2026) and URL-only lines, truncates at 80 graphemes, and **returns null when the derived title would be effectively identical to the first content line** (prevents title==description).
- New `resolveSubmissionTitle(parsed, oembed, url)` fallback chain shared by single + bulk flows: `parsed.title` \u2192 `oEmbed.title` \u2192 `deriveShortTitle(note)` \u2192 URL hostname.
- Bulk parser (`parseBulkIssueBody`) now accepts an **optional 5-column format** `URL | Type | Title | Tags | Summary` and remains backward compatible with the legacy 4-column layout. Forbidden chars in the title (`|`, tab, CR/LF) cause the line to be skipped.

### Duplicate detection + failure reporting

- `isDuplicateUrl(url)` kept as boolean wrapper; new `findDuplicateUrl(url)` returns the conflicting file path for user-facing messages.
- New `buildUrlIndex()` loads `url \u2192 filePath` once per bulk run instead of rescanning the repo per item.
- `process-submission.ts` writes `bulk-result.json` and exits 0 on partial failure / non-zero only on **total** failure.
- New workflow step `Report bulk submission results` **upserts** a detailed comment on the Issue (marked with `<!-- honeycombo-bulk-result -->`) listing failed URLs + reasons when any bulk item fails. The generic success comment is suppressed in that case.

### Coverage

- 6 new `describe` blocks (`deriveShortTitle`, `resolveSubmissionTitle`, `parseBulkIssueBody 5-column format`, `findDuplicateUrl`, `buildUrlIndex`) \u2014 15 new test cases plus updated existing ones.
- Final: **54/54 tests pass**.
- Updated `docs/features/bulk-submission.md` and new `docs/troubleshooting/bulk-title-description-overlap.md`.

## Validation

| Check | Result |
|---|---|
| `bun run validate` | \u2705 All 336 files valid |
| `bun run validate:docs` | \u2705 All 64 doc files valid |
| `bun run validate:docs -- --check-coverage` | \u2705 \ubb38\uc11c \ubcc0\uacbd \ubc94\uc704 \uac80\uc0ac \ud1b5\uacfc |
| `bun run build` | \u2705 701 pages built in 7.47s |
| `bun run test` | \u2705 326/326 pass |

## Backward compatibility

- Legacy 4-column bulk TSV submissions continue to work unchanged.
- `isDuplicateUrl` kept as public wrapper so external callers don't break.
- Existing `extractTitleFromNote` is preserved (still tested) \u2014 it is no longer called by the fallback chain, but other modules may still reference it.

## Client-side follow-up (separate PR)

The `honeypot` monorepo's `plugins/link-curator` will ship a matching client update that adds an `--emit-title` flag to `submit_bulk.sh` and rejects pipe/tab/CR/LF in TITLE/SUMMARY fields before submission.
