### PR TITLE
feat: replace auto-playlist-add with /my/articles management page

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -405,43 +405,78 @@ transition: background 0.15s, color 0.15s;
 | Visibility | 기본 `display: none`; `.batch-edit-mode` 하위에서 `display: flex` |
 | A11y | `aria-label="드래그하여 순서 변경"` |
 
-#### 4.9 Batch Edit Mode (플레이리스트 배치 편집) — `functions/p/[id].ts`
+#QM|#### 4.9 Batch Edit Mode (플레이리스트 배치 편집) — `functions/p/[id].ts`
+#XK|
+#BW|플레이리스트 소유자가 아이템 순서를 한 번에 재배치할 수 있는 토글 모드. `📋 배치 편집` 버튼으로 진입 → SortableJS 드래그로 재정렬 → `저장` 또는 `취소`로 종료한다. 아이템이 2개 이상인 소유자에게만 노출.
+#PN|
+#QJ|**컨테이너 (`.items.batch-edit-mode`)**
+#RZ|
+#XR|- `border: 2px dashed var(--color-border)` (편집 중임을 나타내는 점선 테두리)
+#JP|- `border-radius: var(--radius-md)`
+#TS|- `padding: var(--space-md)`
+#RS|- `background: var(--color-bg-secondary)` (따뜻한 cream 배경으로 모드 차별화)
+#QM|- `grid-template-columns: 1fr` (배치 중에는 단일 열로 강제 — 세로 드래그에 집중)
+#WY|
+#JJ|**링크·컨트롤 비활성화 (`.batch-edit-mode` 하위)**
+#RM|
+#MZ|- `.item-title a { pointer-events: none; color: var(--color-text-muted); }` — 편집 중 페이지 이탈 방지
+#ZZ|- `.item-controls { display: none; }` — 삭제/메모 버튼 숨김 (배치 작업에 집중)
+#PX|
+#VM|**툴바 (`.items-toolbar`)**
+#XT|
+#YR|- `display: flex; justify-content: flex-end; align-items: center; gap: var(--space-sm); margin-bottom: var(--space-md);`
+#ZJ|- 평상시: `📋 배치 편집` 버튼 한 개 노출 (§4.2 Inline small button 패턴, `.btn-sm`)
+#YJ|- 편집 중: `.batch-edit-btn`은 `hidden`, `.batch-action-bar` 노출
+#WZ|
+#TW|**액션 바 (`.batch-action-bar`)**
+#WS|
+#PV|- `display: flex; gap: var(--space-sm); align-items: center;`
+#BW|- `취소` 버튼: §4.3 Ghost 패턴 (`.btn.btn-sm`, transparent bg → bg-secondary hover)
+#HH|- `저장` 버튼: §4.1 Global `.btn-primary` 패턴 (gradient + warm shadow)
+#VV|- 저장 중에는 `disabled` + `저장 중...` 라벨
+#YY|
+#ZZ|**상태 전이 요약**
+#ST|
+#RY|| 전이 | 트리거 | 동작 |
+#MB||------|--------|------|
+#WP|| normal → editing | `📋 배치 편집` 클릭 | 원래 순서 snapshot, SortableJS lazy-load·초기화, 툴바·링크 비활성화 |
+#VV|| editing → normal (저장) | `저장` 클릭 | `PUT /api/playlists/{id}/items/reorder` → 성공 시 reload |
+#PS|| editing → normal (취소) | `취소` 클릭 | snapshot으로 DOM 복원, SortableJS destroy |
 
-플레이리스트 소유자가 아이템 순서를 한 번에 재배치할 수 있는 토글 모드. `📋 배치 편집` 버튼으로 진입 → SortableJS 드래그로 재정렬 → `저장` 또는 `취소`로 종료한다. 아이템이 2개 이상인 소유자에게만 노출.
+#### 4.10 Content Tabs (`.tab-header`, `.tab-btn`)
 
-**컨테이너 (`.items.batch-edit-mode`)**
+탭 전환 UI 패턴. `src/components/ContentTabs.astro` 및 `/my/articles` 등에서 사용.
 
-- `border: 2px dashed var(--color-border)` (편집 중임을 나타내는 점선 테두리)
-- `border-radius: var(--radius-md)`
-- `padding: var(--space-md)`
-- `background: var(--color-bg-secondary)` (따뜻한 cream 배경으로 모드 차별화)
-- `grid-template-columns: 1fr` (배치 중에는 단일 열로 강제 — 세로 드래그에 집중)
+- **Tab bar container (`.tab-header`)**: `display: flex; border-bottom: 2px solid var(--color-border);`
+- **Active state (`.tab-btn.active`)**: `color: var(--color-primary); border-bottom-color: var(--color-primary); font-weight: 600;`
+- **Inactive state (`.tab-btn`)**: `color: var(--color-text-muted); border-bottom-color: transparent;`
+- **Hover (inactive)**: `color: var(--color-text);`
+- **Focus-visible**: `outline: 2px solid var(--color-primary); outline-offset: 2px;`
+- **Transition**: `color 0.15s ease-out, border-color 0.15s ease-out;`
+- **Disabled**: `opacity: 0.5; cursor: not-allowed;`
 
-**링크·컨트롤 비활성화 (`.batch-edit-mode` 하위)**
+#### 4.11 Playlist Badge (`.playlist-badge`)
 
-- `.item-title a { pointer-events: none; color: var(--color-text-muted); }` — 편집 중 페이지 이탈 방지
-- `.item-controls { display: none; }` — 삭제/메모 버튼 숨김 (배치 작업에 집중)
+Used in `/my/articles` assigned tab to show which playlists contain an article. Each badge has a ✕ remove button.
 
-**툴바 (`.items-toolbar`)**
+- **Container**: `display: inline-flex; align-items: center; gap: var(--space-xs); padding: var(--space-xs) var(--space-sm); background: var(--color-bg-secondary); border: 1px solid var(--color-border); border-radius: var(--radius-sm); color: var(--color-text); font-size: 0.8125rem; transition: border-color 0.15s ease-out;`
+- **Hover**: `border-color: var(--color-primary);`
+- **Focus-visible** (keyboard navigation on the badge): `outline: 2px solid var(--color-primary); outline-offset: 2px;`
+- **Remove button (`.playlist-badge-remove`)**: `background: transparent; border: none; cursor: pointer; color: var(--color-text-muted); padding: 0; font-size: inherit; line-height: 1; transition: color 0.15s ease-out;`
+- **Remove hover**: `color: var(--color-danger);`
+- **Remove focus-visible**: outline ring.
+- **Disabled** (during API call): `opacity: 0.5; pointer-events: none;`
 
-- `display: flex; justify-content: flex-end; align-items: center; gap: var(--space-sm); margin-bottom: var(--space-md);`
-- 평상시: `📋 배치 편집` 버튼 한 개 노출 (§4.2 Inline small button 패턴, `.btn-sm`)
-- 편집 중: `.batch-edit-btn`은 `hidden`, `.batch-action-bar` 노출
+#### 4.12 Page Notification (`.page-notification`)
 
-**액션 바 (`.batch-action-bar`)**
+Scoped success/error messages shown at the top of a page's content area. Auto-dismiss after 3 seconds. NOT a global toast system.
 
-- `display: flex; gap: var(--space-sm); align-items: center;`
-- `취소` 버튼: §4.3 Ghost 패턴 (`.btn.btn-sm`, transparent bg → bg-secondary hover)
-- `저장` 버튼: §4.1 Global `.btn-primary` 패턴 (gradient + warm shadow)
-- 저장 중에는 `disabled` + `저장 중...` 라벨
-
-**상태 전이 요약**
-
-| 전이 | 트리거 | 동작 |
-|------|--------|------|
-| normal → editing | `📋 배치 편집` 클릭 | 원래 순서 snapshot, SortableJS lazy-load·초기화, 툴바·링크 비활성화 |
-| editing → normal (저장) | `저장` 클릭 | `PUT /api/playlists/{id}/items/reorder` → 성공 시 reload |
-| editing → normal (취소) | `취소` 클릭 | snapshot으로 DOM 복원, SortableJS destroy |],op:
+- **Container**: `position: sticky;` (or fixed at top of content); `max-width: var(--max-width, 1200px); margin: 0 auto var(--space-md); padding: var(--space-sm) var(--space-md); border-radius: var(--radius-sm); background: var(--color-bg-secondary); font-size: 0.9375rem;`
+- **Success variant (`.page-notification--success`)**: `border-left: 3px solid var(--color-success); color: var(--color-text);`
+- **Error variant (`.page-notification--error`)**: `border-left: 3px solid var(--color-danger); color: var(--color-text);`
+- **Enter animation**: `transform: translateY(-100%) -> translateY(0); opacity: 0 -> 1; 0.2s ease-out;`
+- **Exit animation**: `opacity: 1 -> 0; 0.2s ease-out;` then removed from DOM.
+- **Usage note**: Create via JS, append to page, auto-remove via setTimeout. Keep DOM lean — at most 1 visible at a time; new notifications replace the previous.
 
 ### Card (`.card`) — `styles/global.css`
 
@@ -825,12 +860,13 @@ body with rationale.
 - [`src/pages/articles/[...slug].astro`](./src/pages/articles/[...slug].astro) — `.article-detail-title`
 - [`src/pages/influencers.astro`](./src/pages/influencers.astro) — `.platform-title`
 
-## 변경 이력
-
-| 날짜 | 변경 내용 |
-|------|----------|
-| 2026-04-21 | 최초 작성 — 9개 섹션 초판 (global.css + 주요 컴포넌트 기반). |
-| 2026-04-21 | Oracle 검증 피드백 반영 — (1) §1에서 "gradient는 브랜드 포인트만" 문구를 "Energetic CTAs"로 교정해 `.btn-primary`/`.like-button` 실 사용 반영, (2) §3 Hierarchy에 `.hero-headline`/`.home-section-title`/`.article-detail-title`/`.platform-title`/`.comments-title` 추가, (3) §4에 전역 `.btn`/`.btn-primary`/`.btn-secondary` 실패턴과 `.form-control`/`.search-input`/`.article-search-input` 3종 input을 실제 코드 기준으로 기술, (4) §6에 warm shadow rgba 공식화, (5) §7에 파란색 focus ring 금지 + gradient 남용 금지 추가, (6) AGENTS.md에서 "항상 DESIGN.md를 먼저 편집"을 리터럴 조항으로 강제하는 방향으로 동기화. |
+#ZQ|## 변경 이력
+#MZ|
+#TT|| 날짜 | 변경 내용 |
+#YB||------|----------|
+| 2026-04-21 | 기사 관리 페이지(/my/articles) 신설에 따른 플레이리스트 배지 패턴, 인페이지 알림 패턴 추가. 탭 패턴 기존 정의 확인/보강. |
+#VK|| 2026-04-21 | 최초 작성 — 9개 섹션 초판 (global.css + 주요 컴포넌트 기반). |
+#YS|| 2026-04-21 | Oracle 검증 피드백 반영 — (1) §1에서 "gradient는 브랜드 포인트만" 문구를 "Energetic CTAs"로 교정해 `.btn-primary`/`.like-button` 실 사용 반영, (2) §3 Hierarchy에 `.hero-headline`/`.home-section-title`/`.article-detail-title`/`.platform-title`/`.comments-title` 추가, (3) §4에 전역 `.btn`/`.btn-primary`/`.btn-secondary` 실패턴과 `.form-control`/`.search-input`/`.article-search-input` 3종 input을 실제 코드 기준으로 기술, (4) §6에 warm shadow rgba 공식화, (5) §7에 파란색 focus ring 금지 + gradient 남용 금지 추가, (6) AGENTS.md에서 "항상 DESIGN.md를 먼저 편집"을 리터럴 조항으로 강제하는 방향으로 동기화. |
 | 2026-04-21 | Oracle 2차 검증 피드백 반영 — (a) `.like-button.is-liked`가 primary→accent 그라데이션이 아닌 별도 Like 토큰(`--color-like-*`, `--shadow-like`)을 쓴다는 실제 코드를 반영해 §1/§2/§4/§6/§7 전반에서 오보 제거. (b) §2에 Like Family 전용 토큰 도표 추가. (c) §4.6 Like Button + §4.7 기타 전용 버튼 패밀리(bookmark/itp/playlist-item/article-search-clear/auth) 추가. (d) §3 "현행 코드에서 실제 정의된 모든" 문구를 "주요 텍스트 계층"으로 완화하고 `.playlist-title`/`.influencer-name`/`.pending-title`/`.itp-section-title`/`.guide-card h3`/`.write-form h2` 추가. (e) §6 L7/L8 계층 추가 (Like 전용 shadow, pink rgba 231,76,111). (f) §7 Gradient 남용 조항에 like-family 명시. (g) AGENTS.md 리터럴 규칙을 "항상 DESIGN.md를 열고 검토, 변경 없어도 변경 이력에 작업 것질장 남김"으로 강화. |
 | 2026-04-21 | Oracle 3차 검증 피드백 반영 — §3 타이포그래피 테이블의 '체크 필요' 플레이스홀더 4개를 실제 코드에서 추출한 값으로 교체. §1/§7 Gradient 조항을 (a)~(f) 6군 실제 그라데이션 패턴으로 정리. '남용 금지' → '남용 지양, 신규 그룹 도입은 문서 먼저'로 소프닝. |
 | 2026-04-21 | Oracle 4차 검증 피드백 반영 — §3 'Button (small) | `.btn` (forms)' 행의 잘못된 추출값을 실제 코드 값으로 교체(pages/p/new.astro:425-437, admin/must-read.astro:565-579). |

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -89,6 +89,9 @@
 | `lib/validate.ts` | URL/제목/source_id 검증 |
 | `webhooks/submission-approved.ts` | 기사 승인 시 플레이리스트 자동 추가 webhook |
 | `webhooks/submission-removed.ts` | 기사 삭제/거부 시 플레이리스트 자동 정리 webhook |
