### PR TITLE
fix(playlist): escape backticks in SSR script comments (fix deploy)

### DIFF
--- a/docs/troubleshooting/playlist-batch-edit-drag-scroll-asymmetry.md
+++ b/docs/troubleshooting/playlist-batch-edit-drag-scroll-asymmetry.md
@@ -102,6 +102,7 @@ let scrollOffsetY = autoScrolls[this.layer].vy ? autoScrolls[this.layer].vy * sp
 - **Sticky/fixed 헤더가 있는 레이아웃**에서 브라우저의 drag-at-edge fast-scroll에 의존하지 말 것. 헤더 높이를 명시적으로 보정한 effective edge를 사용하자.
 - **SortableJS의 `scrollSpeed`는 gradient가 아니다**. 부드러운 가속감을 원하면 커스텀 스크롤러가 필요하다. `#1907` 이슈가 해결되기 전까지는 동일하다.
 - 커스텀 rAF 스크롤러를 쓸 때는 반드시 (1) 문서 경계 clamp, (2) 드래그 종료/배치 모드 종료에서의 확실한 `cancelAnimationFrame` + 리스너 해제를 보장할 것(메모리 누수/멈춤 방지).
+- **`functions/p/[id].ts`의 SSR 스크립트 블록은 TypeScript template literal 안에 렌더링된다**. 이 안에 추가하는 **주석/문자열에 백틱(`` ` ``)을 쓰면 template literal이 중간에 종료되어 wrangler 배포 시점에 `Expected ":" but found ...` 형태의 파싱 에러가 난다**. 로컬 `bun run build`(Astro)는 이 파일을 건드리지 않고 Cloudflare Pages 배포 단계(`wrangler pages deploy`)에서만 파싱하므로 PR CI에서는 잡히지 않는다. 해결: (a) 주석에서 백틱을 떼고 평문으로 쓰거나, (b) 반드시 써야 하면 `\`` 로 이스케이프. 푸시 전 `npx wrangler pages functions build --outdir=.wrangler-dry` 로 한 번 더 파싱 검증하면 재발 방지된다.
 
 ---
 

--- a/functions/p/[id].ts
+++ b/functions/p/[id].ts
@@ -1797,7 +1797,7 @@ export const onRequest: AppPagesFunction = async ({ env, request, params }) => {
           // WHY CUSTOM: SortableJS's built-in auto-scroll is binary
           // (scrollSpeed is applied as-is regardless of edge distance; see
           // AutoScroll.js vy = (...) - (...) line 225 in v1.15.2). Combined
-          // with the sticky `.nav` header (position: sticky, top: 0, height
+          // with the sticky .nav header (position: sticky, top: 0, height
           // var(--nav-height) = 60px), the top edge zone is visually
           // unreachable by the pointer, so the browser's native
           // drag-at-edge fast-scroll never fires when dragging UP, while it
@@ -1806,7 +1806,7 @@ export const onRequest: AppPagesFunction = async ({ env, request, params }) => {
           //
           // This implementation replaces SortableJS's scroll plugin with a
           // symmetric gradient using requestAnimationFrame. The effective
-          // top edge is measured from `.nav`'s bounding rect at drag start,
+          // top edge is measured from .nav's bounding rect at drag start,
           // so the sticky header no longer blocks the fast-scroll zone.
           var AUTO_SCROLL_ZONE = 120;        // px from (effective) edge that triggers scroll
           var AUTO_SCROLL_MAX_SPEED = 32;    // px/frame at deepest edge (~1920 px/s @ 60fps)
@@ -1836,7 +1836,7 @@ export const onRequest: AppPagesFunction = async ({ env, request, params }) => {
             var distFromTop = pointerY - autoScrollEffectiveTop;
             var distFromBottom = autoScrollEffectiveBottom - pointerY;
 
-            // Upward scroll: pointer within `zone` px of (or above) the
+            // Upward scroll: pointer within zone px of (or above) the
             // effective top edge. distFromTop can be negative if the
             // pointer is above the nav bottom — still treat as max speed.
             if (distFromTop < zone) {
@@ -1845,7 +1845,7 @@ export const onRequest: AppPagesFunction = async ({ env, request, params }) => {
               var speed = AUTO_SCROLL_MIN_SPEED + (AUTO_SCROLL_MAX_SPEED - AUTO_SCROLL_MIN_SPEED) * t;
               return -speed;
             }
-            // Downward scroll: pointer within `zone` px of (or below) the
+            // Downward scroll: pointer within zone px of (or below) the
             // effective bottom edge. Symmetric formula.
             if (distFromBottom < zone) {
               var b = distFromBottom <= 0 ? 1 : 1 - (distFromBottom / zone);


### PR DESCRIPTION
## Summary

Hotfix: PR #175 introduced a deploy-blocking parse error on master.

### Root cause

The SSR \`<script>\` in \`functions/p/[id].ts\` lives inside a TypeScript **template literal** (it's emitted via a tagged backtick string). PR #175 added JS comments that contained literal backticks (e.g. \`\`// Upward scroll: pointer within \`zone\` px of...\`\`). The template literal terminated prematurely at those backticks, so wrangler failed to parse the file at deploy time:

\`\`\`
functions/p/[id].ts:1839:46: ERROR: Expected ':' but found 'zone'
\`\`\`

\`bun run build\` (Astro) does **not** process \`functions/\`, so the error never surfaced locally or in the PR's CI — it only fired at Cloudflare Pages deploy. See: [failed run](https://github.com/orientpine/honeycombo/actions/runs/24755413714).

### Fix

- Drop backticks from the affected JS comments (plain identifiers are fine).
- Verified locally with \`npx wrangler pages functions build --outdir=.wrangler-dry\` → \`✨ Compiled Worker successfully\`.
- Added a **prevention note** to \`docs/troubleshooting/playlist-batch-edit-drag-scroll-asymmetry.md\` so future edits to this file either (a) avoid backticks in comments or (b) run the wrangler parse locally before pushing.

## Validation (local CI + deploy parse)

- bun run validate — 353 files valid
- bun run validate:docs — 69 docs valid
- bun run validate:docs -- --check-coverage — passed
- bun run build — 737 pages, 13.56s
- bun run test — 355/355 passed
- npx wrangler pages functions build — Compiled Worker successfully

## Why this was missed

The PR's CI (\`.github/workflows/ci.yml\`) runs validate/build/test, not \`wrangler pages deploy\`. The deploy step only runs after merge to master. I should have run \`wrangler pages functions build\` locally as an extra gate — this is now captured in the troubleshooting doc.