+| `api/my/articles/index.ts` | GET 기사 목록 (status=unassigned/assigned/all) |
+| `api/my/articles/[articleId]/playlists/index.ts` | POST 기사를 플레이리스트에 추가 |
+| `api/my/articles/[articleId]/playlists/[playlistId].ts` | DELETE 기사를 플레이리스트에서 제거 |
 | `lib/webhooks.ts` | Webhook shared secret 검증 유틸리티 |
 
 ### `.github/workflows/` — CI/CD
@@ -117,6 +120,7 @@
 | `/p/new` | `p/new.astro` | 유저 플레이리스트 생성 폼 |
 | `/p/{id}` | `functions/p/[id].ts` | 유저 플레이리스트 상세 (SSR, 기사 검색/관리) |
 | `/my/playlists` | `my/playlists.astro` | 내 플레이리스트 관리 |
+| `/my/articles` | `my/articles.astro` | 사용자의 제출 기사를 미배정/배정 탭으로 관리 |
 | `/admin/playlists` | `admin/playlists.astro` | 관리자 플레이리스트 승인 페이지 |
 | `/admin/must-read` | `admin/must-read.astro` | 관리자 Must-read 선정 페이지 |
 | `/search-index.json` | `search-index.json.ts` | 플레이리스트 상세 기사 검색용 정적 JSON 인덱스 |
@@ -156,9 +160,7 @@ GitHub Issue (single/bulk) → scripts/process-submission.ts → PR (src/content
 - 제출 시 GitHub Issue 작성자의 numeric user id(`submitted_by_id`)도 함께 저장해 승인 webhook에서 D1 사용자와 매칭한다.
 ### 4. 기사 승인 시 플레이리스트 자동 추가
 
-PR merge (새 파일 감지) → git push master → on-article-approved.yml → POST /webhooks/submission-approved → D1 (플레이리스트 자동 추가)
-
-미로그인 제출자 → submissions 적재 → `/api/auth/github/callback` 로그인 시 catch-up → 자동 플레이리스트 반영
+GitHub Issue → PR → merge → webhook → submissions table (D1) → 사용자가 /my/articles에서 수동 배정
 
 
 ### 5. 빌드
@@ -204,6 +206,7 @@ src/ (pages + components + data + content) → astro build → dist/
 
 | 날짜 | 변경 내용 |
 |------|----------|
+| 2026-04-21 | /my/articles 페이지 및 /api/my/articles/* API 추가. 자동 플레이리스트 추가 흐름 제거 반영. |
 | 2026-04-11 | 최초 작성 — 현재 프로젝트 구조 기반 |
 | 2026-04-12 | validate-docs 스크립트 추가, CI 파이프라인 반영 |
 | 2026-04-12 | 단건 제출 워크플로우에 bulk submission 처리 추가 |

--- a/docs/decisions/0006-remove-auto-playlist-add.md
+++ b/docs/decisions/0006-remove-auto-playlist-add.md
@@ -1,0 +1,53 @@
+# 0006. 자동 플레이리스트 추가 제거 및 기사 관리 페이지 도입
+
+> 기사 제출 시 자동 플레이리스트 추가를 제거하고, 사용자가 직접 기사를 플레이리스트에 배정하는 `/my/articles` 페이지를 신설한다.
+
+## 상태
+
+승인 (2026-04-21)
+
+## 맥락
+
+기존 동작:
+- 사용자가 기사를 제출하면 webhook(`functions/webhooks/submission-approved.ts`)이 자동으로 사용자의 가장 최근 플레이리스트에 기사를 추가.
+- 플레이리스트가 없는 사용자에게는 "내 제출 기사" 플레이리스트를 자동 생성 (`is_auto_created=1`, unlisted, draft).
+- OAuth 콜백(`functions/api/auth/github/callback.ts`)은 첫 로그인 시 `submissions` 테이블의 pending 기사를 catch-up sync로 플레이리스트에 추가.
+
+문제점:
+- 사용자가 어느 플레이리스트에 기사가 들어갈지 선택 불가.
+- "최근 플레이리스트"가 사용자 의도와 다른 경우 오배정 발생.
+- 자동 플레이리스트 이름("내 제출 기사")이 사용자 의도와 무관.
+
+## 결정
+
+1. `submission-approved.ts`의 자동 플레이리스트 추가 로직 제거. 대신 `submissions` 테이블에 항상 upsert (사용자 로그인 여부 무관).
+2. `github/callback.ts`의 catch-up sync 로직 제거.
+3. 새 페이지 `/my/articles` 도입. 미배정/배정된 두 탭으로 기사 관리.
+4. `submissions` 테이블의 역할을 "deferred pending"에서 "사용자 제출 기사의 canonical registry"로 재정의.
+5. 기존 자동 생성 플레이리스트 및 자동 추가된 `playlist_items` 레코드는 삭제하지 않고 유지 (사용자가 직접 제거 선택).
+6. 과거 기사는 `scripts/backfill-submissions.ts`로 `submissions` 테이블에 백필.
+
+## 고려한 대안
+
+- **대안 1: 자동 추가 유지 + 수동 오버라이드 UI 추가** → 거부. UX 이중화로 혼란 증가, 여전히 초기 배정이 불투명.
+- **대안 2: 자동 추가를 "제거 전용" UI로만 보완** → 거부. "잘못된 플레이리스트" 문제 미해결.
+- **대안 3: 기사 관리용 새 D1 테이블 신설** → 거부. `submissions` 테이블이 이미 필요한 스키마(article_id, submitted_by_id, title, url)를 보유.
+
+## 결과
+
+- 사용자가 기사 배정을 완전히 제어.
+- 과거 기사는 backfill을 통해 신규 페이지에 즉시 노출.
+- 기존 자동 플레이리스트는 그대로 유지되어 사용자 데이터 손실 없음.
+- `submissions.synced_to_playlist` 컬럼은 유지하되 새 의미(현재 어느 플레이리스트에도 속하지 않음)로 재해석 가능. V1에서는 실질적으로 미사용(향후 사용 여지).
+
+## 관련 문서
+
+- [기사 관리 페이지](../features/article-management.md)
+- [자동 플레이리스트 추가 (deprecated)](../features/auto-playlist-add.md)
+- [플레이리스트 시스템](../features/playlists.md)
+
+## 변경 이력
+
+| 날짜 | 변경 내용 |
+|------|----------|
+| 2026-04-21 | 최초 작성. 승인. |

--- a/docs/features/article-management.md
+++ b/docs/features/article-management.md
@@ -1,0 +1,56 @@
+# 기사 관리 페이지 (/my/articles)
+
+> 사용자가 제출한 기사의 플레이리스트 배정을 직접 관리할 수 있는 개인 페이지.
+
+## 개요
+
+- **목적**: 기존에 자동으로 최근 플레이리스트에 추가되던 기사를 사용자가 직접 원하는 플레이리스트에 배정하도록 UX 변경.
+- **대상 사용자**: 로그인한 모든 사용자(에디터 포함). 본인이 제출한 기사만 관리 가능.
+- **구성**: 한 페이지 내 두 개의 탭 — "미배정 기사" / "배정된 기사".
+
+## 동작 흐름
+
+1. 사용자가 GitHub Issue로 기사 제출 → `.github/workflows/process-submission.yml` → `scripts/process-submission.ts` → PR 생성 → merge → `.github/workflows/on-article-approved.yml` → webhook POST.
+2. `functions/webhooks/submission-approved.ts`가 webhook을 받아 `submissions` 테이블에 무조건 upsert. **자동 플레이리스트 추가는 수행하지 않음.**
+3. 사용자가 `/my/articles` 접속 → `GET /api/my/articles?status=all` 호출.
+4. 페이지가 두 탭으로 기사 분할 표시:
+   - 미배정 기사 탭: `playlists.length === 0`인 기사 카드 + "플레이리스트에 추가" 버튼.
+   - 배정된 기사 탭: `playlists.length > 0`인 기사 카드 + 플레이리스트 배지 + "다른 플레이리스트에 추가" 버튼.
+5. 플레이리스트에 추가 → `POST /api/my/articles/:articleId/playlists`.
+6. 플레이리스트에서 제거 → `DELETE /api/my/articles/:articleId/playlists/:playlistId`.
+7. 마지막 배지 제거 시 카드는 미배정 탭으로 이동.
+
+## 관련 파일
+
+| 경로 | 역할 |
+|---|---|
+| `src/pages/my/articles.astro` | 기사 관리 페이지 UI (Astro shell + client-side JS) |
+| `functions/api/my/articles/index.ts` | GET 기사 목록 (status=unassigned/assigned/all) |
+| `functions/api/my/articles/[articleId]/playlists/index.ts` | POST 기사를 플레이리스트에 추가 |
+| `functions/api/my/articles/[articleId]/playlists/[playlistId].ts` | DELETE 기사를 플레이리스트에서 제거 |
+| `functions/webhooks/submission-approved.ts` | 기사 승인 webhook (submissions 테이블 upsert) |
+| `scripts/backfill-submissions.ts` | 기존 기사 submissions 테이블 백필 스크립트 |
+| `migrations/0004_auto_playlist.sql` | `submissions` 테이블 정의 |
+
+## 설정값
+
+새 환경 변수 없음. 기존 `WEBHOOK_SECRET` 및 D1 binding `DB`를 재사용.
+
+## 제약 사항
+
+- V1 범위: 벌크 작업 없음, 검색/필터/정렬 없음, 드래그&드롭 없음, 페이지 내 플레이리스트 생성 없음.
+- 페이지는 로그인한 사용자 본인이 제출한 기사만 표시 (`submissions.submitted_by_id = current_user.id`).
+- 한 번에 최대 100개 기사까지 로드(`limit=100`). 그 이상은 pagination 필요 (V2).
+- 플레이리스트 "변경"은 독립 API가 아니라 client-side에서 `DELETE` + `POST`의 조합.
+
+## 관련 문서
+
+- [0006. 자동 플레이리스트 추가 제거 (ADR)](../decisions/0006-remove-auto-playlist-add.md)
+- [플레이리스트 시스템](./playlists.md)
+- [자동 플레이리스트 추가 (deprecated)](./auto-playlist-add.md)
+
+## 변경 이력
+
+| 날짜 | 변경 내용 |
+|------|----------|
+| 2026-04-21 | 최초 작성 |

--- a/docs/features/auto-playlist-add.md
+++ b/docs/features/auto-playlist-add.md
@@ -1,4 +1,7 @@
 # 기사 승인 시 플레이리스트 자동 추가
+> ⚠️ **DEPRECATED (2026-04-21)**: 이 기능은 제거되었습니다.
+> 대체: [기사 관리 페이지 (/my/articles)](./article-management.md)
+> 관련 ADR: [0006. 자동 플레이리스트 추가 제거](../decisions/0006-remove-auto-playlist-add.md)
 
 > 승인된 제출 기사를 제출자 플레이리스트에 자동 반영하고, 미가입 제출자는 deferred submission으로 보관하는 기능.
 
@@ -64,6 +67,7 @@ PR merge 이벤트 (새 파일 감지) → functions/webhooks/submission-approve
 
 | 날짜 | 변경 내용 |
 |------|----------|
+| 2026-04-21 | Deprecated. 자동 플레이리스트 추가 제거됨. /my/articles로 대체. |
 | 2026-04-13 | 최초 작성 |
 | 2026-04-13 | Wave 4: OAuth callback catch-up과 `synced_to_playlist` 갱신 흐름 반영 |
 | 2026-04-13 | 환경변수 설정 가이드 보강 (WEBHOOK_SECRET, SITE_URL), _routes.json 제약 추가 |

--- a/docs/features/playlists.md
+++ b/docs/features/playlists.md
@@ -154,6 +154,7 @@
 
 ### 승인 기사 자동 추가 (auto-playlist)
 
+> 참고: 기사 자동 플레이리스트 추가 기능은 2026-04-21부로 제거되었습니다. [ADR 0006](../decisions/0006-remove-auto-playlist-add.md) 참조.
 ```text
 승인 webhook → functions/webhooks/submission-approved.ts
             → users.id = submitted_by_id 조회
@@ -282,6 +283,7 @@
 
 ## 관련 문서
 
+- [기사 관리 페이지](./article-management.md)
 - [아키텍처 개요](../architecture/overview.md)
 - [기사 승인 시 플레이리스트 자동 추가](./auto-playlist-add.md)
 - [플레이리스트 데이터 미스매치 트러블슈팅](../troubleshooting/playlist-data-mismatch.md)
@@ -293,6 +295,7 @@
 
 | 날짜 | 변경 내용 |
 |------|----------|
+| 2026-04-21 | 자동 플레이리스트 추가 제거 반영. /my/articles 페이지 링크 추가. |
 | 2026-04-12 | 최초 작성 — 플레이리스트 기능 전체 문서화 |
 | 2026-04-12 | AddToPlaylist 로그인 return URL, 중복 추가 409 처리, contains_item 기반 비활성화 표시 반영 |
 | 2026-04-12 | 유저 플레이리스트 상세(`/p/{id}`)에 소유자 전용 아이템 삭제/재정렬/메모 수정 UI 반영 |

--- a/functions/api/auth/github/callback.ts
+++ b/functions/api/auth/github/callback.ts
@@ -93,46 +93,7 @@ export const onRequest: AppPagesFunction = async (context: { env: Env; request: 
   });
   const { sessionId } = await createSession(env.DB, user.id);
 
-  // Catch-up: sync pending submissions to playlist
-  try {
-    const pending = await env.DB
-      .prepare(
-        'SELECT article_id, title, url FROM submissions WHERE submitted_by_id = ? AND synced_to_playlist = 0'
-      )
-      .bind(user.id)
-      .all();
-
-    const pendingResults = pending.results as Array<{ article_id: string; title: string; url: string }>;
-
-    if (pendingResults.length > 0) {
-      const { getOrCreateAutoPlaylist } = await import('../../../lib/playlists');
-      const { addItem, DuplicateItemError } = await import('../../../lib/playlist-items');
-      const playlist = await getOrCreateAutoPlaylist(env.DB, user.id);
-
-      for (const sub of pendingResults) {
-        try {
-          await addItem(env.DB, playlist.id, user.id, {
-            item_type: 'curated',
-            source_id: sub.article_id,
-            title_snapshot: sub.title,
-            url_snapshot: sub.url,
-          });
-        } catch (err) {
-          if (!(err instanceof DuplicateItemError)) {
-            console.error(`Catch-up failed for ${sub.article_id}:`, err);
-          }
-        }
-      }
-
-      await env.DB
-        .prepare('UPDATE submissions SET synced_to_playlist = 1 WHERE submitted_by_id = ?')
-        .bind(user.id)
-        .run();
-    }
-  } catch (err) {
-    console.error('Catch-up sync failed:', err);
-    // Non-blocking — user can still log in
-  }
+  // Auto-playlist catch-up sync removed — articles are now managed manually via /my/articles. See docs/decisions/0006-remove-auto-playlist-add.md.
 
   const headers = new Headers({
     Location: (returnTo && returnTo.startsWith('/') && !returnTo.startsWith('//')) ? returnTo : '/my/playlists',

--- a/functions/api/my/articles/[articleId]/playlists/[playlistId].ts
+++ b/functions/api/my/articles/[articleId]/playlists/[playlistId].ts
@@ -1,0 +1,83 @@
+import type { AppPagesFunction } from '../../../../../lib/types';
+
+interface SubmissionLookupRow {
+  article_id: string;
+}
+
+interface PlaylistLookupRow {
+  id: string;
+}
+
+interface PlaylistItemLookupRow {
+  id: string;
+}
+
+function json(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+async function getOwnedSubmission(db: D1Database, articleId: string, userId: string): Promise<SubmissionLookupRow | null> {
+  return db
+    .prepare('SELECT article_id FROM submissions WHERE article_id = ? AND submitted_by_id = ?')
+    .bind(articleId, userId)
+    .first<SubmissionLookupRow>();
+}
+
+async function getOwnedPlaylist(db: D1Database, playlistId: string, userId: string): Promise<PlaylistLookupRow | null> {
+  return db
+    .prepare('SELECT id FROM user_playlists WHERE id = ? AND user_id = ?')
+    .bind(playlistId, userId)
+    .first<PlaylistLookupRow>();
+}
+
+async function getPlaylistItem(db: D1Database, playlistId: string, articleId: string): Promise<PlaylistItemLookupRow | null> {
+  return db
+    .prepare(
+      `SELECT id
+       FROM playlist_items
+       WHERE playlist_id = ?
+         AND source_id = ?
+         AND item_type IN ('curated', 'feed')`,
+    )
+    .bind(playlistId, articleId)
+    .first<PlaylistItemLookupRow>();
+}
+
+export const onRequest: AppPagesFunction[] = [
+  async (context) => {
+    const { request, env, params, data } = context;
+    const articleId = params.articleId;
+    const playlistId = params.playlistId;
+
+    if (request.method === 'DELETE') {
+      if (!data.user) {
+        return json({ error: 'Unauthorized' }, 401);
+      }
+
+      const userId = data.user.id;
+      const submission = await getOwnedSubmission(env.DB, articleId, userId);
+      if (!submission) {
+        return json({ error: 'Article not found' }, 404);
+      }
+
+      const playlist = await getOwnedPlaylist(env.DB, playlistId, userId);
+      if (!playlist) {
+        return json({ error: 'Playlist not found' }, 404);
+      }
+
+      const playlistItem = await getPlaylistItem(env.DB, playlist.id, articleId);
+      if (!playlistItem) {
+        return json({ error: 'Article not in this playlist' }, 404);
+      }
+
+      await env.DB.prepare('DELETE FROM playlist_items WHERE id = ?').bind(playlistItem.id).run();
+
+      return json({ success: true });
+    }
+
+    return json({ error: 'Method not allowed' }, 405);
+  },
+];

--- a/functions/api/my/articles/[articleId]/playlists/index.ts
+++ b/functions/api/my/articles/[articleId]/playlists/index.ts
@@ -1,0 +1,110 @@
+import { addItem, DuplicateItemError } from '../../../../../lib/playlist-items';
+import type { AppPagesFunction, AddItemInput } from '../../../../../lib/types';
+
+interface SubmissionLookupRow {
+  article_id: string;
+  title: string;
+  url: string;
+}
+
+interface PlaylistLookupRow {
+  id: string;
+}
+
+function json(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+async function parsePlaylistId(request: Request): Promise<string | Response> {
+  let body: unknown;
+
+  try {
+    body = await request.json();
+  } catch {
+    return json({ error: 'Invalid JSON body' }, 400);
+  }
+
+  if (!isObject(body)) {
+    return json({ error: 'Invalid request body' }, 400);
+  }
+
+  if (typeof body.playlist_id !== 'string' || !body.playlist_id.trim()) {
+    return json({ error: 'playlist_id is required' }, 400);
+  }
+
+  return body.playlist_id.trim();
+}
+
+async function getOwnedSubmission(db: D1Database, articleId: string, userId: string): Promise<SubmissionLookupRow | null> {
+  return db
+    .prepare('SELECT article_id, title, url FROM submissions WHERE article_id = ? AND submitted_by_id = ?')
+    .bind(articleId, userId)
+    .first<SubmissionLookupRow>();
+}
+
+async function getOwnedPlaylist(db: D1Database, playlistId: string, userId: string): Promise<PlaylistLookupRow | null> {
+  return db
+    .prepare('SELECT id FROM user_playlists WHERE id = ? AND user_id = ?')
+    .bind(playlistId, userId)
+    .first<PlaylistLookupRow>();
+}
+
+export const onRequest: AppPagesFunction[] = [
+  async (context) => {
+    const { request, env, params, data } = context;
+    const articleId = params.articleId;
+
+    if (request.method === 'POST') {
+      if (!data.user) {
+        return json({ error: 'Unauthorized' }, 401);
+      }
+
+      const playlistId = await parsePlaylistId(request);
+      if (playlistId instanceof Response) {
+        return playlistId;
+      }
+
+      const userId = data.user.id;
+      const submission = await getOwnedSubmission(env.DB, articleId, userId);
+      if (!submission) {
+        return json({ error: 'Article not found' }, 404);
+      }
+
+      const playlist = await getOwnedPlaylist(env.DB, playlistId, userId);
+      if (!playlist) {
+        return json({ error: 'Playlist not found' }, 404);
+      }
+
+      const input: AddItemInput = {
+        item_type: 'curated',
+        source_id: articleId,
+        title_snapshot: submission.title,
+        url_snapshot: submission.url,
+      };
+
+      try {
+        const item = await addItem(env.DB, playlist.id, userId, input);
+        if (!item) {
+          return json({ error: 'Unable to add article' }, 400);
+        }
+
+        return json({ success: true, playlist_id: playlist.id, article_id: articleId }, 201);
+      } catch (error) {
+        if (error instanceof DuplicateItemError) {
+          return json({ error: 'Article already in this playlist' }, 409);
+        }
+
+        throw error;
+      }
+    }
+
+    return json({ error: 'Method not allowed' }, 405);
+  },
+];

--- a/functions/api/my/articles/index.ts
+++ b/functions/api/my/articles/index.ts
@@ -1,0 +1,260 @@
+import type { AppPagesFunction } from '../../../lib/types';
+
+type ArticleStatus = 'unassigned' | 'assigned' | 'all';
+
+interface UnassignedArticleRow {
+  article_id: string;
+  title: string;
+  url: string;
+  submitted_by_id: string;
+  created_at: string;
+}
+
+interface AssignedArticleRow extends UnassignedArticleRow {
+  playlist_info: string | null;
+}
+
+interface CountRow {
+  total: number;
+}
+
+interface PlaylistSummary {
+  id: string;
+  title: string;
+}
+
+interface ArticleResponse {
+  article_id: string;
+  title: string;
+  url: string;
+  submitted_at: string;
+  playlists: PlaylistSummary[];
+}
+
+function json(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function parsePositiveInt(value: string | null, fallback: number): number {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : fallback;
+}
+
+function parseStatus(value: string | null): ArticleStatus {
+  if (value === 'unassigned' || value === 'assigned' || value === 'all') {
+    return value;
+  }
+
+  return 'all';
+}
+
+function parsePlaylistInfo(playlistInfo: string | null): PlaylistSummary[] {
+  if (!playlistInfo) {
+    return [];
+  }
+
+  return playlistInfo.split(',').reduce<PlaylistSummary[]>((playlists, entry) => {
+    const separatorIndex = entry.indexOf('::');
+    if (separatorIndex === -1) {
+      return playlists;
+    }
+
+    const id = entry.slice(0, separatorIndex);
+    const title = entry.slice(separatorIndex + 2);
+
+    if (!id || !title) {
+      return playlists;
+    }
+
+    playlists.push({ id, title });
+    return playlists;
+  }, []);
+}
+
+function mapUnassignedArticle(row: UnassignedArticleRow): ArticleResponse {
+  return {
+    article_id: row.article_id,
+    title: row.title,
+    url: row.url,
+    submitted_at: row.created_at,
+    playlists: [],
+  };
+}
+
+function mapAssignedArticle(row: AssignedArticleRow): ArticleResponse {
+  return {
+    article_id: row.article_id,
+    title: row.title,
+    url: row.url,
+    submitted_at: row.created_at,
+    playlists: parsePlaylistInfo(row.playlist_info),
+  };
+}
+
+async function getUnassignedCount(db: D1Database, userId: string): Promise<number> {
+  const row = await db
+    .prepare(
+      `SELECT COUNT(*) AS total
+       FROM (
+         SELECT s.article_id
+         FROM submissions s
+         WHERE s.submitted_by_id = ?
+           AND NOT EXISTS (
+             SELECT 1 FROM playlist_items pi
+             INNER JOIN user_playlists up ON pi.playlist_id = up.id
+             WHERE pi.source_id = s.article_id
+               AND pi.item_type IN ('curated', 'feed')
+               AND up.user_id = ?
+           )
+       ) AS unassigned_articles`,
+    )
+    .bind(userId, userId)
+    .first<CountRow>();
+
+  return row?.total ?? 0;
+}
+
+async function getAssignedCount(db: D1Database, userId: string): Promise<number> {
+  const row = await db
+    .prepare(
+      `SELECT COUNT(*) AS total
+       FROM (
+         SELECT s.article_id
+         FROM submissions s
+         INNER JOIN playlist_items pi ON pi.source_id = s.article_id
+           AND pi.item_type IN ('curated', 'feed')
+         INNER JOIN user_playlists up ON pi.playlist_id = up.id AND up.user_id = ?
+         WHERE s.submitted_by_id = ?
+         GROUP BY s.article_id
+       ) AS assigned_articles`,
+    )
+    .bind(userId, userId)
+    .first<CountRow>();
+
+  return row?.total ?? 0;
+}
+
+async function listUnassignedArticles(
+  db: D1Database,
+  userId: string,
+  limit: number,
+  offset: number,
+): Promise<UnassignedArticleRow[]> {
+  const result = await db
+    .prepare(
+      `SELECT s.article_id, s.title, s.url, s.submitted_by_id, s.created_at
+       FROM submissions s
+       WHERE s.submitted_by_id = ?
+         AND NOT EXISTS (
+           SELECT 1 FROM playlist_items pi
+           INNER JOIN user_playlists up ON pi.playlist_id = up.id
+           WHERE pi.source_id = s.article_id
+             AND pi.item_type IN ('curated', 'feed')
+             AND up.user_id = ?
+         )
+       ORDER BY s.created_at DESC
+       LIMIT ? OFFSET ?`,
+    )
+    .bind(userId, userId, limit, offset)
+    .all<UnassignedArticleRow>();
+
+  return result.results;
+}
+
+async function listAssignedArticles(
+  db: D1Database,
+  userId: string,
+  limit: number,
+  offset: number,
+): Promise<AssignedArticleRow[]> {
+  const result = await db
+    .prepare(
+      `SELECT s.article_id, s.title, s.url, s.submitted_by_id, s.created_at,
+              GROUP_CONCAT(up.id || '::' || up.title) AS playlist_info
+       FROM submissions s
+       INNER JOIN playlist_items pi ON pi.source_id = s.article_id
+         AND pi.item_type IN ('curated', 'feed')
+       INNER JOIN user_playlists up ON pi.playlist_id = up.id AND up.user_id = ?
+       WHERE s.submitted_by_id = ?
+       GROUP BY s.article_id
+       ORDER BY s.created_at DESC
+       LIMIT ? OFFSET ?`,
+    )
+    .bind(userId, userId, limit, offset)
+    .all<AssignedArticleRow>();
+
+  return result.results;
+}
+
+export const onRequest: AppPagesFunction[] = [
+  async (context) => {
+    const { request, env, data } = context;
+
+    if (request.method === 'GET') {
+      if (!data.user) {
+        return json({ error: 'Unauthorized' }, 401);
+      }
+
+      const userId = data.user.id;
+      const url = new URL(request.url);
+      const status = parseStatus(url.searchParams.get('status'));
+      const page = parsePositiveInt(url.searchParams.get('page'), 1);
+      const limit = Math.min(parsePositiveInt(url.searchParams.get('limit'), 20), 100);
+      const offset = (page - 1) * limit;
+
+      if (status === 'unassigned') {
+        const [total, rows] = await Promise.all([
+          getUnassignedCount(env.DB, userId),
+          listUnassignedArticles(env.DB, userId, limit, offset),
+        ]);
+
+        return json({
+          articles: rows.map(mapUnassignedArticle),
+          pagination: { page, limit, total },
+        });
+      }
+
+      if (status === 'assigned') {
+        const [total, rows] = await Promise.all([
+          getAssignedCount(env.DB, userId),
+          listAssignedArticles(env.DB, userId, limit, offset),
+        ]);
+
+        return json({
+          articles: rows.map(mapAssignedArticle),
+          pagination: { page, limit, total },
+        });
+      }
+
+      const [unassignedTotal, assignedTotal] = await Promise.all([
+        getUnassignedCount(env.DB, userId),
+        getAssignedCount(env.DB, userId),
+      ]);
+
+      const total = unassignedTotal + assignedTotal;
+
+      if (offset >= unassignedTotal) {
+        const assignedRows = await listAssignedArticles(env.DB, userId, limit, offset - unassignedTotal);
+
+        return json({
+          articles: assignedRows.map(mapAssignedArticle),
+          pagination: { page, limit, total },
+        });
+      }
+
+      const unassignedRows = await listUnassignedArticles(env.DB, userId, limit, offset);
+      const remaining = limit - unassignedRows.length;
+      const assignedRows = remaining > 0 ? await listAssignedArticles(env.DB, userId, remaining, 0) : [];
+
+      return json({
+        articles: [...unassignedRows.map(mapUnassignedArticle), ...assignedRows.map(mapAssignedArticle)],
+        pagination: { page, limit, total },
+      });
+    }
+
+    return json({ error: 'Method not allowed' }, 405);
+  },
+];

--- a/functions/webhooks/submission-approved.ts
+++ b/functions/webhooks/submission-approved.ts
@@ -1,5 +1,3 @@
-import { addItem, DuplicateItemError } from '../lib/playlist-items';
-import { getOrCreateAutoPlaylist } from '../lib/playlists';
 import type { Env } from '../lib/types';
 import { verifyWebhookSecret } from '../lib/webhooks';
 
@@ -11,11 +9,6 @@ interface ApprovedPayload {
   description?: string;
 }
 
-interface WebhookContext {
-  request: Request;
-  env: Env;
-}
-
 function json(data: unknown, status = 200): Response {
   return new Response(JSON.stringify(data), {
     status,
@@ -23,11 +16,7 @@ function json(data: unknown, status = 200): Response {
   });
 }
 
-export const onRequest = async ({ request, env }: WebhookContext): Promise<Response> => {
-  if (request.method !== 'POST') {
-    return new Response('Method Not Allowed', { status: 405 });
-  }
-
+export const onRequestPost: PagesFunction<Env> = async ({ request, env }) => {
   if (!verifyWebhookSecret(request, env)) {
     return json({ error: 'Unauthorized' }, 401);
   }
@@ -44,35 +33,17 @@ export const onRequest = async ({ request, env }: WebhookContext): Promise<Respo
   }
 
   const user = await env.DB.prepare('SELECT id FROM users WHERE id = ?').bind(payload.submitted_by_id).first<{ id: string }>();
+  const submittedById = user?.id ?? payload.submitted_by_id;
 
-  if (user) {
-    const playlist = await getOrCreateAutoPlaylist(env.DB, user.id);
-
-    try {
-      const item = await addItem(env.DB, playlist.id, user.id, {
-        item_type: 'curated',
-        source_id: payload.article_id,
-        title_snapshot: payload.title,
-        url_snapshot: payload.url,
-        description_snapshot: payload.description,
-      });
-
-      if (!item) {
-        throw new Error('Failed to add approved submission to playlist');
-      }
-    } catch (err) {
-      if (err instanceof DuplicateItemError) {
-        return Response.json({ status: 'already_exists' });
-      }
-      throw err;
-    }
-
-    return Response.json({ status: 'added', playlist_id: playlist.id });
-  }
-
+  // submissions table repurposed as canonical article registry. synced_to_playlist column semantics: 0 = not yet in any playlist, 1 = has been added to at least one (reserved for future use; currently unused).
   await env.DB.prepare(
-    'INSERT OR IGNORE INTO submissions (article_id, submitted_by_id, title, url) VALUES (?, ?, ?, ?)',
-  ).bind(payload.article_id, payload.submitted_by_id, payload.title, payload.url).run();
+    `INSERT INTO submissions (article_id, submitted_by_id, title, url, synced_to_playlist, created_at)
+     VALUES (?, ?, ?, ?, 0, datetime('now'))
+     ON CONFLICT(article_id) DO UPDATE SET
+       submitted_by_id = excluded.submitted_by_id,
+       title = excluded.title,
+       url = excluded.url`,
+  ).bind(payload.article_id, submittedById, payload.title, payload.url).run();
 
-  return Response.json({ status: 'deferred' });
+  return json({ success: true, article_id: payload.article_id });
 };

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "preview": "bun run build && wrangler pages dev dist",
     "check": "astro check",
     "validate": "bun run scripts/validate.ts",
+    "backfill:submissions": "bun run scripts/backfill-submissions.ts",
     "test": "vitest run",
     "generate-types": "wrangler types",
     "deploy": "bun run build && wrangler pages deploy dist",

--- a/scripts/backfill-submissions.ts
+++ b/scripts/backfill-submissions.ts
@@ -1,0 +1,240 @@
+#!/usr/bin/env bun
+
+import { execSync } from 'child_process';
+import { mkdtemp, readdir, readFile, rm, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { extname, join } from 'path';
+
+const ROOT = process.cwd();
+const CURATED_DIR = join(ROOT, 'src/content/curated');
+const WRANGLER_CONFIG_PATH = join(ROOT, 'wrangler.jsonc');
+const DEFAULT_BATCH_SIZE = 50;
+
+type JsonObject = Record<string, unknown>;
+
+export interface SubmissionInsertValues {
+  articleId: string;
+  submittedById: string;
+  title: string;
+  url: string;
+  createdAt: string;
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function getRequiredString(article: JsonObject, key: string): string {
+  const value = article[key];
+  if (!isNonEmptyString(value)) {
+    throw new Error(`Missing required string field: ${key}`);
+  }
+
+  return value;
+}
+
+export function extractSubmissionInsertValues(article: JsonObject): SubmissionInsertValues | null {
+  if (!isNonEmptyString(article.submitted_by_id)) {
+    return null;
+  }
+
+  return {
+    articleId: getRequiredString(article, 'id'),
+    submittedById: article.submitted_by_id,
+    title: getRequiredString(article, 'title'),
+    url: getRequiredString(article, 'url'),
+    createdAt: getRequiredString(article, 'submitted_at'),
+  };
+}
+
+function escapeSqlString(value: string): string {
+  return `'${value.replace(/'/g, "''")}'`;
+}
+
+export function buildInsertStatement(values: SubmissionInsertValues): string {
+  return [
+    'INSERT OR IGNORE INTO submissions (article_id, submitted_by_id, title, url, synced_to_playlist, created_at)',
+    `VALUES (${escapeSqlString(values.articleId)}, ${escapeSqlString(values.submittedById)}, ${escapeSqlString(values.title)}, ${escapeSqlString(values.url)}, 0, ${escapeSqlString(values.createdAt)});`,
+  ].join(' ');
+}
+
+export function chunkSubmissionValues(values: SubmissionInsertValues[], batchSize = DEFAULT_BATCH_SIZE): SubmissionInsertValues[][] {
+  if (batchSize <= 0) {
+    throw new Error('batchSize must be greater than 0');
+  }
+
+  const chunks: SubmissionInsertValues[][] = [];
+  for (let index = 0; index < values.length; index += batchSize) {
+    chunks.push(values.slice(index, index + batchSize));
+  }
+  return chunks;
+}
+
+async function listCuratedJsonFiles(dir: string): Promise<string[]> {
+  const files: string[] = [];
+  const entries = await readdir(dir, { withFileTypes: true });
+
+  for (const entry of entries) {
+    if (entry.name.startsWith('.')) {
+      continue;
+    }
+
+    const fullPath = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await listCuratedJsonFiles(fullPath)));
+      continue;
+    }
+
+    if (entry.isFile() && extname(entry.name).toLowerCase() === '.json') {
+      files.push(fullPath);
+    }
+  }
+
+  return files;
+}
+
+async function loadSubmissionValuesFromFiles(files: string[]): Promise<SubmissionInsertValues[]> {
+  const inserts: SubmissionInsertValues[] = [];
+
+  for (const filePath of files) {
+    const raw = await readFile(filePath, 'utf-8');
+    const article = JSON.parse(raw) as JsonObject;
+    const values = extractSubmissionInsertValues(article);
+    if (values) {
+      inserts.push(values);
+    }
+  }
+
+  return inserts;
+}
+
+function getDatabaseName(configText: string): string {
+  const databaseNameMatch = configText.match(/"database_name"\s*:\s*"([^"]+)"/);
+  if (!databaseNameMatch) {
+    throw new Error('Could not find d1_databases[0].database_name in wrangler.jsonc');
+  }
+
+  return databaseNameMatch[1];
+}
+
+function buildWranglerArgs(databaseName: string, remote: boolean): string[] {
+  return ['d1', 'execute', databaseName, remote ? '--remote' : '--local'];
+}
+
+function runWranglerCommand(args: string[]): string {
+  const command = `bunx wrangler ${args.join(' ')}`;
+  return execSync(command, {
+    cwd: ROOT,
+    encoding: 'utf-8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+}
+
+function extractCountFromWranglerJson(rawOutput: string): number {
+  const parsed = JSON.parse(rawOutput) as unknown;
+
+  function visit(value: unknown): number | null {
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        const found = visit(item);
+        if (found !== null) {
+          return found;
+        }
+      }
+      return null;
+    }
+
+    if (value && typeof value === 'object') {
+      const record = value as Record<string, unknown>;
+      if (typeof record.count === 'number') {
+        return record.count;
+      }
+
+      if (typeof record.count === 'string') {
+        const numericCount = Number(record.count);
+        if (Number.isFinite(numericCount)) {
+          return numericCount;
+        }
+      }
+
+      for (const child of Object.values(record)) {
+        const found = visit(child);
+        if (found !== null) {
+          return found;
+        }
+      }
+    }
+
+    return null;
+  }
+
+  const count = visit(parsed);
+  if (count === null) {
+    throw new Error(`Could not parse submissions count from wrangler output: ${rawOutput}`);
+  }
+
+  return count;
+}
+
+async function getSubmissionCount(databaseName: string, remote: boolean): Promise<number> {
+  const output = runWranglerCommand([
+    ...buildWranglerArgs(databaseName, remote),
+    '--json',
+    '--command',
+    '"SELECT COUNT(*) AS count FROM submissions;"',
+  ]);
+
+  return extractCountFromWranglerJson(output);
+}
+
+async function executeInsertBatches(databaseName: string, remote: boolean, inserts: SubmissionInsertValues[]): Promise<void> {
+  if (inserts.length === 0) {
+    return;
+  }
+
+  const batchDir = await mkdtemp(join(tmpdir(), 'honeycombo-backfill-'));
+
+  try {
+    const batches = chunkSubmissionValues(inserts, DEFAULT_BATCH_SIZE);
+
+    for (const [index, batch] of batches.entries()) {
+      const sql = `${batch.map(buildInsertStatement).join('\n')}\n`;
+      const sqlFilePath = join(batchDir, `batch-${index + 1}.sql`);
+      await writeFile(sqlFilePath, sql, 'utf-8');
+
+      runWranglerCommand([
+        ...buildWranglerArgs(databaseName, remote),
+        `--file="${sqlFilePath}"`,
+      ]);
+    }
+  } finally {
+    await rm(batchDir, { recursive: true, force: true });
+  }
+}
+
+export async function main(argv = process.argv.slice(2)): Promise<void> {
+  const remote = argv.includes('--remote');
+  const wranglerConfig = await readFile(WRANGLER_CONFIG_PATH, 'utf-8');
+  const databaseName = getDatabaseName(wranglerConfig);
+  const files = await listCuratedJsonFiles(CURATED_DIR);
+  const inserts = await loadSubmissionValuesFromFiles(files);
+
+  const beforeCount = await getSubmissionCount(databaseName, remote);
+  await executeInsertBatches(databaseName, remote, inserts);
+  const afterCount = await getSubmissionCount(databaseName, remote);
+
+  const inserted = Math.max(afterCount - beforeCount, 0);
+  const skipped = Math.max(inserts.length - inserted, 0);
+
+  console.log(
+    `Scanned: ${files.length} files | With submitted_by_id: ${inserts.length} | Inserted: ${inserted} | Skipped (already exist): ${skipped}`,
+  );
+}
+
+if (import.meta.main) {
+  main().catch((error: unknown) => {
+    const message = error instanceof Error ? error.stack ?? error.message : String(error);
+    console.error('Unexpected error:', message);
+    process.exit(1);
+  });
+}

--- a/src/components/Navigation.astro
+++ b/src/components/Navigation.astro
@@ -62,6 +62,7 @@ const currentPath = Astro.url.pathname;
     '<img src="' + avatar + '" alt="' + name + '" class="auth-avatar" />' +
     '<span class="auth-username">' + name + '</span>' +
     '<div class="auth-dropdown">' +
+    '<a href="/my/articles" class="auth-dropdown-item">내 기사 관리</a>' +
     '<a href="/my/playlists" class="auth-dropdown-item">내 플레이리스트</a>' +
     (user.is_admin ? '<a href="/admin/must-read" class="auth-dropdown-item auth-dropdown-admin">⭐ Must-read 관리</a><a href="/admin/playlists" class="auth-dropdown-item auth-dropdown-admin">🛡️ 플레이리스트 관리</a><a href="/admin" class="auth-dropdown-item auth-dropdown-admin">🛡️ 기사 검토 (CMS)</a>' : '') +
     '<button class="auth-dropdown-item text-danger auth-logout-btn">로그아웃</button>' +
@@ -89,6 +90,7 @@ function renderAuthUser(authArea: HTMLElement, user: { username: string; avatar_
     '<img src="' + avatarUrl + '" alt="' + safeName + '" class="auth-avatar" />' +
     '<span class="auth-username">' + safeName + '</span>' +
     '<div class="auth-dropdown">' +
+    '<a href="/my/articles" class="auth-dropdown-item">내 기사 관리</a>' +
     '<a href="/my/playlists" class="auth-dropdown-item">내 플레이리스트</a>' +
     (user.is_admin ? '<a href="/admin/must-read" class="auth-dropdown-item auth-dropdown-admin">⭐ Must-read 관리</a><a href="/admin/playlists" class="auth-dropdown-item auth-dropdown-admin">🛡️ 플레이리스트 관리</a><a href="/admin" class="auth-dropdown-item auth-dropdown-admin">🛡️ 기사 검토 (CMS)</a>' : '') +
     '<button class="auth-dropdown-item text-danger auth-logout-btn">로그아웃</button>' +

--- a/src/pages/my/articles.astro
+++ b/src/pages/my/articles.astro
@@ -1,0 +1,645 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+---
+
+<BaseLayout title="내 기사 관리">
+  <header class="page-header">
+    <h1 class="page-title">내 기사 관리</h1>
+    <p class="page-description">내가 제출한 기사를 플레이리스트에 배정하고 관리하세요.</p>
+  </header>
+
+  <div id="page-loading" class="state-message">
+    <p>데이터를 불러오는 중입니다...</p>
+  </div>
+
+  <div id="auth-gate" class="state-message" hidden>
+    <p>기사를 관리하려면 로그인이 필요합니다.</p>
+    <a href="/api/auth/github/login?return_to=/my/articles" class="btn btn-primary">GitHub로 로그인</a>
+  </div>
+
+  <div id="main-content" hidden>
+    <div id="page-notification" role="status" aria-live="polite" hidden></div>
+
+    <div class="tab-header" role="tablist">
+      <button class="tab-btn active" role="tab" data-tab="unassigned" aria-selected="true">미배정 기사 <span class="tab-count" data-count="unassigned">(0)</span></button>
+      <button class="tab-btn" role="tab" data-tab="assigned" aria-selected="false">배정된 기사 <span class="tab-count" data-count="assigned">(0)</span></button>
+    </div>
+
+    <div class="tab-panel" role="tabpanel" data-panel="unassigned">
+      <div class="articles-grid" id="unassigned-grid"></div>
+    </div>
+
+    <div class="tab-panel" role="tabpanel" data-panel="assigned" hidden>
+      <div class="articles-grid" id="assigned-grid"></div>
+    </div>
+  </div>
+</BaseLayout>
+
+<script>
+document.addEventListener('astro:page-load', () => {
+  const loadingEl = document.getElementById('page-loading');
+  const authGateEl = document.getElementById('auth-gate');
+  const mainContentEl = document.getElementById('main-content');
+  const notificationEl = document.getElementById('page-notification');
+  const unassignedGrid = document.getElementById('unassigned-grid');
+  const assignedGrid = document.getElementById('assigned-grid');
+  const tabBtns = document.querySelectorAll('.tab-btn');
+  const tabPanels = document.querySelectorAll('.tab-panel');
+  const countUnassigned = document.querySelector('[data-count="unassigned"]');
+  const countAssigned = document.querySelector('[data-count="assigned"]');
+
+  if (!loadingEl || !authGateEl || !mainContentEl) return;
+
+  let articles: any[] = [];
+  let playlists: any[] = [];
+  let activeDropdown: HTMLElement | null = null;
+
+  async function init() {
+    try {
+      const authRes = await fetch('/api/auth/me');
+      if (!authRes.ok) {
+        loadingEl!.hidden = true;
+        authGateEl!.hidden = false;
+        return;
+      }
+      
+      const [articlesRes, playlistsRes] = await Promise.all([
+        fetch('/api/my/articles?status=all&limit=100'),
+        fetch('/api/playlists?mine=true')
+      ]);
+
+      if (!articlesRes.ok || !playlistsRes.ok) throw new Error('데이터를 불러오는데 실패했습니다.');
+
+      const articlesData = await articlesRes.json();
+      const playlistsData = await playlistsRes.json();
+
+      articles = articlesData.articles || [];
+      playlists = playlistsData.playlists || [];
+
+      loadingEl!.hidden = true;
+      mainContentEl!.hidden = false;
+
+      setupTabs();
+      renderAll();
+    } catch (err: any) {
+      loadingEl!.hidden = true;
+      showNotification(err.message || '오류가 발생했습니다.', 'error');
+    }
+  }
+
+  function setupTabs() {
+    const hash = window.location.hash.replace('#', '') || 'unassigned';
+    switchTab(hash);
+
+    tabBtns.forEach(btn => {
+      btn.addEventListener('click', () => {
+        const tab = btn.getAttribute('data-tab');
+        if (tab) {
+          switchTab(tab);
+          window.location.hash = tab;
+        }
+      });
+    });
+  }
+
+  function switchTab(tabId: string) {
+    tabBtns.forEach(btn => {
+      const isSelected = btn.getAttribute('data-tab') === tabId;
+      btn.classList.toggle('active', isSelected);
+      btn.setAttribute('aria-selected', isSelected.toString());
+    });
+
+    tabPanels.forEach(panel => {
+      (panel as HTMLElement).hidden = panel.getAttribute('data-panel') !== tabId;
+    });
+  }
+
+  function renderAll() {
+    const unassigned = articles.filter(a => !a.playlists || a.playlists.length === 0);
+    const assigned = articles.filter(a => a.playlists && a.playlists.length > 0);
+
+    if (countUnassigned) countUnassigned.textContent = `(${unassigned.length})`;
+    if (countAssigned) countAssigned.textContent = `(${assigned.length})`;
+
+    renderUnassigned(unassigned);
+    renderAssigned(assigned);
+  }
+
+  function renderUnassigned(items: any[]) {
+    if (!unassignedGrid) return;
+    if (items.length === 0) {
+      unassignedGrid.innerHTML = `<div class="empty-state">플레이리스트에 추가되지 않은 기사가 없습니다.</div>`;
+      return;
+    }
+
+    unassignedGrid.innerHTML = items.map(article => `
+      <article class="article-card card" data-article-id="${article.article_id}">
+        <a class="article-title" href="${escapeHtml(article.url)}" target="_blank" rel="noopener noreferrer">${escapeHtml(article.title)}</a>
+        <div class="article-meta">제출일 ${formatDate(article.submitted_at)}</div>
+        <div class="article-actions">
+          <button class="btn btn-secondary btn-add-to-playlist" type="button">플레이리스트에 추가</button>
+        </div>
+      </article>
+    `).join('');
+  }
+
+  function renderAssigned(items: any[]) {
+    if (!assignedGrid) return;
+    if (items.length === 0) {
+      assignedGrid.innerHTML = `<div class="empty-state">아직 플레이리스트에 배정된 기사가 없습니다. 미배정 탭에서 기사를 플레이리스트에 추가해보세요.</div>`;
+      return;
+    }
+
+    assignedGrid.innerHTML = items.map(article => `
+      <article class="article-card card" data-article-id="${article.article_id}">
+        <a class="article-title" href="${escapeHtml(article.url)}" target="_blank" rel="noopener noreferrer">${escapeHtml(article.title)}</a>
+        <div class="article-meta">제출일 ${formatDate(article.submitted_at)}</div>
+        <div class="playlist-badges">
+          ${(article.playlists || []).map((p: any) => `
+            <span class="playlist-badge" data-playlist-id="${p.id}">
+              <span class="playlist-badge-title">${escapeHtml(p.title)}</span>
+              <button class="playlist-badge-remove" type="button" aria-label="${escapeHtml(p.title)} 플레이리스트에서 제거">✕</button>
+            </span>
+          `).join('')}
+        </div>
+        <div class="article-actions">
+          <button class="btn btn-secondary btn-add-to-playlist" type="button">다른 플레이리스트에 추가</button>
+        </div>
+      </article>
+    `).join('');
+  }
+
+  // Event delegation for adding/removing playlists
+  mainContentEl.addEventListener('click', async (e) => {
+    const target = e.target as HTMLElement;
+
+    // Close dropdown if clicked outside
+    if (activeDropdown && !target.closest('.dropdown-container')) {
+      activeDropdown.remove();
+      activeDropdown = null;
+    }
+
+    // Remove from playlist
+    if (target.classList.contains('playlist-badge-remove')) {
+      const badge = target.closest('.playlist-badge');
+      const card = target.closest('.article-card');
+      if (!badge || !card) return;
+      
+      const articleId = card.getAttribute('data-article-id');
+      const playlistId = badge.getAttribute('data-playlist-id');
+
+      try {
+        (target as HTMLButtonElement).disabled = true;
+        const res = await fetch(`/api/my/articles/${articleId}/playlists/${playlistId}`, { method: 'DELETE' });
+        if (!res.ok) throw new Error('제거 실패');
+
+        // Update state
+        const article = articles.find(a => a.article_id === articleId);
+        if (article) {
+          article.playlists = article.playlists.filter((p: any) => p.id !== playlistId);
+        }
+        renderAll();
+        showNotification('플레이리스트에서 제거되었습니다.', 'success');
+      } catch (err) {
+        (target as HTMLButtonElement).disabled = false;
+        showNotification('제거 중 오류가 발생했습니다.', 'error');
+      }
+      return;
+    }
+
+    // Open dropdown
+    if (target.classList.contains('btn-add-to-playlist')) {
+      e.stopPropagation();
+      if (activeDropdown) {
+        activeDropdown.remove();
+        if (activeDropdown.previousElementSibling === target) {
+          activeDropdown = null;
+          return; // Toggle off
+        }
+      }
+
+      const card = target.closest('.article-card');
+      if (!card) return;
+      
+      const articleId = card.getAttribute('data-article-id');
+      const article = articles.find(a => a.article_id === articleId);
+      const existingPlaylistIds = new Set((article.playlists || []).map((p: any) => p.id));
+
+      const availablePlaylists = playlists.filter(p => !existingPlaylistIds.has(p.id));
+
+      const dropdown = document.createElement('div');
+      dropdown.className = 'playlist-dropdown dropdown-container';
+      
+      if (availablePlaylists.length === 0) {
+        dropdown.innerHTML = `<div class="dropdown-empty">추가할 수 있는 플레이리스트가 없습니다.</div>`;
+      } else {
+        dropdown.innerHTML = `<ul class="dropdown-list">
+          ${availablePlaylists.map(p => `
+            <li><button class="dropdown-item" data-playlist-id="${p.id}">${escapeHtml(p.title)}</button></li>
+          `).join('')}
+        </ul>`;
+      }
+
+      target.parentNode!.insertBefore(dropdown, target.nextSibling);
+      activeDropdown = dropdown;
+      return;
+    }
+
+    // Add to playlist (dropdown item click)
+    if (target.classList.contains('dropdown-item')) {
+      const playlistId = target.getAttribute('data-playlist-id');
+      const card = target.closest('.article-card');
+      if (!card) return;
+      
+      const articleId = card.getAttribute('data-article-id');
+      const playlist = playlists.find(p => p.id === playlistId);
+
+      try {
+        (target as HTMLButtonElement).disabled = true;
+        const res = await fetch(`/api/my/articles/${articleId}/playlists`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ playlist_id: playlistId })
+        });
+
+        if (res.status === 409) {
+          showNotification('이미 추가된 플레이리스트입니다.', 'error');
+          if (activeDropdown) activeDropdown.remove();
+          activeDropdown = null;
+          return;
+        }
+        if (!res.ok) throw new Error('추가 실패');
+
+        // Update state
+        const article = articles.find(a => a.article_id === articleId);
+        if (article) {
+          if (!article.playlists) article.playlists = [];
+          article.playlists.push({ id: playlist.id, title: playlist.title });
+        }
+        
+        if (activeDropdown) {
+          activeDropdown.remove();
+          activeDropdown = null;
+        }
+        
+        renderAll();
+        showNotification('플레이리스트에 추가되었습니다.', 'success');
+      } catch (err) {
+        (target as HTMLButtonElement).disabled = false;
+        showNotification('추가 중 오류가 발생했습니다.', 'error');
+      }
+    }
+  });
+
+  let notificationTimeout: ReturnType<typeof setTimeout>;
+  function showNotification(message: string, type = 'success') {
+    if (!notificationEl) return;
+    
+    clearTimeout(notificationTimeout);
+    notificationEl.className = `page-notification page-notification--${type}`;
+    notificationEl.textContent = message;
+    notificationEl.hidden = false;
+
+    notificationTimeout = setTimeout(() => {
+      notificationEl.classList.add('page-notification--exiting');
+      setTimeout(() => {
+        notificationEl.hidden = true;
+        notificationEl.classList.remove('page-notification--exiting');
+        notificationEl.textContent = '';
+      }, 200);
+    }, 3000);
+  }
+
+  function escapeHtml(unsafe: string) {
+    if (!unsafe) return '';
+    return unsafe
+         .replace(/&/g, "&amp;")
+         .replace(/</g, "&lt;")
+         .replace(/>/g, "&gt;")
+         .replace(/"/g, "&quot;")
+         .replace(/'/g, "&#039;");
+  }
+
+  function formatDate(iso: string) {
+    if (!iso) return '';
+    const d = new Date(iso);
+    return `${d.getFullYear()}.${String(d.getMonth() + 1).padStart(2, '0')}.${String(d.getDate()).padStart(2, '0')}`;
+  }
+
+  init();
+});
+</script>
+
+<style>
+.page-header {
+  margin-bottom: var(--space-xl);
+}
+
+.page-title {
+  font-size: 1.5rem;
+  font-weight: 700;
+  margin-bottom: var(--space-xs);
+}
+
+.page-description {
+  color: var(--color-text-muted);
+}
+
+.state-message {
+  padding: var(--space-2xl) var(--space-xl);
+  text-align: center;
+  background: var(--color-bg-secondary);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-md);
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-sm) var(--space-lg);
+  border-radius: var(--radius-md);
+  font-weight: 600;
+  font-size: 0.95rem;
+  transition: all 0.15s ease-out;
+  text-decoration: none;
+  border: 1px solid var(--color-border);
+  background: var(--color-bg);
+  color: var(--color-text);
+  cursor: pointer;
+}
+
+.btn:hover:not(:disabled) {
+  background: var(--color-bg-secondary);
+}
+
+.btn:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+.btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.btn-primary {
+  background: var(--color-primary);
+  color: white;
+  border-color: var(--color-primary);
+}
+
+.btn-primary:hover:not(:disabled) {
+  background: var(--color-primary-hover);
+  color: white;
+}
+
+.btn-secondary {
+  background: var(--color-bg-secondary);
+  color: var(--color-text);
+  border-color: var(--color-border);
+}
+
+.btn-secondary:hover:not(:disabled) {
+  background: var(--color-border);
+}
+
+/* 4.10 Content Tabs */
+.tab-header {
+  display: flex;
+  border-bottom: 2px solid var(--color-border);
+  margin-bottom: var(--space-lg);
+  gap: var(--space-md);
+}
+
+.tab-btn {
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  padding: var(--space-sm) var(--space-xs);
+  margin-bottom: -2px;
+  color: var(--color-text-muted);
+  font-size: 1rem;
+  cursor: pointer;
+  transition: color 0.15s ease-out, border-color 0.15s ease-out;
+}
+
+.tab-btn:hover:not(:disabled) {
+  color: var(--color-text);
+}
+
+.tab-btn.active {
+  color: var(--color-primary);
+  border-bottom-color: var(--color-primary);
+  font-weight: 600;
+}
+
+.tab-btn:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+.tab-count {
+  font-size: 0.85em;
+  opacity: 0.8;
+}
+
+/* 4.12 Page Notification */
+.page-notification {
+  position: sticky;
+  top: var(--space-md);
+  z-index: 10;
+  max-width: var(--max-width, 1200px);
+  margin: 0 auto var(--space-md);
+  padding: var(--space-sm) var(--space-md);
+  border-radius: var(--radius-sm);
+  background: var(--color-bg-secondary);
+  font-size: 0.9375rem;
+  transform: translateY(0);
+  opacity: 1;
+  transition: transform 0.2s ease-out, opacity 0.2s ease-out;
+}
+
+.page-notification--success {
+  border-left: 3px solid var(--color-success);
+  color: var(--color-text);
+}
+
+.page-notification--error {
+  border-left: 3px solid var(--color-danger);
+  color: var(--color-text);
+}
+
+.page-notification--exiting {
+  opacity: 0;
+}
+
+/* Articles Grid */
+.articles-grid {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+
+.empty-state {
+  padding: var(--space-xl);
+  text-align: center;
+  color: var(--color-text-muted);
+  background: var(--color-bg-secondary);
+  border-radius: var(--radius-md);
+  border: 1px dashed var(--color-border);
+}
+
+/* Article Card */
+#main-content :global(.article-card) {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+}
+
+#main-content :global(.article-title) {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--color-text);
+  text-decoration: none;
+  line-height: 1.4;
+}
+
+#main-content :global(.article-title:hover) {
+  color: var(--color-primary);
+  text-decoration: underline;
+}
+
+#main-content :global(.article-meta) {
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+}
+
+#main-content :global(.article-actions) {
+  position: relative;
+  margin-top: var(--space-xs);
+}
+
+/* 4.11 Playlist Badge */
+#main-content :global(.playlist-badges) {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-xs);
+  margin-top: var(--space-xs);
+}
+
+#main-content :global(.playlist-badge) {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-xs);
+  padding: var(--space-xs) var(--space-sm);
+  background: var(--color-bg-secondary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  color: var(--color-text);
+  font-size: 0.8125rem;
+  transition: border-color 0.15s ease-out;
+}
+
+#main-content :global(.playlist-badge:hover) {
+  border-color: var(--color-primary);
+}
+
+#main-content :global(.playlist-badge:focus-within) {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+#main-content :global(.playlist-badge-remove) {
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  color: var(--color-text-muted);
+  padding: 0;
+  font-size: inherit;
+  line-height: 1;
+  transition: color 0.15s ease-out;
+}
+
+#main-content :global(.playlist-badge-remove:hover) {
+  color: var(--color-danger);
+}
+
+#main-content :global(.playlist-badge-remove:focus-visible) {
+  outline: none; /* Handled by focus-within on parent */
+}
+
+/* Dropdown */
+#main-content :global(.dropdown-container) {
+  position: absolute;
+  top: calc(100% + var(--space-xs));
+  left: 0;
+  z-index: 20;
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  min-width: 200px;
+  max-height: 300px;
+  overflow-y: auto;
+}
+
+#main-content :global(.dropdown-empty) {
+  padding: var(--space-sm) var(--space-md);
+  color: var(--color-text-muted);
+  font-size: 0.9rem;
+}
+
+#main-content :global(.dropdown-list) {
+  list-style: none;
+  margin: 0;
+  padding: var(--space-xs) 0;
+}
+
+#main-content :global(.dropdown-item) {
+  width: 100%;
+  text-align: left;
+  background: none;
+  border: none;
+  padding: var(--space-sm) var(--space-md);
+  font-size: 0.9rem;
+  color: var(--color-text);
+  cursor: pointer;
+  transition: background 0.15s ease-out;
+}
+
+#main-content :global(.dropdown-item:hover) {
+  background: var(--color-bg-secondary);
+}
+
+#main-content :global(.dropdown-item:focus-visible) {
+  outline: 2px solid var(--color-primary);
+  outline-offset: -2px;
+  background: var(--color-bg-secondary);
+}
+
+@media (max-width: 768px) {
+  .tab-header {
+    flex-direction: column;
+    border-bottom: none;
+    gap: 0;
+  }
+  
+  .tab-btn {
+    width: 100%;
+    text-align: left;
+    border-bottom: 1px solid var(--color-border);
+    padding: var(--space-sm) var(--space-md);
+    margin-bottom: 0;
+  }
+  
+  .tab-btn.active {
+    border-bottom-color: var(--color-primary);
+    background: var(--color-bg-secondary);
+  }
+}
+</style>

--- a/tests/api/my-articles.test.ts
+++ b/tests/api/my-articles.test.ts
@@ -1,0 +1,560 @@
+import { describe, expect, it } from 'vitest';
+import { createMockContext } from '../helpers/context-mock';
+import { createMockD1 } from '../helpers/d1-mock';
+import type { UserRow } from '../../functions/lib/types';
+import { onRequest as myArticlesHandlers } from '../../functions/api/my/articles/index';
+import { onRequest as addArticleToPlaylistHandlers } from '../../functions/api/my/articles/[articleId]/playlists/index';
+import { onRequest as removeArticleFromPlaylistHandlers } from '../../functions/api/my/articles/[articleId]/playlists/[playlistId]';
+
+const listMyArticles = myArticlesHandlers[0]!;
+const addArticleToPlaylist = addArticleToPlaylistHandlers[0]!;
+const removeArticleFromPlaylist = removeArticleFromPlaylistHandlers[0]!;
+
+function makeUser(id: string): UserRow {
+  return {
+    id,
+    username: `${id}_name`,
+    display_name: id.toUpperCase(),
+    avatar_url: `https://example.com/${id}.png`,
+    created_at: '2026-04-22T00:00:00.000Z',
+  };
+}
+
+function makeSubmissionRow(articleId: string, userId: string, overrides: Record<string, unknown> = {}) {
+  return {
+    article_id: articleId,
+    title: `Title for ${articleId}`,
+    url: `https://example.com/${articleId}`,
+    submitted_by_id: userId,
+    created_at: '2026-04-22T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function makeAssignedArticleRow(
+  articleId: string,
+  userId: string,
+  playlistInfo = 'playlist_1::Favorites',
+  overrides: Record<string, unknown> = {},
+) {
+  return {
+    ...makeSubmissionRow(articleId, userId),
+    playlist_info: playlistInfo,
+    ...overrides,
+  };
+}
+
+function makePlaylistItem(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'item_1',
+    playlist_id: 'playlist_1',
+    item_type: 'curated',
+    source_id: 'article_1',
+    external_url: null,
+    title_snapshot: 'Title for article_1',
+    url_snapshot: 'https://example.com/article_1',
+    description_snapshot: null,
+    note: null,
+    position: 1,
+    added_at: '2026-04-22T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function createApiContext(options: {
+  db: D1Database;
+  user?: UserRow | null;
+  method?: string;
+  url: string;
+  params?: Record<string, string>;
+  body?: unknown;
+}) {
+  return createMockContext({
+    env: { DB: options.db },
+    user: options.user === undefined ? makeUser('user_1') : options.user,
+    method: options.method ?? 'GET',
+    url: options.url,
+    params: options.params ?? {},
+    body: options.body === undefined ? null : JSON.stringify(options.body),
+  });
+}
+
+function createDuplicateInsertDatabase(controller: ReturnType<typeof createMockD1>): D1Database {
+  const originalPrepare = controller.db.prepare.bind(controller.db);
+  const createStatement = (sql: string): D1PreparedStatement =>
+    ({
+      bind(..._boundParams: unknown[]) {
+        return createStatement(sql);
+      },
+      async first<T = Record<string, unknown>>(_columnName?: keyof T & string) {
+        throw new Error(`Unexpected first() for ${sql}`);
+      },
+      async all<T = Record<string, unknown>>() {
+        throw new Error(`Unexpected all() for ${sql}`);
+      },
+      async run<T = Record<string, unknown>>() {
+        throw new Error('UNIQUE constraint failed: playlist_items.playlist_id, playlist_items.item_type, playlist_items.source_id');
+      },
+    }) as D1PreparedStatement;
+
+  return {
+    ...controller.db,
+    prepare(sql: string) {
+      if (sql.includes('INSERT INTO playlist_items')) {
+        return createStatement(sql);
+      }
+
+      return originalPrepare(sql);
+    },
+  } as D1Database;
+}
+
+describe('GET /api/my/articles', () => {
+  it('returns 401 when user is not authenticated', async () => {
+    const controller = createMockD1();
+    const context = createApiContext({
+      db: controller.db,
+      user: null,
+      url: 'https://example.com/api/my/articles',
+    });
+
+    const response = await listMyArticles(context);
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({ error: 'Unauthorized' });
+    expect(controller.getQueries()).toHaveLength(0);
+  });
+
+  it('returns an empty state for a user with zero submissions', async () => {
+    const controller = createMockD1();
+    controller.setResults([{ total: 0 }, { total: 0 }, []]);
+
+    const response = await listMyArticles(
+      createApiContext({
+        db: controller.db,
+        url: 'https://example.com/api/my/articles',
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      articles: [],
+      pagination: { page: 1, limit: 20, total: 0 },
+    });
+  });
+
+  it('returns unassigned articles with empty playlists arrays', async () => {
+    const controller = createMockD1();
+    controller.setResults([
+      { total: 2 },
+      [makeSubmissionRow('article_1', 'user_1'), makeSubmissionRow('article_2', 'user_1')],
+    ]);
+
+    const response = await listMyArticles(
+      createApiContext({
+        db: controller.db,
+        url: 'https://example.com/api/my/articles?status=unassigned',
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      articles: [
+        {
+          article_id: 'article_1',
+          title: 'Title for article_1',
+          url: 'https://example.com/article_1',
+          submitted_at: '2026-04-22T00:00:00.000Z',
+          playlists: [],
+        },
+        {
+          article_id: 'article_2',
+          title: 'Title for article_2',
+          url: 'https://example.com/article_2',
+          submitted_at: '2026-04-22T00:00:00.000Z',
+          playlists: [],
+        },
+      ],
+      pagination: { page: 1, limit: 20, total: 2 },
+    });
+
+    expect(controller.getQueries()[1]?.params).toEqual(['user_1', 'user_1', 20, 0]);
+  });
+
+  it('returns assigned articles with populated playlists arrays', async () => {
+    const controller = createMockD1();
+    controller.setResults([
+      { total: 1 },
+      [
+        makeAssignedArticleRow(
+          'article_1',
+          'user_1',
+          'playlist_1::Favorites,playlist_2::Reading List',
+        ),
+      ],
+    ]);
+
+    const response = await listMyArticles(
+      createApiContext({
+        db: controller.db,
+        url: 'https://example.com/api/my/articles?status=assigned',
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      articles: [
+        {
+          article_id: 'article_1',
+          title: 'Title for article_1',
+          url: 'https://example.com/article_1',
+          submitted_at: '2026-04-22T00:00:00.000Z',
+          playlists: [
+            { id: 'playlist_1', title: 'Favorites' },
+            { id: 'playlist_2', title: 'Reading List' },
+          ],
+        },
+      ],
+      pagination: { page: 1, limit: 20, total: 1 },
+    });
+  });
+
+  it('returns mixed assigned and unassigned articles for status=all', async () => {
+    const controller = createMockD1();
+    controller.setResults([
+      { total: 1 },
+      { total: 1 },
+      [makeSubmissionRow('article_1', 'user_1')],
+      [makeAssignedArticleRow('article_2', 'user_1', 'playlist_9::Deep Dives')],
+    ]);
+
+    const response = await listMyArticles(
+      createApiContext({
+        db: controller.db,
+        url: 'https://example.com/api/my/articles?status=all',
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      articles: [
+        {
+          article_id: 'article_1',
+          title: 'Title for article_1',
+          url: 'https://example.com/article_1',
+          submitted_at: '2026-04-22T00:00:00.000Z',
+          playlists: [],
+        },
+        {
+          article_id: 'article_2',
+          title: 'Title for article_2',
+          url: 'https://example.com/article_2',
+          submitted_at: '2026-04-22T00:00:00.000Z',
+          playlists: [{ id: 'playlist_9', title: 'Deep Dives' }],
+        },
+      ],
+      pagination: { page: 1, limit: 20, total: 2 },
+    });
+  });
+
+  it('applies page and limit params when paginating mixed results', async () => {
+    const controller = createMockD1();
+    controller.setResults([
+      { total: 1 },
+      { total: 2 },
+      [makeAssignedArticleRow('article_3', 'user_1', 'playlist_3::Page Three')],
+    ]);
+
+    const response = await listMyArticles(
+      createApiContext({
+        db: controller.db,
+        url: 'https://example.com/api/my/articles?status=all&page=3&limit=1',
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      articles: [
+        {
+          article_id: 'article_3',
+          title: 'Title for article_3',
+          url: 'https://example.com/article_3',
+          submitted_at: '2026-04-22T00:00:00.000Z',
+          playlists: [{ id: 'playlist_3', title: 'Page Three' }],
+        },
+      ],
+      pagination: { page: 3, limit: 1, total: 3 },
+    });
+
+    expect(controller.getQueries()[2]?.params).toEqual(['user_1', 'user_1', 1, 1]);
+  });
+
+  it('isolates results so user A cannot see user B submissions', async () => {
+    const controller = createMockD1();
+    controller.setResults([{ total: 1 }, [makeSubmissionRow('article_a', 'user_a')]]);
+
+    const response = await listMyArticles(
+      createApiContext({
+        db: controller.db,
+        user: makeUser('user_a'),
+        url: 'https://example.com/api/my/articles?status=unassigned',
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      articles: [
+        {
+          article_id: 'article_a',
+          title: 'Title for article_a',
+          url: 'https://example.com/article_a',
+          submitted_at: '2026-04-22T00:00:00.000Z',
+          playlists: [],
+        },
+      ],
+      pagination: { page: 1, limit: 20, total: 1 },
+    });
+
+    const queries = controller.getQueries();
+    expect(queries[0]?.params).toEqual(['user_a', 'user_a']);
+    expect(queries[1]?.params).toEqual(['user_a', 'user_a', 20, 0]);
+  });
+});
+
+describe('POST /api/my/articles/:articleId/playlists', () => {
+  it('returns 401 when no authenticated user is present', async () => {
+    const controller = createMockD1();
+    const response = await addArticleToPlaylist(
+      createApiContext({
+        db: controller.db,
+        user: null,
+        method: 'POST',
+        url: 'https://example.com/api/my/articles/article_1/playlists',
+        params: { articleId: 'article_1' },
+        body: { playlist_id: 'playlist_1' },
+      }),
+    );
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({ error: 'Unauthorized' });
+    expect(controller.getQueries()).toHaveLength(0);
+  });
+
+  it('returns 404 when the submission is not owned by the user', async () => {
+    const controller = createMockD1();
+    controller.setResults([null]);
+
+    const response = await addArticleToPlaylist(
+      createApiContext({
+        db: controller.db,
+        method: 'POST',
+        url: 'https://example.com/api/my/articles/article_404/playlists',
+        params: { articleId: 'article_404' },
+        body: { playlist_id: 'playlist_1' },
+      }),
+    );
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({ error: 'Article not found' });
+    expect(controller.getQueries()[0]?.params).toEqual(['article_404', 'user_1']);
+  });
+
+  it('returns 404 when the playlist is not owned by the user', async () => {
+    const controller = createMockD1();
+    controller.setResults([makeSubmissionRow('article_1', 'user_1'), null]);
+
+    const response = await addArticleToPlaylist(
+      createApiContext({
+        db: controller.db,
+        method: 'POST',
+        url: 'https://example.com/api/my/articles/article_1/playlists',
+        params: { articleId: 'article_1' },
+        body: { playlist_id: 'playlist_missing' },
+      }),
+    );
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({ error: 'Playlist not found' });
+    expect(controller.getQueries()[1]?.params).toEqual(['playlist_missing', 'user_1']);
+  });
+
+  it('returns 201 when a valid article is added to a user playlist', async () => {
+    const controller = createMockD1();
+    controller.setResults([
+      makeSubmissionRow('article_1', 'user_1'),
+      { id: 'playlist_1' },
+      { user_id: 'user_1' },
+      { max_position: 0 },
+      [],
+      [],
+      makePlaylistItem(),
+    ]);
+
+    const response = await addArticleToPlaylist(
+      createApiContext({
+        db: controller.db,
+        method: 'POST',
+        url: 'https://example.com/api/my/articles/article_1/playlists',
+        params: { articleId: 'article_1' },
+        body: { playlist_id: 'playlist_1' },
+      }),
+    );
+
+    expect(response.status).toBe(201);
+    await expect(response.json()).resolves.toEqual({
+      success: true,
+      playlist_id: 'playlist_1',
+      article_id: 'article_1',
+    });
+
+    expect(controller.getQueries()[4]).toMatchObject({
+      params: [
+        expect.any(String),
+        'playlist_1',
+        'curated',
+        'article_1',
+        null,
+        'Title for article_1',
+        'https://example.com/article_1',
+        null,
+        null,
+        1,
+      ],
+    });
+  });
+
+  it('returns 409 when the article already exists in the playlist', async () => {
+    const controller = createMockD1();
+    controller.setResults([
+      makeSubmissionRow('article_1', 'user_1'),
+      { id: 'playlist_1' },
+      { user_id: 'user_1' },
+      { max_position: 0 },
+    ]);
+
+    const response = await addArticleToPlaylist(
+      createApiContext({
+        db: createDuplicateInsertDatabase(controller),
+        method: 'POST',
+        url: 'https://example.com/api/my/articles/article_1/playlists',
+        params: { articleId: 'article_1' },
+        body: { playlist_id: 'playlist_1' },
+      }),
+    );
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toEqual({ error: 'Article already in this playlist' });
+  });
+
+  it('prevents user A from adding user B article to user A playlist', async () => {
+    const controller = createMockD1();
+    controller.setResults([null]);
+
+    const response = await addArticleToPlaylist(
+      createApiContext({
+        db: controller.db,
+        user: makeUser('user_a'),
+        method: 'POST',
+        url: 'https://example.com/api/my/articles/article_b/playlists',
+        params: { articleId: 'article_b' },
+        body: { playlist_id: 'playlist_a' },
+      }),
+    );
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({ error: 'Article not found' });
+    expect(controller.getQueries()).toHaveLength(1);
+    expect(controller.getQueries()[0]?.params).toEqual(['article_b', 'user_a']);
+  });
+});
+
+describe('DELETE /api/my/articles/:articleId/playlists/:playlistId', () => {
+  it('returns 401 when no authenticated user is present', async () => {
+    const controller = createMockD1();
+    const response = await removeArticleFromPlaylist(
+      createApiContext({
+        db: controller.db,
+        user: null,
+        method: 'DELETE',
+        url: 'https://example.com/api/my/articles/article_1/playlists/playlist_1',
+        params: { articleId: 'article_1', playlistId: 'playlist_1' },
+      }),
+    );
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({ error: 'Unauthorized' });
+    expect(controller.getQueries()).toHaveLength(0);
+  });
+
+  it('returns 404 when the submission is not owned by the user', async () => {
+    const controller = createMockD1();
+    controller.setResults([null]);
+
+    const response = await removeArticleFromPlaylist(
+      createApiContext({
+        db: controller.db,
+        method: 'DELETE',
+        url: 'https://example.com/api/my/articles/article_404/playlists/playlist_1',
+        params: { articleId: 'article_404', playlistId: 'playlist_1' },
+      }),
+    );
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({ error: 'Article not found' });
+  });
+
+  it('returns 404 when the playlist is not owned by the user', async () => {
+    const controller = createMockD1();
+    controller.setResults([{ article_id: 'article_1' }, null]);
+
+    const response = await removeArticleFromPlaylist(
+      createApiContext({
+        db: controller.db,
+        method: 'DELETE',
+        url: 'https://example.com/api/my/articles/article_1/playlists/playlist_missing',
+        params: { articleId: 'article_1', playlistId: 'playlist_missing' },
+      }),
+    );
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({ error: 'Playlist not found' });
+  });
+
+  it('returns 404 when the article is not already in the playlist', async () => {
+    const controller = createMockD1();
+    controller.setResults([{ article_id: 'article_1' }, { id: 'playlist_1' }, null]);
+
+    const response = await removeArticleFromPlaylist(
+      createApiContext({
+        db: controller.db,
+        method: 'DELETE',
+        url: 'https://example.com/api/my/articles/article_1/playlists/playlist_1',
+        params: { articleId: 'article_1', playlistId: 'playlist_1' },
+      }),
+    );
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({ error: 'Article not in this playlist' });
+  });
+
+  it('returns 200 when a playlist membership is removed successfully', async () => {
+    const controller = createMockD1();
+    controller.setResults([{ article_id: 'article_1' }, { id: 'playlist_1' }, { id: 'item_1' }, []]);
+
+    const response = await removeArticleFromPlaylist(
+      createApiContext({
+        db: controller.db,
+        method: 'DELETE',
+        url: 'https://example.com/api/my/articles/article_1/playlists/playlist_1',
+        params: { articleId: 'article_1', playlistId: 'playlist_1' },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ success: true });
+    expect(controller.getQueries()[3]).toMatchObject({
+      sql: expect.stringContaining('DELETE FROM playlist_items WHERE id = ?'),
+      params: ['item_1'],
+    });
+  });
+});

--- a/tests/backfill-submissions.test.ts
+++ b/tests/backfill-submissions.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { buildInsertStatement, extractSubmissionInsertValues } from '../scripts/backfill-submissions';
+
+describe('backfill-submissions', () => {
+  it('extracts submission SQL values from a submitted article', () => {
+    const article = {
+      id: 'submission-149-8d20db04',
+      title: 'What Is Yann LeCun Cooking? JEPA Explained Simply',
+      url: 'https://www.youtube.com/watch?v=oM4neOyZOi0',
+      submitted_by_id: '32758428',
+      submitted_at: '2026-04-21T02:03:09.291Z',
+    };
+
+    expect(extractSubmissionInsertValues(article)).toEqual({
+      articleId: 'submission-149-8d20db04',
+      submittedById: '32758428',
+      title: 'What Is Yann LeCun Cooking? JEPA Explained Simply',
+      url: 'https://www.youtube.com/watch?v=oM4neOyZOi0',
+      createdAt: '2026-04-21T02:03:09.291Z',
+    });
+  });
+
+  it('filters out articles without submitted_by_id', () => {
+    const article = {
+      id: 'submission-200-abc12345',
+      title: 'No submitter',
+      url: 'https://example.com/article',
+      submitted_at: '2026-04-21T03:00:00.000Z',
+    };
+
+    expect(extractSubmissionInsertValues(article)).toBeNull();
+  });
+
+  it('uses INSERT OR IGNORE for idempotent SQL', () => {
+    const sql = buildInsertStatement({
+      articleId: 'submission-149-8d20db04',
+      submittedById: '32758428',
+      title: 'What Is Yann LeCun Cooking? JEPA Explained Simply',
+      url: 'https://www.youtube.com/watch?v=oM4neOyZOi0',
+      createdAt: '2026-04-21T02:03:09.291Z',
+    });
+
+    expect(sql).toContain('INSERT OR IGNORE INTO submissions');
+    expect(sql).toContain("'submission-149-8d20db04'");
+    expect(sql).toContain("'32758428'");
+    expect(sql).toContain("'2026-04-21T02:03:09.291Z'");
+    expect(sql).toContain(', 0,');
+  });
+});

--- a/tests/webhooks/submission-approved.test.ts
+++ b/tests/webhooks/submission-approved.test.ts
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createMockD1 } from '../helpers/d1-mock';
+
+const { playlistSideEffectSpy } = vi.hoisted(() => ({
+  playlistSideEffectSpy: vi.fn(),
+}));
+
+vi.mock('../../functions/lib/playlists', () => ({
+  createPlaylist: (...args: unknown[]) => playlistSideEffectSpy('createPlaylist', args),
+}));
+
+vi.mock('../../functions/lib/playlist-items', () => ({
+  addItem: (...args: unknown[]) => playlistSideEffectSpy('addItem', args),
+  removeItem: (...args: unknown[]) => playlistSideEffectSpy('removeItem', args),
+}));
+
+import { onRequestPost } from '../../functions/webhooks/submission-approved';
+
+const payload = {
+  article_id: 'article_1',
+  submitted_by_id: 'user_1',
+  title: 'A good article',
+  url: 'https://example.com/article-1',
+};
+
+function createWebhookRequest(body: unknown, token?: string): Request {
+  return new Request('https://example.com/functions/webhooks/submission-approved', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+function createWebhookEnv(db: D1Database, secret = 'test-secret') {
+  return {
+    DB: db,
+    WEBHOOK_SECRET: secret,
+  } as { DB: D1Database; WEBHOOK_SECRET: string };
+}
+
+describe('POST /functions/webhooks/submission-approved', () => {
+  beforeEach(() => {
+    playlistSideEffectSpy.mockReset();
+  });
+
+  it('returns 200 and upserts into submissions without creating playlist items', async () => {
+    const controller = createMockD1();
+    controller.setResults([{ id: 'user_1' }, []]);
+
+    const response = await onRequestPost({
+      request: createWebhookRequest(payload, 'test-secret'),
+      env: createWebhookEnv(controller.db),
+    } as never);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ success: true, article_id: 'article_1' });
+
+    const queries = controller.getQueries();
+    expect(queries).toHaveLength(2);
+    expect(queries[0]?.sql).toContain('SELECT id FROM users');
+    expect(queries[1]?.sql).toContain('INSERT INTO submissions');
+    expect(queries[1]?.params).toEqual(['article_1', 'user_1', 'A good article', 'https://example.com/article-1']);
+    expect(queries.some((query) => query.sql.includes('playlist_items'))).toBe(false);
+    expect(queries.some((query) => query.sql.includes('user_playlists'))).toBe(false);
+    expect(playlistSideEffectSpy).not.toHaveBeenCalled();
+  });
+
+  it('is idempotent when the same article_id is received twice', async () => {
+    const controller = createMockD1();
+    controller.setResults([{ id: 'user_1' }, [], { id: 'user_1' }, []]);
+    const env = createWebhookEnv(controller.db);
+
+    const firstResponse = await onRequestPost({
+      request: createWebhookRequest(payload, 'test-secret'),
+      env,
+    } as never);
+    const secondResponse = await onRequestPost({
+      request: createWebhookRequest(payload, 'test-secret'),
+      env,
+    } as never);
+
+    expect(firstResponse.status).toBe(200);
+    expect(secondResponse.status).toBe(200);
+    expect(controller.getQueries().filter((query) => query.sql.includes('INSERT INTO submissions'))).toHaveLength(2);
+    expect(controller.getQueries().some((query) => query.sql.includes('playlist_items'))).toBe(false);
+    expect(playlistSideEffectSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 when the Bearer token is missing', async () => {
+    const controller = createMockD1();
+
+    const response = await onRequestPost({
+      request: createWebhookRequest(payload),
+      env: createWebhookEnv(controller.db),
+    } as never);
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({ error: 'Unauthorized' });
+    expect(controller.getQueries()).toHaveLength(0);
+    expect(playlistSideEffectSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 when the Bearer token is invalid', async () => {
+    const controller = createMockD1();
+
+    const response = await onRequestPost({
+      request: createWebhookRequest(payload, 'wrong-secret'),
+      env: createWebhookEnv(controller.db),
+    } as never);
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({ error: 'Unauthorized' });
+    expect(controller.getQueries()).toHaveLength(0);
+    expect(playlistSideEffectSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

기사 업로드 후 자동 플레이리스트 추가를 제거하고, 사용자가 직접 배정을 관리하는 `/my/articles` 페이지를 도입합니다.

## Breaking Behavior Change

**이전**: 기사 제출 시 webhook이 자동으로 사용자의 최근 플레이리스트에 추가하거나 `내 제출 기사` 자동 플레이리스트를 생성했습니다.

**이후**: 기사는 `submissions` D1 테이블에만 upsert됩니다. 사용자는 `/my/articles`에서 원하는 플레이리스트에 직접 배정/해제/이동합니다.

## 🚨 Post-Merge Operational Step (REQUIRED)

master 머지 후 반드시 다음 명령을 실행하여 기존 기사들을 submissions 테이블에 백필하세요:

```bash
bun run backfill:submissions --remote
```

백필하지 않으면 기존 사용자의 `/my/articles` 페이지는 빈 상태로 표시됩니다 (로그인 상태에서 제출한 기사는 submissions 테이블에 기록되지 않았기 때문).

## Changes

### Backend
- `functions/webhooks/submission-approved.ts`: 자동 플레이리스트 추가 로직 제거, `submissions` 테이블 upsert만 수행
- `functions/api/auth/github/callback.ts`: 첫 로그인 시 catch-up sync 제거
- **새 API 엔드포인트**:
  - `GET /api/my/articles?status=unassigned|assigned|all` — 사용자 기사 목록
  - `POST /api/my/articles/:articleId/playlists` — 플레이리스트에 추가
  - `DELETE /api/my/articles/:articleId/playlists/:playlistId` — 플레이리스트에서 제거

### Frontend
- `src/pages/my/articles.astro`: 탭 UI (미배정/배정됨), 플레이리스트 드롭다운, 배지 관리
- `src/components/Navigation.astro`: `내 기사 관리` 링크 추가

### Scripts
- `scripts/backfill-submissions.ts`: `src/content/curated/**/*.json` → `submissions` 테이블 백필 (idempotent, `--remote` 플래그 지원)

### Docs
- `docs/features/article-management.md` — 신규 기능 명세
- `docs/decisions/0006-remove-auto-playlist-add.md` — ADR
- `docs/features/auto-playlist-add.md` — Deprecated 표시
- `docs/features/playlists.md` — 자동 추가 제거 반영
- `docs/architecture/overview.md` — 새 페이지/API 반영
- `DESIGN.md` — 탭 패턴, 플레이리스트 배지, 페이지 알림 패턴 추가

## Test Coverage

- **22개 신규 테스트**, 총 **338개 테스트** 통과 (19 test files)
- API 엔드포인트: 인증, 소유권 검증, 쿼리 정확성, cross-user 격리
- Webhook: auto-add 부수효과 없음 확인
- Backfill 파서 idempotency

## CI Gate Verification

로컬에서 전체 CI gate 통과 확인:
- `bun run validate` ✅ (336 files)
- `bun run validate:docs` ✅ (66 files)
- `bun run validate:docs -- --check-coverage` ✅
- `bun run build` ✅ (702 pages)
- `bun run test` ✅ (338 tests)

## User-Confirmed Decisions

- ✅ 과거 기사 백필 (Q1)
- ✅ 기존 자동 플레이리스트 그대로 유지 (Q2)
- ✅ 본인 제출 기사만 관리 (Q3)