### PR TITLE
feat: 북마크를 '나중에 볼 기사' Read Later 플레이리스트로 통합

### DIFF
--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -25,7 +25,7 @@
 ┌─────────────────────────────────────────────────────┐
 │  Cloudflare Pages                                    │
 │  정적 파일 서빙 + functions/ (SSR & API)             │
-│  (D1 데이터베이스 연동)                               │
+│  (D1 데이터베이스 연동: users, playlists, bookmarks)         │
 └─────────────────────────────────────────────────────┘
 ```
 ## 디렉토리 구조
@@ -69,13 +69,16 @@
 | `api/playlists/[id]/items/index.ts` | POST (기사 추가, 중복 시 409) |
 | `api/playlists/[id]/items/[itemId].ts` | PUT/DELETE (기사 수정/삭제) |
 | `api/playlists/[id]/visibility.ts` | PUT (공개 범위 변경) |
-`api/admin/playlists/[id]/reject.ts` | PUT (관리자: 반려) |
-`api/playlists/[id]/like.ts` | GET/POST 좋아요 API |
-`api/discussions/index.ts` | GET(목록)/POST(작성) Discussions API |
-`api/discussions/[number].ts` | GET 단건 Discussion API |
-`lib/github-graphql.ts` | GitHub GraphQL API 클라이언트 (queryDiscussions, getDiscussion, createDiscussion) |
-`api/trending.ts` | GET 트렌딩 API (JSON) |
-`trending.ts` | 트렌딩 페이지 SSR 렌더링 |
+| `api/admin/playlists/[id]/reject.ts` | PUT (관리자: 반려) |
+| `api/playlists/[id]/like.ts` | GET/POST 좋아요 API |
+| `api/bookmarks/toggle.ts` | POST 북마크 토글 |
+| `api/bookmarks/ids.ts` | GET 북마크 ID 목록 조회 |
+| `api/bookmarks/migrate.ts` | POST localStorage 북마크 마이그레이션 |
+| `api/discussions/index.ts` | GET(목록)/POST(작성) Discussions API |
+| `api/discussions/[number].ts` | GET 단건 Discussion API |
+| `lib/github-graphql.ts` | GitHub GraphQL API 클라이언트 (queryDiscussions, getDiscussion, createDiscussion) |
+| `api/trending.ts` | GET 트렌딩 API (JSON) |
+| `trending.ts` | 트렌딩 페이지 SSR 렌더링 |
 | `must-read.ts` | Must-read 페이지 SSR 렌더링 (D1 에디터 관리) |
 | `api/admin/must-read/index.ts` | GET/POST Must-read 관리 API |
 | `api/admin/must-read/[id].ts` | DELETE Must-read 항목 삭제 |
@@ -83,7 +86,7 @@
 | `lib/must-read.ts` | Must-read D1 CRUD 연산 |
 | `p/[id].ts` | 유저 플레이리스트 SSR (아이템 관리, 기사 검색, 외부 URL 추가) |
 | `lib/auth.ts` | 세션 관리 (upsertUser, createSession, getSession) |
-| `lib/playlists.ts` | 플레이리스트 CRUD, 자동 플레이리스트 생성/조회, 포함 여부 확인 |
+| `lib/playlists.ts` | 플레이리스트 CRUD, 카테고리별 자동 생성, 보호 로직 |
 | `lib/playlist-items.ts` | 아이템 추가/수정/삭제, 중복 방지 (DuplicateItemError) |
 | `lib/types.ts` | TypeScript 타입 정의 |
 | `lib/validate.ts` | URL/제목/source_id 검증 |
@@ -158,12 +161,19 @@ GitHub Issue (single/bulk) → scripts/process-submission.ts → PR (src/content
 ```
 
 - 제출 시 GitHub Issue 작성자의 numeric user id(`submitted_by_id`)도 함께 저장해 승인 webhook에서 D1 사용자와 매칭한다.
+
 ### 4. 기사 승인 시 플레이리스트 자동 추가
 
 GitHub Issue → PR → merge → webhook → submissions table (D1) → 사용자가 /my/articles에서 수동 배정
 
+### 5. 북마크 데이터 흐름
 
-### 5. 빌드
+```
+사용자 클릭 → /api/bookmarks/toggle → D1 user_playlists (category='read_later')
+                                  └─ sessionStorage 캐시 업데이트
+```
+
+### 6. 빌드
 
 ```
 src/ (pages + components + data + content) → astro build → dist/
@@ -201,6 +211,7 @@ src/ (pages + components + data + content) → astro build → dist/
 - [트렌딩 플레이리스트](../features/trending-playlists.md)
 - [Must-read 에디터 관리](../features/must-read-management.md)
 - [기사 승인 시 플레이리스트 자동 추가](../features/auto-playlist-add.md)
+- [북마크 — 나중에 볼 기사](../features/bookmark-read-later.md)
 
 ## 변경 이력
 
@@ -225,3 +236,4 @@ src/ (pages + components + data + content) → astro build → dist/
 | 2026-04-14 | 커뮤니티 자유 발제 기능 추가 (GitHub Discussions 기반, /community 페이지, api/discussions/* API) |
 | 2026-04-16 | CI 파이프라인에 wrangler 직접 배포 추가 (Cloudflare GitHub App 이벤트 누락 근본 해결) |
 | 2026-04-17 | 메인 페이지 콘텐츠 허브화 — 소개 섹션·최근 기사·트렌딩·추천 인플루언서 추가, `color-scheme: light` 메타/CSS로 라이트 모드 고정 |
+| 2026-04-23 | 북마크 기능을 D1 Read Later 플레이리스트로 통합 |

--- a/docs/decisions/0005-bookmark-as-read-later-playlist.md
+++ b/docs/decisions/0005-bookmark-as-read-later-playlist.md
@@ -1,0 +1,147 @@
+# 0005: 북마크를 "나중에 볼 기사" 기본 Private 플레이리스트로 통합
+
+> 상태: **승인**
+
+## 맥락
+
+HoneyCombo는 두 개의 독립된 "기사 저장" 기능을 운영해 왔다.
+
+1. **북마크(BookmarkButton)**: `localStorage` 기반 디바이스-로컬 저장. 로그인 불필요, 서버 비용 0. 하트 아이콘 사용.
+2. **플레이리스트(AddToPlaylist)**: D1 기반 서버 저장, GitHub OAuth 필수, 공유 가능한 큐레이션.
+
+이 구조는 다음 문제를 야기했다.
+
+- **UX 중복**: 기사 카드에 두 기능이 나란히 노출되어 "어느 걸 눌러야 하나?" 혼란을 유발.
+- **아이콘 충돌**: 북마크가 하트 아이콘을 사용하는데, 플레이리스트 좋아요(Like) 기능도 하트로 표현되어 의미 충돌.
+- **북마크 조회 불가능**: 사용자가 북마크한 기사를 확인할 UI가 전혀 없어서 북마크는 사실상 "write-only" 기능이었다. `docs/features/article-detail-community.md`는 "로그인 연동 미구현"을 명시적으로 설계 한계로 인정하고 있었다.
+- **크로스 디바이스 불가**: localStorage 특성상 디바이스 간 동기화 불가.
+
+사용자의 질문 "북마크를 '나중에 볼 기사' private 플레이리스트에 추가하는 기능으로 만들어줘. 북마크 조회도 가능하게 하고. 기존의 플레이리스트 페이지에서 처리할 수 있지?"가 통합 방향을 명확히 했다.
+
+## 결정
+
+**북마크 = 시스템이 자동 생성하는 "나중에 볼 기사"라는 이름의 private 플레이리스트.**
+
+구체 설계:
+
+1. **스키마**: `user_playlists` 테이블에 `playlist_category` 컬럼 추가.
+   - 값: `'read_later'` | `'submissions'` | `NULL`
+   - 부분 UNIQUE 인덱스 `uq_user_playlist_category (user_id, playlist_category) WHERE playlist_category IS NOT NULL`로 사용자당 카테고리별 단일 플레이리스트 보장.
+   - 기존 `is_auto_created=1` 레코드는 `'submissions'`으로 backfill.
+
+2. **생성 시점**: Lazy. 사용자가 처음 북마크 버튼을 클릭하는 순간 `getOrCreateReadLaterPlaylist()`가 호출되어 생성.
+   - 속성: `title='나중에 볼 기사'`, `visibility='unlisted'`, `status='draft'`, `playlist_type='community'`, `is_auto_created=1`, `playlist_category='read_later'`.
+
+3. **API 신설**:
+   - `POST /api/bookmarks/toggle` — 기사 추가/제거 토글
+   - `GET  /api/bookmarks/ids`    — 현재 사용자의 북마크 source_id 배열 반환 (UI 상태 복원용)
+   - `POST /api/bookmarks/migrate` — localStorage 북마크를 D1으로 배치 이관
+
+4. **보호 규칙**:
+   - `playlist_category='read_later'`인 플레이리스트는 삭제 불가 (`deletePlaylist` 가드)
+   - visibility 변경 불가 — 항상 `unlisted` 유지 (`setVisibility` 가드)
+   - AddToPlaylist 드롭다운에서 제외 (`?exclude_category=read_later`) — 별도 북마크 버튼이 이미 존재하므로 중복 UX 방지
+
+5. **UI 변경**:
+   - BookmarkButton 아이콘: 하트 → 책갈피(bookmark) SVG
+   - 색상: `#e74c6f` → `var(--color-primary)` (오렌지)
+   - 미로그인 클릭 시: 현재 페이지로 `return_to`를 포함한 로그인 페이지로 리다이렉트
+   - `/my/playlists`에서 Read Later는 항상 최상단에 고정 노출 (`ORDER BY (playlist_category = 'read_later') DESC, updated_at DESC`)
+   - `/p/{id}` 상세 페이지: Read Later인 경우 삭제/공개 버튼 숨김, 항목 관리(추가/삭제/메모)는 유지
+
+6. **마이그레이션**: 기존 localStorage(`honeycombo:bookmarks`) 사용자 대상 일회성 자동 이관.
+   - 첫 로그인 후 BookmarkButton 초기화 시 localStorage 확인
+   - 비어있지 않으면 `/api/bookmarks/migrate`로 배치 POST
+   - 성공 시 토스트 `"N개의 북마크를 '나중에 볼 기사'로 옮겼습니다"` + localStorage 키 삭제
+
+7. **기존 버그 동시 수정**: `getOrCreateAutoPlaylist()`가 auto-created 여부와 무관하게 "가장 최근 플레이리스트"를 반환하던 버그를 `playlist_category='submissions'` 필터로 정정.
+
+## 고려한 대안
+
+### 대안 1: 북마크를 localStorage에 유지하고 조회 페이지만 추가
+
+- 장점: 스키마 변경 없음, 로그인 불필요 유지, 서버 비용 0
+- 단점:
+  - 아이콘 충돌은 해결되나 "북마크 vs 플레이리스트 추가" UX 혼란은 그대로
+  - 크로스 디바이스 동기화 불가
+  - `/articles/` 필터 또는 신규 `/bookmarks` 페이지 구축 필요 — 또 하나의 조회 경로 증가
+- 탈락 사유: 사용자의 "기존 플레이리스트 페이지에서 처리할 수 있을 것 같다"는 요구와 어긋남. 통합이 아닌 또 다른 분리를 만듦.
+
+### 대안 2: 별도의 `user_bookmarks` 테이블 신설
+
+- 장점: 기능 경계가 명확, 플레이리스트 시스템과 분리
+- 단점:
+  - 플레이리스트와 완전히 동일한 CRUD 패턴을 중복 구현 (list/add/remove/detail/snapshot)
+  - `/my/playlists` 외에 `/my/bookmarks` 페이지를 별도 구축 — 사용자 요구("전용 페이지 없이도 되지?")에 반함
+  - snapshot, position, note 등 동일 기능을 두 테이블에서 관리
+- 탈락 사유: 명백한 over-engineering. 플레이리스트 시스템이 이미 모든 요구 기능을 갖춤.
+
+### 대안 3: 북마크 제거 + AddToPlaylist만 사용
+
+- 장점: UX 완전 단순화, 단일 경로
+- 단점:
+  - "빠른 한 번의 클릭"으로 저장하던 경험 상실 (드롭다운에서 플레이리스트 선택 필요)
+  - 처음 사용하는 유저는 플레이리스트 생성부터 해야 하는 진입 장벽
+- 탈락 사유: 북마크의 "원 클릭 저장" UX를 버림. Read Later를 기본 타깃으로 삼으면 이 장점을 유지하면서도 서버 저장 가능.
+
+### 대안 4: localStorage + "익명 플레이리스트" 하이브리드 (Guest Mode)
+
+- 장점: 미로그인 UX 유지하면서 조회 페이지 제공 가능
+- 단점: 익명/인증 상태 전환 시 동기화 로직 복잡, 디바이스 이관 시 데이터 손실 가능
+- 탈락 사유: 구현 복잡도가 얻는 이득보다 큼. OAuth 로그인 허들이 낮은 GitHub 사용자층 특성상 로그인 요구가 수용 가능.
+
+## 결과
+
+**긍정적 영향**:
+
+- 북마크가 서버 저장으로 전환되어 크로스 디바이스 동기화가 가능해진다.
+- 플레이리스트 시스템 하나로 "내가 저장한 기사"의 단일 접근 경로를 확립 → UX 통일성.
+- 아이콘 충돌 해소 (하트는 Like 전용, 책갈피는 Bookmark 전용).
+- `/articles/` 기사 카드의 UI 복잡도 감소.
+
+**부정적 영향 / 트레이드오프**:
+
+- **Breaking change**: 북마크가 로그인 필수 기능이 된다. 미로그인 사용자는 클릭 시 로그인 페이지로 리다이렉트.
+  - 완화: 기존 localStorage 북마크는 첫 로그인 시 자동 이관 (최대 200건, 초과 시 안내).
+- D1 쿼리 증가: 페이지 로드당 `GET /api/bookmarks/ids` 1회, 토글 시 `POST /api/bookmarks/toggle` 1회.
+  - 완화: sessionStorage 캐시로 페이지 내 재호출 없음.
+- 기존 auto-playlist 시스템(제출 기사 동기화)과의 카테고리 충돌을 `playlist_category` 컬럼으로 명시적 구분 → 향후 auto-playlist 유형 추가가 용이.
+
+**향후 확장 여지**:
+
+- `playlist_category`에 다른 값 추가 가능 (예: `'favorites'`, `'history'` 등)
+- Read Later만의 특수 정렬/필터 UI를 플레이리스트 상세 페이지에 추가 가능
+
+## 관련 파일
+
+- `migrations/0005_playlist_category.sql`
+- `functions/lib/playlists.ts` — `getOrCreateReadLaterPlaylist`, `getOrCreateAutoPlaylist` 버그 수정, 가드
+- `functions/lib/types.ts` — `PlaylistCategory`, `ToggleBookmarkInput` 등
+- `functions/api/bookmarks/toggle.ts`
+- `functions/api/bookmarks/ids.ts`
+- `functions/api/bookmarks/migrate.ts`
+- `functions/api/playlists/[id]/index.ts` — DELETE 가드
+- `functions/api/playlists/[id]/visibility.ts` — 가드
+- `functions/api/playlists/index.ts` — `exclude_category` 파라미터
+- `src/components/BookmarkButton.astro` — 전면 재작성 (localStorage → API)
+- `src/components/ArticleCard.astro` — props 확장
+- `src/components/AddToPlaylist.astro` — `exclude_category=read_later` 반영
+- `src/pages/my/playlists.astro` — Read Later 특수 렌더링
+- `functions/p/[id].ts` — Read Later 상세 페이지 가드
+- `docs/features/bookmark-read-later.md`
+- `docs/features/playlists.md`
+- `docs/features/article-detail-community.md`
+- `docs/architecture/overview.md`
+
+---
+
+## 관련 문서
+
+- [아키텍처 개요](../architecture/overview.md)
+- [플레이리스트](../features/playlists.md)
+
+## 변경 이력
+
+| 날짜 | 변경 내용 |
+|------|----------|
+| 2026-04-23 | 최초 작성. 사용자 요청에 따른 북마크 → Read Later 플레이리스트 통합 결정. |

--- a/docs/features/article-detail-community.md
+++ b/docs/features/article-detail-community.md
@@ -11,12 +11,12 @@
 ```
 기사 상세페이지 로드
   → astro:page-load 이벤트 발생
-  → BookmarkButton: localStorage에서 북마크 상태 복원
+  → BookmarkButton: sessionStorage 또는 API에서 북마크 상태 복원 (미로그인 시 localStorage 마이그레이션 체크)
   → Giscus: 동적으로 script 요소 생성 → iframe 렌더링
   → ShareButtons: 클릭 시 clipboard/window.open/navigator.share
 
 기사 목록 페이지 로드
-  → BookmarkButton: localStorage에서 전체 북마크 상태 복원
+  → BookmarkButton: sessionStorage 또는 API에서 전체 북마크 상태 복원
   → IntersectionObserver: 뷰포트 진입 카드에 대해 Giscus API fetch
   → sessionStorage 캐시 확인 → 없으면 API 호출 → 댓글 수 표시
 ```
@@ -32,10 +32,12 @@
 
 ### 2. 북마크 (BookmarkButton)
 
-- **localStorage 기반**: `honeycombo:bookmarks` 키에 기사 ID 배열 저장
-- **하트 아이콘 토글**: outline ↔ filled, 핑크 컬러 (#e74c6f)
+- **D1 플레이리스트 기반**: 북마크는 로그인 사용자의 '나중에 볼 기사' private 플레이리스트에 저장된다.
+- **책갈피 아이콘 토글**: outline ↔ filled, primary 컬러 (`var(--color-primary)`)
 - **동기화**: 같은 페이지 내 동일 기사의 북마크 버튼 자동 동기화
+- **로그인 필수**: 미로그인 시 클릭하면 로그인 페이지로 리다이렉트된다.
 - 상세페이지: `size="md"` (액션 바), 목록 카드: `size="sm"` (아이콘만)
+- 상세 내용은 [북마크 — 나중에 볼 기사](./bookmark-read-later.md) 참조.
 
 ### 3. 관련 기사 개선 (RelatedArticles)
 
@@ -81,18 +83,15 @@
 
 | 이름 | 위치 | 기본값 | 설명 |
 |------|------|--------|------|
-| `honeycombo:bookmarks` | localStorage | `[]` | 북마크된 기사 ID 배열 |
+| `honeycombo:bookmark-ids` | sessionStorage | `[]` | 북마크 상태 캐시 (API 응답 캐시) |
+| `honeycombo:bookmarks` | localStorage (legacy) | — | 구버전 북마크, 첫 로그인 시 자동 마이그레이션 후 제거 |
 | `honeycombo:comment-counts` | sessionStorage | `{}` | 댓글 수 캐시 (path → count) |
 | `REPO_ID` | `Comments.astro` | `R_kgDOR_fpgQ` | GitHub repo ID (Giscus) |
 | `CATEGORY_ID` | `Comments.astro` | `DIC_kwDOR_fpgc4C6lgR` | GitHub Discussions category ID |
 
-- **북마크를 localStorage로 구현**: 서버 비용 없이 즉시 동작. 크로스 디바이스는 기존 플레이리스트 기능으로 대체 가능.
-- **댓글 수를 클라이언트에서 fetch**: SSG 빌드 시점에 GitHub API 토큰 불필요. IntersectionObserver + sessionStorage로 성능 최적화.
-- **Giscus를 `astro:page-load`로 초기화**: View Transitions(ClientRouter) 호환. 기존 `is:inline` + 외부 스크립트 방식은 페이지 전환 시 재초기화 실패.
-
 ## 제약 사항
 
-- 북마크는 디바이스별 저장 (localStorage). 로그인 연동 미구현.
+- 북마크는 로그인 사용자의 '나중에 볼 기사' private 플레이리스트에 저장된다. 미로그인 시 클릭하면 로그인 페이지로 리다이렉트된다. (D1 기반 동기화 지원)
 - 댓글 수는 Giscus API 응답 속도에 의존 (보통 100~300ms).
 - Giscus Discussion이 아직 생성되지 않은 기사는 댓글 수 0 표시.
 
@@ -101,6 +100,7 @@
 ## 관련 문서
 
 - [아키텍처 개요](../architecture/overview.md)
+- [북마크 — 나중에 볼 기사](./bookmark-read-later.md)
 
 ## 변경 이력
 
@@ -108,3 +108,4 @@
 |------|----------|
 | 2026-04-14 | 최초 작성 |
 | 2026-04-14 | 에디터 추천 뱃지 추가 (ArticleCard, TagFilter), 댓글 UI 개선 (Comments) |
+| 2026-04-23 | 북마크를 localStorage에서 D1 기반 '나중에 볼 기사' 플레이리스트로 마이그레이션 |

--- a/docs/features/bookmark-read-later.md
+++ b/docs/features/bookmark-read-later.md
@@ -1,0 +1,86 @@
+# 북마크 — 나중에 볼 기사 (Read Later)
+
+> 사용자가 관심 있는 기사를 북마크하여 '나중에 볼 기사' 플레이리스트에 자동으로 저장하고 관리하는 기능.
+
+## 개요
+
+기존의 localStorage 기반 북마크 시스템은 브라우저나 디바이스가 바뀌면 데이터가 유지되지 않는 한계가 있었다. 이를 해결하기 위해 Cloudflare D1 데이터베이스 기반의 '나중에 볼 기사' 플레이리스트로 통합했다. 사용자가 북마크 버튼을 누르면 서버에 비공개 플레이리스트가 자동으로 생성되며, 모든 디바이스에서 동기화된 북마크 목록을 확인할 수 있다.
+
+## 동작 흐름
+
+### 1. 북마크 토글
+```
+사용자 클릭 → Optimistic UI (아이콘 변경) 
+           → POST /api/bookmarks/toggle 
+           → D1 user_playlists (read_later 카테고리) & playlist_items 업데이트
+           → sessionStorage 캐시 (honeycombo:bookmark-ids) 갱신
+```
+
+### 2. 페이지 로드 시 상태 복원
+```
+페이지 로드 → sessionStorage 캐시 확인
+           → (캐시 없음) GET /api/bookmarks/ids 
+           → sessionStorage 캐시 저장
+           → UI 반영 (북마크된 기사 표시)
+```
+
+### 3. localStorage 마이그레이션
+```
+첫 로그인 후 BookmarkButton 초기화 
+           → 기존 localStorage (honeycombo:bookmarks) 검사 
+           → (데이터 존재 시) POST /api/bookmarks/migrate (최대 200개)
+           → D1 저장 완료 후 localStorage 제거
+           → "N개의 북마크를 '나중에 볼 기사'로 옮겼습니다." 토스트 표시
+```
+
+### 4. 북마크 조회 및 관리
+```
+사용자 → /my/playlists (내 플레이리스트 목록)
+       → '나중에 볼 기사' 카드 클릭 (🔖 배지 표시)
+       → /p/{id} (플레이리스트 상세 페이지)
+       → 항목 확인, 메모 추가, 순서 변경 등 수행
+```
+
+## 관련 파일
+
+| 파일 | 역할 |
+|------|------|
+| `migrations/0005_playlist_category.sql` | `playlist_category` 컬럼 및 유니크 인덱스 추가 |
+| `functions/lib/playlists.ts` | `read_later` 카테고리 생성 및 보호 로직 (`ReadLaterProtectedError`) |
+| `functions/api/bookmarks/toggle.ts` | 북마크 토글 API |
+| `functions/api/bookmarks/ids.ts` | 북마크된 ID 목록 조회 API |
+| `functions/api/bookmarks/migrate.ts` | localStorage 데이터를 D1으로 마이그레이션하는 API |
+| `src/components/BookmarkButton.astro` | 북마크 버튼 UI 및 클라이언트 사이드 로직 (마이그레이션 포함) |
+| `src/pages/my/playlists.astro` | 내 플레이리스트 목록에서 Read Later 특수 UI 처리 |
+| `functions/p/[id].ts` | Read Later 상세 페이지 전용 헤더 및 컨트롤 제어 |
+
+## 설정값
+
+| 이름 | 위치 | 기본값 | 설명 |
+|------|------|--------|------|
+| `honeycombo:bookmark-ids` | sessionStorage | `[]` | 클라이언트 사이드 북마크 상태 캐시 (source_id 배열) |
+| `honeycombo:bookmarks` | localStorage | — | (레거시) 구버전 북마크 데이터, 마이그레이션 후 삭제됨 |
+| `playlist_category` | D1 테이블 | `'read_later'` | 자동 생성된 북마크 플레이리스트를 식별하는 값 |
+| `Max migration batch` | `/api/bookmarks/migrate` | `200` | 한 번에 마이그레이션 가능한 최대 아이템 수 |
+
+## 제약 사항
+
+- **로그인 필수**: D1 데이터베이스를 사용하므로 로그인이 필요하다. 미로그인 상태에서 클릭 시 로그인 페이지로 리다이렉트된다.
+- **동기화 타이밍**: sessionStorage 캐시를 사용하며, 브라우저 탭을 새로고침하거나 다른 기기에서 접속 시 서버에서 최신 상태를 재조회한다.
+- **자동 마이그레이션 조건**: `#all-articles-data` JSON 데이터가 포함된 페이지(기사 목록 등)에서만 마이그레이션이 트리거된다.
+- **삭제 및 설정 변경 제한**: '나중에 볼 기사' 플레이리스트는 삭제하거나 공개 범위를 변경할 수 없다. (`ReadLaterProtectedError` 가드 적용)
+- **중복 방지**: 동일한 기사는 하나의 플레이리스트에 중복해서 추가될 수 없다. (UNIQUE 제약)
+
+---
+
+## 관련 문서
+
+- [플레이리스트](./playlists.md)
+- [기사 상세페이지 커뮤니티 기능](./article-detail-community.md)
+- [아키텍처 개요](../architecture/overview.md)
+
+## 변경 이력
+
+| 날짜 | 변경 내용 |
+|------|----------|
+| 2026-04-23 | 최초 작성. 북마크를 D1 기반 Read Later 플레이리스트로 통합 |

--- a/docs/features/playlists.md
+++ b/docs/features/playlists.md
@@ -13,6 +13,7 @@
 - `playlist_type`: 'community' (일반 유저) 또는 'editor' (공식 에디터)
 - `tags`: 플레이리스트 분류를 위한 태그 (쉼표로 구분된 문자열)
 - `status`: 'draft', 'pending', 'approved', 'rejected' (에디터 타입은 생성 시 즉시 'approved' 상태가 됨)
+- `playlist_category`: 자동 생성된 플레이리스트의 용도를 구분 ('read_later', 'submissions' 또는 NULL)
 
 ## 동작 흐름
 
@@ -138,8 +139,8 @@
 - 관리자 승인 UI는 `/admin/playlists` 정적 페이지(`src/pages/admin/playlists.astro`)에서 클라이언트 사이드 렌더링으로 동작한다.
 - 로그인 상태 + 관리자 권한 검증 후 대기 목록을 표시한다.
 - 각 카드에서 승인/반려/미리보기 버튼을 제공하며, 처리 완료 시 카드가 페이드아웃 후 제거된다.
-
 - 에디터 플레이리스트(`playlist_type: 'editor'`)는 승인 절차를 거치지 않고 생성 즉시 `approved` 상태가 되어 목록에 노출된다. (Auto-approve)
+
 ### 좋아요 기능
 
 ```
@@ -158,7 +159,7 @@
 ```text
 승인 webhook → functions/webhooks/submission-approved.ts
             → users.id = submitted_by_id 조회
-            → 최근 플레이리스트 재사용 또는 `내 제출 기사` 자동 생성
+            → `playlist_category = 'submissions'` 필터로 기존 플레이리스트 재사용 또는 자동 생성
             → curated 아이템 추가
 미가입 사용자 → submissions 테이블에 deferred 저장
 삭제 webhook  → functions/webhooks/submission-removed.ts → playlist_items/submissions 정리
@@ -167,6 +168,23 @@
 - 자동 생성 플레이리스트는 `visibility: 'unlisted'`, `status: 'draft'`, `playlist_type: 'community'`, `is_auto_created = 1` 로 생성된다.
 - 이미 같은 curated 기사가 존재하면 `DuplicateItemError`를 `already_exists` 응답으로 변환해 중복 삽입을 막는다.
 - 제출 파이프라인(`scripts/process-submission.ts`)은 GitHub Issue 작성자의 numeric user id를 `submitted_by_id`로 함께 저장한다.
+
+### 자동 생성 카테고리 플레이리스트 (auto-playlist categories)
+
+특정 용도를 위해 시스템이 자동으로 생성하는 플레이리스트는 `playlist_category` 값을 가진다. partial unique index를 통해 사용자당 카테고리별로 단 하나만 존재하도록 보장한다.
+
+- `'submissions'`: 사용자가 제출한 기사가 승인되었을 때 자동으로 모이는 플레이리스트.
+- `'read_later'`: 사용자가 북마크한 기사가 저장되는 플레이리스트. 첫 북마크 시점에 생성된다. 상세 내용은 [북마크 — 나중에 볼 기사](./bookmark-read-later.md) 참조.
+
+### 보호된 플레이리스트 (Protected auto-playlists)
+
+`read_later` 카테고리의 플레이리스트는 시스템 무결성을 위해 다음과 같은 변경이 제한된다.
+
+- 삭제 불가: API 호출 시 403 응답 (`'나중에 볼 기사 플레이리스트는 삭제할 수 없습니다'`)
+- 공개 설정 변경 불가: API 호출 시 403 응답 (`'나중에 볼 기사 플레이리스트는 공개 설정을 변경할 수 없습니다'`)
+- 제목 및 설명 수정 불가: API 호출 시 403 응답 (`'나중에 볼 기사 플레이리스트는 수정할 수 없습니다'`)
+
+이 가드는 `functions/lib/playlists.ts`의 `ReadLaterProtectedError` 클래스를 통해 구현되어 있다.
 
 ## 관련 파일
 
@@ -177,7 +195,7 @@
 | `src/pages/p/new.astro` | 플레이리스트 생성 폼 (인증 필요) |
 | `src/pages/my/playlists.astro` | 내 플레이리스트 관리 페이지 |
 | `src/pages/search-index.json.ts` | 빌드 시 기사 검색용 정적 JSON 인덱스 생성 |
- `src/pages/playlists/index.astro` | 에디터+커뮤니티 플레이리스트 목록 (D1 API 기반) |
+| `src/pages/playlists/index.astro` | 에디터+커뮤니티 플레이리스트 목록 (D1 API 기반) |
 | `src/components/AddToPlaylist.astro` | 기사에 "플레이리스트에 추가" 드롭다운 |
 | `src/pages/admin/playlists.astro` | 관리자 플레이리스트 승인/반려 UI 페이지 |
 | `src/components/ArticleCard.astro` | 기사 카드 (각 기사에 AddToPlaylist 버튼 포함) |
@@ -198,6 +216,9 @@
 | `functions/api/admin/playlists/[id]/approve.ts` | PUT (관리자: 승인) |
 | `functions/api/admin/playlists/[id]/reject.ts` | PUT (관리자: 반려) |
 | `functions/api/playlists/[id]/like.ts` | GET/POST 좋아요 API |
+| `functions/api/bookmarks/toggle.ts` | 북마크 토글 API |
+| `functions/api/bookmarks/ids.ts` | 북마크 ID 목록 조회 API |
+| `functions/api/bookmarks/migrate.ts` | localStorage 북마크 마이그레이션 API |
 | `functions/webhooks/submission-approved.ts` | 승인 기사 auto-playlist webhook |
 | `functions/webhooks/submission-removed.ts` | 승인 취소/삭제 정리 webhook |
 
@@ -216,10 +237,11 @@
 
 | 파일 | 역할 |
 |------|------|
- `migrations/0001_user_playlists.sql` | D1 테이블 스키마 (users, sessions, user_playlists, playlist_items) |
- `migrations/0002_playlist_type.sql` | `playlist_type`, `tags` 컬럼 추가 마이그레이션 |
+| `migrations/0001_user_playlists.sql` | D1 테이블 스키마 (users, sessions, user_playlists, playlist_items) |
+| `migrations/0002_playlist_type.sql` | `playlist_type`, `tags` 컬럼 추가 마이그레이션 |
 | `migrations/0002_playlist_likes.sql` | playlist_likes 테이블 스키마 |
 | `migrations/0004_auto_playlist.sql` | auto-created playlist / deferred submissions 스키마 |
+| `migrations/0005_playlist_category.sql` | `playlist_category` 컬럼 및 유니크 인덱스 추가 |
 
 ## API 응답 형태
 
@@ -286,6 +308,7 @@
 - [기사 관리 페이지](./article-management.md)
 - [아키텍처 개요](../architecture/overview.md)
 - [기사 승인 시 플레이리스트 자동 추가](./auto-playlist-add.md)
+- [북마크 — 나중에 볼 기사](./bookmark-read-later.md)
 - [플레이리스트 데이터 미스매치 트러블슈팅](../troubleshooting/playlist-data-mismatch.md)
 - [플레이리스트 검색 렌더링·순서 변경 트러블슈팅](../troubleshooting/playlist-detail-search-and-reorder.md)
 - [플레이리스트 기사 링크 홈 리다이렉트 트러블슈팅](../troubleshooting/playlist-article-links-redirect-to-home.md)
@@ -313,7 +336,8 @@
 | 2026-04-21 | 플레이리스트 상세 페이지(`/p/{id}`) 소유자 전용 “🏷️ 태그 편집” 섹션 추가 — inline 태그 관리 UI(pill + Enter/쉼표 추가 + × 제거), `data-initial-tags` 속성 기반 XSS-safe 전달, PUT /api/playlists/{id} 호출, 리로드 없이 헤더 태그 디스플레이 즉시 갱신, DESIGN.md §4.4/§4.2 패턴 재사용. |
 | 2026-04-21 | **최신순 정렬 + 드래그 재정렬 전환** — `ORDER BY position DESC`로 정렬 방향 역전, `↑`/`↓` 버튼 전면 제거, `📋 배치 편집` 토글 모드 + SortableJS 드래그 도입, 새 API `PUT /api/playlists/{id}/items/reorder`와 `reorderItems()` 함수 추가 (D1 `batch()`로 원자 position 재할당). DESIGN.md §4.8 Drag Handle, §4.9 Batch Edit Mode, §6 L9 Dragging Elevation 패턴 참조. |
 | 2026-04-21 | 배치 편집 드래그 **자동 스크롤 활성화** — SortableJS `scroll`/`scrollSensitivity: 80`/`scrollSpeed: 20`/`bubbleScroll: true`/`forceAutoScrollFallback: true` 옵션 추가. 드래그 중 뷰포트 가장자리 근처에서 페이지 자동 스크롤되어 긴 플레이리스트의 먼 위치로 드래그 가능. 신규 토큰·UI 변경 없음. |
-| 2026-04-21 | 배치 편집 드래그 자동 스크롤 속도 **2배 가속** — SortableJS `scrollSpeed: 20 → 40` (프레임당 40px, 60fps 기준 약 2,400px/s). 더 높은 속도로 드래그 중 스크롤할 수 있어 긴 플레이리스트 탐색이 더 경쯠해짐. `scrollSensitivity: 80`은 유지 — 감지 영역은 동일, 스크롤 개시 후 만 빠르게 이동.
+| 2026-04-21 | 배치 편집 드래그 자동 스크롤 속도 **2배 가속** — SortableJS `scrollSpeed: 20 → 40` (프레임당 40px, 60fps 기준 약 2,400px/s). 더 높은 속도로 드래그 중 스크롤할 수 있어 긴 플레이리스트 탐색이 더 경영해짐. `scrollSensitivity: 80`은 유지 — 감지 영역은 동일, 스크롤 개시 후 만 빠르게 이동.
 | 2026-04-22 | 배치 편집 드래그 자동 스크롤 **위/아래 비대칭 버그 수정 + 커스텀 rAF 구현으로 교체** — SortableJS 내장 `scroll` 플러그인 비활성화(`scroll: false`)하고 `requestAnimationFrame` 기반 gradient 오토스크롤을 `onStart`/`onEnd`에 직접 연결. sticky `.nav` 헤더(60px)가 가리던 위쪽 edge 영역을 `.nav.getBoundingClientRect().bottom`으로 측정한 effective top edge로 보정. zone 120px, 속도 `4 → 32 px/frame` gradient (edge에 가까울수록 빠름). 이전 binary 속도로 인해 위 방향이 느리고 2단 계단식으로 느껴지던 현상 해소, 위/아래 모두 부드럽고 대칭적으로 스크롤됨. 참조: [troubleshooting/playlist-batch-edit-drag-scroll-asymmetry.md](../troubleshooting/playlist-batch-edit-drag-scroll-asymmetry.md).
 | 2026-04-22 | 배치 편집 드래그 자동 스크롤 **후속 수정** — 앞 변경에서 `forceFallback: true` 옵션이 누락되어 SortableJS가 HTML5 native drag를 사용했고, native drag 중 브라우저가 `pointermove`를 window로 발화시키지 않아 커스텀 rAF 스크롤러가 `clientY`를 전혀 받지 못해 **위 방향 자동 스크롤이 완전히 멈추는** 회귀 발생. Sortable 옵션에 `forceFallback: true` + `fallbackTolerance: 3` 추가(클론 기반 시뮬레이션 드래그로 전환)로 해결. 트러블슈팅 문서의 예방 조치에 "커스텀 pointer 기반 auto-scroll 쓸 때는 `forceFallback` 필수" 항목 추가.
-| 2026-04-22 | 배치 편집 **버튼 가시성 버그 수정 + entrance animation** — `.batch-edit-btn`(`📋 배치 편집`)과 `.batch-action-bar`(`취소`/`저장`)가 배치 편집 진입 전후에 **세 버튼이 동시에 보이던** 문제 해결. 원인: `.btn` 의 `display: inline-flex` 와 `.batch-action-bar` 의 `display: flex` 가 user-agent의 `[hidden] { display: none }` 를 덮어씀. `.batch-edit-btn[hidden], .batch-action-bar[hidden] { display: none !important; }` 명시 선언으로 HTML `hidden` 속성이 정상 동작하도록 복구. 부가로 action bar 등장 시 0.18s spring easing opacity+translateX 애니메이션으로 자연스러운 모드 전환 UX 제공(`prefers-reduced-motion: reduce` 존중). 툴바에 `min-height: 2.25rem` 로 레이아웃 점프 방지.
+| 2026-04-22 | 배치 편집 **버튼 가시성 버그 수정 + entrance animation** — `.batch-edit-btn`(`📋 배치 편집`)과 `.batch-action-bar`(`취소`/`저장`)가 배치 편집 진입 전후에 **세 버튼이 동시에 보이던** 문제 해결. 원인: `.btn` 의 `display: inline-flex` 와 `.batch-action-bar` 의 `display: flex` 가 user-agent의 `[hidden] { display: none }` 를 덮어씬. `.batch-edit-btn[hidden], .batch-action-bar[hidden] { display: none !important; }` 명시 선언으로 HTML `hidden` 속성이 정상 동작하도록 복구. 부가로 action bar 등장 시 0.18s spring easing opacity+translateX 애니메이션으로 자연스러운 모드 전환 UX 제공(`prefers-reduced-motion: reduce` 존중). 툴바에 `min-height: 2.25rem` 로 레이아웃 점프 방지.
+| 2026-04-23 | `playlist_category` 컴럼 도입 (read_later/submissions/NULL). Read Later 자동 플레이리스트 통합, getOrCreateAutoPlaylist 버그 수정, 삭제/공개 가드 추가 |

--- a/functions/api/bookmarks/ids.ts
+++ b/functions/api/bookmarks/ids.ts
@@ -1,0 +1,51 @@
+import type { AppPagesFunction, BookmarkStatusResponse, PlaylistCategory } from '../../lib/types';
+
+const READ_LATER_CATEGORY: PlaylistCategory = 'read_later';
+
+function json(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+export const onRequestGet: AppPagesFunction = async (context) => {
+  const { env, data } = context;
+
+  if (!data.user) {
+    return json({ error: 'Unauthorized' }, 401);
+  }
+
+  const playlist = await env.DB
+    .prepare(
+      `SELECT id FROM user_playlists
+       WHERE user_id = ? AND playlist_category = ?
+       LIMIT 1`,
+    )
+    .bind(data.user.id, READ_LATER_CATEGORY)
+    .first<{ id: string }>();
+
+  if (!playlist) {
+    const response: BookmarkStatusResponse = {
+      bookmarked_ids: [],
+      playlist_id: null,
+    };
+
+    return json(response);
+  }
+
+  const items = await env.DB
+    .prepare(
+      `SELECT source_id FROM playlist_items
+       WHERE playlist_id = ? AND source_id IS NOT NULL`,
+    )
+    .bind(playlist.id)
+    .all<{ source_id: string | null }>();
+
+  const response: BookmarkStatusResponse = {
+    bookmarked_ids: items.results.map((row) => String(row.source_id)),
+    playlist_id: playlist.id,
+  };
+
+  return json(response);
+};

--- a/functions/api/bookmarks/migrate.ts
+++ b/functions/api/bookmarks/migrate.ts
@@ -1,0 +1,123 @@
+import { addItem, DuplicateItemError } from '../../lib/playlist-items';
+import { getOrCreateReadLaterPlaylist } from '../../lib/playlists';
+import type {
+  AppPagesFunction,
+  MigrateBookmarksInput,
+  MigrateBookmarksResponse,
+  ToggleBookmarkInput,
+} from '../../lib/types';
+
+function json(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function isBookmarkItemType(value: unknown): value is ToggleBookmarkInput['item_type'] {
+  return value === 'curated' || value === 'feed';
+}
+
+function parseBookmarkItem(value: unknown): ToggleBookmarkInput | null {
+  if (!isObject(value)) {
+    return null;
+  }
+
+  const sourceId = value.source_id;
+  const itemType = value.item_type;
+  const titleSnapshot = value.title_snapshot;
+  const urlSnapshot = value.url_snapshot;
+  const descriptionSnapshot = value.description_snapshot;
+
+  if (
+    typeof sourceId !== 'string' ||
+    !sourceId.trim() ||
+    !isBookmarkItemType(itemType) ||
+    typeof titleSnapshot !== 'string' ||
+    !titleSnapshot.trim() ||
+    typeof urlSnapshot !== 'string' ||
+    !urlSnapshot.trim() ||
+    (descriptionSnapshot !== undefined && typeof descriptionSnapshot !== 'string')
+  ) {
+    return null;
+  }
+
+  return {
+    source_id: sourceId,
+    item_type: itemType,
+    title_snapshot: titleSnapshot,
+    url_snapshot: urlSnapshot,
+    ...(typeof descriptionSnapshot === 'string' ? { description_snapshot: descriptionSnapshot } : {}),
+  };
+}
+
+async function parseMigrateBookmarksInput(request: Request): Promise<MigrateBookmarksInput | Response> {
+  let body: unknown;
+
+  try {
+    body = await request.json();
+  } catch {
+    return json({ error: 'Invalid input' }, 400);
+  }
+
+  if (!isObject(body) || !Array.isArray(body.items) || body.items.length < 1 || body.items.length > 200) {
+    return json({ error: 'Invalid input' }, 400);
+  }
+
+  return { items: body.items };
+}
+
+export const onRequestPost: AppPagesFunction = async (context) => {
+  const { request, env, data } = context;
+
+  if (!data.user) {
+    return json({ error: 'Unauthorized' }, 401);
+  }
+
+  const parsed = await parseMigrateBookmarksInput(request);
+  if (parsed instanceof Response) {
+    return parsed;
+  }
+
+  const playlist = await getOrCreateReadLaterPlaylist(env.DB, data.user.id);
+  let imported = 0;
+  let skipped = 0;
+
+  for (const rawItem of parsed.items) {
+    const item = parseBookmarkItem(rawItem);
+
+    if (!item) {
+      skipped += 1;
+      continue;
+    }
+
+    try {
+      const added = await addItem(env.DB, playlist.id, data.user.id, item);
+
+      if (added) {
+        imported += 1;
+      } else {
+        skipped += 1;
+      }
+    } catch (error) {
+      if (error instanceof DuplicateItemError) {
+        skipped += 1;
+        continue;
+      }
+
+      throw error;
+    }
+  }
+
+  const response: MigrateBookmarksResponse = {
+    imported,
+    skipped,
+    playlist_id: playlist.id,
+  };
+
+  return json(response);
+};

--- a/functions/api/bookmarks/toggle.ts
+++ b/functions/api/bookmarks/toggle.ts
@@ -1,0 +1,104 @@
+import { addItem, DuplicateItemError, removeItem } from '../../lib/playlist-items';
+import { getOrCreateReadLaterPlaylist } from '../../lib/playlists';
+import type { AppPagesFunction, ToggleBookmarkInput, ToggleBookmarkResponse } from '../../lib/types';
+
+function json(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function isBookmarkItemType(value: unknown): value is ToggleBookmarkInput['item_type'] {
+  return value === 'curated' || value === 'feed';
+}
+
+async function parseToggleBookmarkInput(request: Request): Promise<ToggleBookmarkInput | Response> {
+  let body: unknown;
+
+  try {
+    body = await request.json();
+  } catch {
+    return json({ error: 'Invalid input' }, 400);
+  }
+
+  if (!isObject(body)) {
+    return json({ error: 'Invalid input' }, 400);
+  }
+
+  const sourceId = body.source_id;
+  const itemType = body.item_type;
+  const titleSnapshot = body.title_snapshot;
+  const urlSnapshot = body.url_snapshot;
+  const descriptionSnapshot = body.description_snapshot;
+
+  if (
+    typeof sourceId !== 'string' ||
+    !sourceId.trim() ||
+    !isBookmarkItemType(itemType) ||
+    typeof titleSnapshot !== 'string' ||
+    !titleSnapshot.trim() ||
+    typeof urlSnapshot !== 'string' ||
+    !urlSnapshot.trim() ||
+    (descriptionSnapshot !== undefined && typeof descriptionSnapshot !== 'string')
+  ) {
+    return json({ error: 'Invalid input' }, 400);
+  }
+
+  return {
+    source_id: sourceId,
+    item_type: itemType,
+    title_snapshot: titleSnapshot,
+    url_snapshot: urlSnapshot,
+    ...(typeof descriptionSnapshot === 'string' ? { description_snapshot: descriptionSnapshot } : {}),
+  };
+}
+
+export const onRequestPost: AppPagesFunction = async (context) => {
+  const { request, env, data } = context;
+
+  if (!data.user) {
+    return json({ error: 'Unauthorized' }, 401);
+  }
+
+  const parsed = await parseToggleBookmarkInput(request);
+  if (parsed instanceof Response) {
+    return parsed;
+  }
+
+  const playlist = await getOrCreateReadLaterPlaylist(env.DB, data.user.id);
+  const existing = await env.DB
+    .prepare(
+      `SELECT id FROM playlist_items
+       WHERE playlist_id = ? AND item_type = ? AND source_id = ?
+       LIMIT 1`,
+    )
+    .bind(playlist.id, parsed.item_type, parsed.source_id)
+    .first<{ id: string }>();
+
+  const response: ToggleBookmarkResponse = {
+    bookmarked: !existing,
+    playlist_id: playlist.id,
+  };
+
+  if (existing) {
+    await removeItem(env.DB, existing.id, playlist.id, data.user.id);
+    response.bookmarked = false;
+    return json(response);
+  }
+
+  try {
+    await addItem(env.DB, playlist.id, data.user.id, parsed);
+    return json(response);
+  } catch (error) {
+    if (error instanceof DuplicateItemError) {
+      return json(response);
+    }
+
+    throw error;
+  }
+};

--- a/functions/api/playlists/[id]/index.ts
+++ b/functions/api/playlists/[id]/index.ts
@@ -1,4 +1,4 @@
-import { deletePlaylist, getPlaylist, updatePlaylist } from '../../../lib/playlists';
+import { deletePlaylist, getPlaylist, ReadLaterProtectedError, updatePlaylist } from '../../../lib/playlists';
 import { validatePlaylistDescription, validatePlaylistTitle } from '../../../lib/validate';
 import type { AppPagesFunction, UpdatePlaylistInput } from '../../../lib/types';
 
@@ -116,7 +116,17 @@ export const onRequest: AppPagesFunction[] = [
         return parsed;
       }
 
-      const playlist = await updatePlaylist(env.DB, playlistId, data.user.id, parsed);
+      let playlist;
+
+      try {
+        playlist = await updatePlaylist(env.DB, playlistId, data.user.id, parsed);
+      } catch (error) {
+        if (error instanceof ReadLaterProtectedError) {
+          return json({ error: '나중에 볼 기사 플레이리스트는 수정할 수 없습니다' }, 403);
+        }
+
+        throw error;
+      }
 
       if (!playlist) {
         return json({ error: 'Forbidden' }, 403);
@@ -130,7 +140,17 @@ export const onRequest: AppPagesFunction[] = [
         return json({ error: 'Unauthorized' }, 401);
       }
 
-      const deleted = await deletePlaylist(env.DB, playlistId, data.user.id);
+      let deleted;
+
+      try {
+        deleted = await deletePlaylist(env.DB, playlistId, data.user.id);
+      } catch (error) {
+        if (error instanceof ReadLaterProtectedError) {
+          return json({ error: '나중에 볼 기사 플레이리스트는 삭제할 수 없습니다' }, 403);
+        }
+
+        throw error;
+      }
 
       if (!deleted) {
         return json({ error: 'Forbidden' }, 403);

--- a/functions/api/playlists/[id]/visibility.ts
+++ b/functions/api/playlists/[id]/visibility.ts
@@ -1,4 +1,4 @@
-import { setVisibility } from '../../../lib/playlists';
+import { ReadLaterProtectedError, setVisibility } from '../../../lib/playlists';
 import type { AppPagesFunction } from '../../../lib/types';
 
 function json(data: unknown, status = 200): Response {
@@ -42,7 +42,17 @@ export const onRequest: AppPagesFunction[] = [
         return visibility;
       }
 
-      const playlist = await setVisibility(env.DB, params.id, data.user.id, visibility);
+      let playlist;
+
+      try {
+        playlist = await setVisibility(env.DB, params.id, data.user.id, visibility);
+      } catch (error) {
+        if (error instanceof ReadLaterProtectedError) {
+          return json({ error: '나중에 볼 기사 플레이리스트는 공개 설정을 변경할 수 없습니다' }, 403);
+        }
+
+        throw error;
+      }
 
       if (!playlist) {
         return json({ error: 'Forbidden' }, 403);

--- a/functions/api/playlists/index.ts
+++ b/functions/api/playlists/index.ts
@@ -1,7 +1,9 @@
 import { isAdmin } from '../../lib/admin';
 import { createPlaylist, listPublicPlaylists, listUserPlaylists } from '../../lib/playlists';
 import { validatePlaylistDescription, validatePlaylistTitle } from '../../lib/validate';
-import type { AppPagesFunction, CreatePlaylistInput } from '../../lib/types';
+import type { AppPagesFunction, CreatePlaylistInput, PlaylistCategory } from '../../lib/types';
+
+const PLAYLIST_CATEGORIES: PlaylistCategory[] = ['read_later', 'submissions'];
 
 function json(data: unknown, status = 200): Response {
   return new Response(JSON.stringify(data), {
@@ -110,6 +112,7 @@ export const onRequest: AppPagesFunction[] = [
       const sourceId = url.searchParams.get('source_id');
       const itemType = url.searchParams.get('item_type');
       const typeParam = url.searchParams.get('type');
+      const excludeCategoryParam = url.searchParams.get('exclude_category');
 
       if (mine) {
         if (!data.user) {
@@ -117,7 +120,8 @@ export const onRequest: AppPagesFunction[] = [
         }
 
         const containment = sourceId && itemType ? { source_id: sourceId, item_type: itemType } : undefined;
-        const playlists = await listUserPlaylists(env.DB, data.user.id, containment);
+        const excludeCategory = PLAYLIST_CATEGORIES.find((category) => category === excludeCategoryParam);
+        const playlists = await listUserPlaylists(env.DB, data.user.id, containment, excludeCategory);
         return json({ playlists });
       }
 

--- a/functions/lib/playlists.ts
+++ b/functions/lib/playlists.ts
@@ -1,9 +1,28 @@
 import { generateId } from './id';
-import type { PlaylistDetail, PlaylistItemRow, PlaylistListResponse, PlaylistRow, UserPlaylistWithCount, UserRow } from './types';
+import type {
+  PlaylistCategory,
+  PlaylistDetail,
+  PlaylistItemRow,
+  PlaylistListResponse,
+  PlaylistRow,
+  UserPlaylistWithCount,
+  UserRow,
+} from './types';
 
 type PlaylistWithUserRow = PlaylistRow & Pick<UserRow, 'username' | 'display_name' | 'avatar_url'>;
 
 export type PendingPlaylistRow = PlaylistRow & Pick<UserRow, 'username' | 'avatar_url'>;
+
+/**
+ * Error thrown when attempting to modify or delete a protected auto-playlist.
+ * Currently applies to the 'read_later' category (backs the Bookmark feature).
+ */
+export class ReadLaterProtectedError extends Error {
+  constructor(message = '나중에 볼 기사 플레이리스트는 수정/삭제할 수 없습니다.') {
+    super(message);
+    this.name = 'ReadLaterProtectedError';
+  }
+}
 
 function normalizePage(page: number): number {
   return Number.isFinite(page) && page > 0 ? Math.floor(page) : 1;
@@ -28,10 +47,14 @@ function serializeTags(tags?: string[]): string | null {
   return JSON.stringify(tags.slice(0, 5));
 }
 
+// All SELECT queries that hydrate a full PlaylistRow must project these columns.
+const PLAYLIST_ROW_COLUMNS =
+  'id, user_id, title, description, visibility, status, playlist_type, tags, is_auto_created, playlist_category, created_at, updated_at';
+
 async function getPlaylistRow(db: D1Database, playlistId: string): Promise<PlaylistRow | null> {
   return db
     .prepare(
-      `SELECT id, user_id, title, description, visibility, status, playlist_type, tags, created_at, updated_at
+      `SELECT ${PLAYLIST_ROW_COLUMNS}
        FROM user_playlists
        WHERE id = ?`,
     )
@@ -42,7 +65,8 @@ async function getPlaylistRow(db: D1Database, playlistId: string): Promise<Playl
 export async function listPendingPlaylists(db: D1Database): Promise<PendingPlaylistRow[]> {
   const result = await db
     .prepare(
-      `SELECT p.id, p.user_id, p.title, p.description, p.visibility, p.status, p.playlist_type, p.tags, p.created_at, p.updated_at,
+      `SELECT p.id, p.user_id, p.title, p.description, p.visibility, p.status, p.playlist_type, p.tags,
+              p.is_auto_created, p.playlist_category, p.created_at, p.updated_at,
               u.username, u.avatar_url
        FROM user_playlists p
        JOIN users u ON p.user_id = u.id
@@ -95,8 +119,9 @@ export async function createPlaylist(
 
   await db
     .prepare(
-      `INSERT INTO user_playlists (id, user_id, title, description, visibility, status, playlist_type, tags)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+      `INSERT INTO user_playlists
+         (id, user_id, title, description, visibility, status, playlist_type, tags, is_auto_created, playlist_category)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0, NULL)`,
     )
     .bind(id, userId, input.title, input.description ?? null, visibility, status, playlistType, tags)
     .run();
@@ -110,40 +135,90 @@ export async function createPlaylist(
   return playlist;
 }
 
-export async function getOrCreateAutoPlaylist(db: D1Database, userId: string): Promise<PlaylistRow> {
-  const existingPlaylist = await db
-    .prepare('SELECT * FROM user_playlists WHERE user_id = ? ORDER BY updated_at DESC LIMIT 1')
-    .bind(userId)
+/**
+ * Shared helper: find-or-create an auto-playlist with a specific category.
+ * Safe under concurrency thanks to the partial unique index
+ * `uq_user_playlist_category (user_id, playlist_category) WHERE playlist_category IS NOT NULL`.
+ */
+async function getOrCreateCategoryPlaylist(
+  db: D1Database,
+  userId: string,
+  category: PlaylistCategory,
+  title: string,
+): Promise<PlaylistRow> {
+  const existing = await db
+    .prepare(
+      `SELECT ${PLAYLIST_ROW_COLUMNS}
+       FROM user_playlists
+       WHERE user_id = ? AND playlist_category = ?
+       LIMIT 1`,
+    )
+    .bind(userId, category)
     .first<PlaylistRow>();
 
-  if (existingPlaylist) {
-    return existingPlaylist;
-  }
+  if (existing) return existing;
 
   const id = generateId();
-
-  await db
-    .prepare(
-      `INSERT INTO user_playlists (id, user_id, title, visibility, status, playlist_type, is_auto_created)
-       VALUES (?, ?, ?, ?, ?, ?, ?)`,
-    )
-    .bind(id, userId, '내 제출 기사', 'unlisted', 'draft', 'community', 1)
-    .run();
-
-  const playlist = await getPlaylistRow(db, id);
-
-  if (!playlist) {
-    throw new Error('Failed to create auto playlist');
+  try {
+    await db
+      .prepare(
+        `INSERT INTO user_playlists
+           (id, user_id, title, visibility, status, playlist_type, is_auto_created, playlist_category)
+         VALUES (?, ?, ?, 'unlisted', 'draft', 'community', 1, ?)`,
+      )
+      .bind(id, userId, title, category)
+      .run();
+  } catch (err) {
+    // Concurrent insert raced us and won the unique index.
+    // Re-fetch the winning row.
+    const winner = await db
+      .prepare(
+        `SELECT ${PLAYLIST_ROW_COLUMNS}
+         FROM user_playlists
+         WHERE user_id = ? AND playlist_category = ?
+         LIMIT 1`,
+      )
+      .bind(userId, category)
+      .first<PlaylistRow>();
+    if (winner) return winner;
+    throw err;
   }
 
+  const playlist = await getPlaylistRow(db, id);
+  if (!playlist) {
+    throw new Error(`Failed to create ${category} auto-playlist`);
+  }
   return playlist;
+}
+
+/**
+ * Get or create the 'submissions' auto-playlist for a user.
+ * Used by the submission-approved webhook to sync approved articles.
+ *
+ * FIXED: previously returned any arbitrary most-recent playlist,
+ * now correctly filters by `playlist_category='submissions'`.
+ */
+export async function getOrCreateAutoPlaylist(db: D1Database, userId: string): Promise<PlaylistRow> {
+  return getOrCreateCategoryPlaylist(db, userId, 'submissions', '내 제출 기사');
+}
+
+/**
+ * Get or create the 'read_later' auto-playlist that backs the Bookmark feature.
+ * Lazily created on first bookmark click.
+ */
+export async function getOrCreateReadLaterPlaylist(db: D1Database, userId: string): Promise<PlaylistRow> {
+  return getOrCreateCategoryPlaylist(db, userId, 'read_later', '나중에 볼 기사');
+}
+
+export function isReadLaterPlaylist(playlist: Pick<PlaylistRow, 'playlist_category'>): boolean {
+  return playlist.playlist_category === 'read_later';
 }
 
 export async function getPlaylist(db: D1Database, playlistId: string): Promise<PlaylistDetail | null> {
   const playlist = await db
     .prepare(
       `SELECT p.id, p.title, p.description, p.visibility, p.status, p.playlist_type, p.tags,
-              p.created_at, p.updated_at,
+              p.is_auto_created, p.playlist_category, p.created_at, p.updated_at,
               u.id AS user_id, u.username, u.display_name, u.avatar_url
        FROM user_playlists p
        INNER JOIN users u ON u.id = p.user_id
@@ -151,7 +226,20 @@ export async function getPlaylist(db: D1Database, playlistId: string): Promise<P
     )
     .bind(playlistId)
     .first<
-      Pick<PlaylistRow, 'id' | 'title' | 'description' | 'visibility' | 'status' | 'playlist_type' | 'tags' | 'created_at' | 'updated_at'> & {
+      Pick<
+        PlaylistRow,
+        | 'id'
+        | 'title'
+        | 'description'
+        | 'visibility'
+        | 'status'
+        | 'playlist_type'
+        | 'tags'
+        | 'is_auto_created'
+        | 'playlist_category'
+        | 'created_at'
+        | 'updated_at'
+      > & {
         user_id: string;
       } & Pick<UserRow, 'username' | 'display_name' | 'avatar_url'>
     >();
@@ -178,6 +266,8 @@ export async function getPlaylist(db: D1Database, playlistId: string): Promise<P
     visibility: playlist.visibility,
     status: playlist.status,
     playlist_type: playlist.playlist_type,
+    playlist_category: playlist.playlist_category,
+    is_auto_created: playlist.is_auto_created,
     tags: parseTags(playlist.tags),
     created_at: playlist.created_at,
     updated_at: playlist.updated_at,
@@ -216,7 +306,7 @@ export async function listPublicPlaylists(
   const result = await db
     .prepare(
       `SELECT p.id, p.user_id, p.title, p.description, p.visibility, p.status, p.playlist_type, p.tags,
-              p.created_at, p.updated_at,
+              p.is_auto_created, p.playlist_category, p.created_at, p.updated_at,
               u.username, u.display_name, u.avatar_url,
               (
                 SELECT COUNT(*)
@@ -242,6 +332,8 @@ export async function listPublicPlaylists(
       status: playlist.status,
       playlist_type: playlist.playlist_type,
       tags: playlist.tags,
+      is_auto_created: playlist.is_auto_created,
+      playlist_category: playlist.playlist_category,
       created_at: playlist.created_at,
       updated_at: playlist.updated_at,
       user: {
@@ -261,6 +353,7 @@ export async function listUserPlaylists(
   db: D1Database,
   userId: string,
   containment?: { source_id: string; item_type: string },
+  excludeCategory?: PlaylistCategory,
 ): Promise<UserPlaylistWithCount[]> {
   const containsItemSelect = containment
     ? `,
@@ -272,20 +365,30 @@ export async function listUserPlaylists(
               ) AS contains_item`
     : '';
 
+  const excludeClause = excludeCategory
+    ? ' AND (p.playlist_category IS NULL OR p.playlist_category != ?)'
+    : '';
+
+  // Pin 'read_later' playlists to the top of the list so the Bookmark
+  // playlist always appears first in /my/playlists.
   const result = await db
     .prepare(
       `SELECT p.id, p.user_id, p.title, p.description, p.visibility, p.status, p.playlist_type, p.tags,
-              p.created_at, p.updated_at,
+              p.is_auto_created, p.playlist_category, p.created_at, p.updated_at,
               (
                 SELECT COUNT(*)
                 FROM playlist_items pi
                 WHERE pi.playlist_id = p.id
               ) AS item_count${containsItemSelect}
        FROM user_playlists p
-       WHERE p.user_id = ?
-       ORDER BY p.updated_at DESC`,
+       WHERE p.user_id = ?${excludeClause}
+       ORDER BY (p.playlist_category = 'read_later') DESC, p.updated_at DESC`,
     )
-    .bind(...(containment ? [containment.item_type, containment.source_id, userId] : [userId]))
+    .bind(
+      ...(containment ? [containment.item_type, containment.source_id] : []),
+      userId,
+      ...(excludeCategory ? [excludeCategory] : []),
+    )
     .all<PlaylistRow & { item_count: number | string; contains_item?: number | boolean }>();
 
   return result.results.map((row): UserPlaylistWithCount => {
@@ -309,6 +412,15 @@ export async function updatePlaylist(
 
   if (ownerId !== userId) {
     return null;
+  }
+
+  // Read Later playlists have a system-managed title and are not user-editable.
+  const row = await db
+    .prepare('SELECT playlist_category FROM user_playlists WHERE id = ?')
+    .bind(playlistId)
+    .first<Pick<PlaylistRow, 'playlist_category'>>();
+  if (row?.playlist_category === 'read_later') {
+    throw new ReadLaterProtectedError();
   }
 
   const updates: string[] = [];
@@ -352,6 +464,15 @@ export async function deletePlaylist(db: D1Database, playlistId: string, userId:
     return false;
   }
 
+  // Guard: protected auto-playlists (read_later) cannot be deleted.
+  const row = await db
+    .prepare('SELECT playlist_category FROM user_playlists WHERE id = ?')
+    .bind(playlistId)
+    .first<Pick<PlaylistRow, 'playlist_category'>>();
+  if (row?.playlist_category === 'read_later') {
+    throw new ReadLaterProtectedError();
+  }
+
   await db.prepare('DELETE FROM user_playlists WHERE id = ?').bind(playlistId).run();
 
   return true;
@@ -369,11 +490,15 @@ export async function setVisibility(
     return null;
   }
 
-  // Check if this is an editor playlist — editor playlists auto-approve
+  // Check playlist type and category: read_later is locked, editor auto-approves.
   const row = await db
-    .prepare('SELECT playlist_type FROM user_playlists WHERE id = ?')
+    .prepare('SELECT playlist_type, playlist_category FROM user_playlists WHERE id = ?')
     .bind(playlistId)
-    .first<Pick<PlaylistRow, 'playlist_type'>>();
+    .first<Pick<PlaylistRow, 'playlist_type' | 'playlist_category'>>();
+
+  if (row?.playlist_category === 'read_later') {
+    throw new ReadLaterProtectedError();
+  }
 
   const isEditor = row?.playlist_type === 'editor';
   const status = visibility === 'public'

--- a/functions/lib/types.ts
+++ b/functions/lib/types.ts
@@ -43,6 +43,8 @@ export interface SessionRow {
   created_at: string;
 }
 
+export type PlaylistCategory = 'read_later' | 'submissions';
+
 export interface PlaylistRow {
   id: string;
   user_id: string;
@@ -52,6 +54,8 @@ export interface PlaylistRow {
   status: 'draft' | 'pending' | 'approved' | 'rejected';
   playlist_type: 'community' | 'editor';
   tags: string | null;
+  is_auto_created: number;
+  playlist_category: PlaylistCategory | null;
   created_at: string;
   updated_at: string;
 }
@@ -132,6 +136,19 @@ export interface UpdateItemInput {
   position?: number;
 }
 
+// Bookmark (Read Later) feature — wraps AddItemInput for toggle semantics
+export interface ToggleBookmarkInput {
+  source_id: string;
+  item_type: 'curated' | 'feed';
+  title_snapshot: string;
+  url_snapshot: string;
+  description_snapshot?: string;
+}
+
+export interface MigrateBookmarksInput {
+  items: ToggleBookmarkInput[];
+}
+
 // ---------------------------------------------------------------------------
 // API response DTOs
 // ---------------------------------------------------------------------------
@@ -142,6 +159,8 @@ export interface PlaylistDetail {
   visibility: 'unlisted' | 'public';
   status: 'draft' | 'pending' | 'approved' | 'rejected';
   playlist_type: 'community' | 'editor';
+  playlist_category: PlaylistCategory | null;
+  is_auto_created: number;
   tags: string[];
   created_at: string;
   updated_at: string;
@@ -167,6 +186,22 @@ export interface PlaylistListResponse {
 export interface LikeStatusResponse {
   liked: boolean;
   like_count: number;
+}
+
+export interface ToggleBookmarkResponse {
+  bookmarked: boolean;
+  playlist_id: string;
+}
+
+export interface BookmarkStatusResponse {
+  bookmarked_ids: string[];
+  playlist_id: string | null;
+}
+
+export interface MigrateBookmarksResponse {
+  imported: number;
+  skipped: number;
+  playlist_id: string;
 }
 
 export interface TrendingPlaylistItem {

--- a/functions/p/[id].ts
+++ b/functions/p/[id].ts
@@ -1,6 +1,6 @@
 import { getSession } from '../lib/auth';
 import { parseCookies } from '../lib/cookies';
-import { escapeAttr, escapeHtml, stripMd } from '../lib/escape';
+import { escapeAttr, escapeHtml } from '../lib/escape';
 import { renderDocument } from '../lib/layout';
 import { getLikeStatus } from '../lib/likes';
 import { getPlaylist } from '../lib/playlists';
@@ -21,6 +21,10 @@ function canViewPlaylist(playlist: PlaylistDetail, userId?: string): boolean {
   }
 
   return playlist.user.id === userId;
+}
+
+function isReadLaterPlaylist(playlist: PlaylistDetail): boolean {
+  return playlist.playlist_category === 'read_later';
 }
 
 function formatDate(value: string): string {
@@ -173,6 +177,7 @@ function renderItems(items: PlaylistItemRow[], isOwner: boolean, playlistId: str
 }
 
 function renderOwnerControls(playlist: PlaylistDetail): string {
+  const isReadLater = isReadLaterPlaylist(playlist);
   const isUnlisted = playlist.visibility === 'unlisted';
   const isPublicDraft = playlist.visibility === 'public' && playlist.status === 'draft';
   const isPending = playlist.visibility === 'public' && playlist.status === 'pending';
@@ -185,7 +190,9 @@ function renderOwnerControls(playlist: PlaylistDetail): string {
   let visibilityBtnAction = '';
   let visibilityBtnClass = 'btn';
 
-  if (playlist.playlist_type === 'editor') {
+  if (isReadLater) {
+    visibilityTitle = '';
+  } else if (playlist.playlist_type === 'editor') {
     // Editor playlists are always public and approved, no visibility controls needed
     visibilityTitle = '';
   } else if (isUnlisted || isPublicDraft) {
@@ -211,16 +218,24 @@ function renderOwnerControls(playlist: PlaylistDetail): string {
     visibilityBtnAction = 'public';
     visibilityBtnClass = 'btn btn-visibility';
   }
+
+  const ownerDescription = isReadLater
+    ? '북마크한 기사를 정리하고 메모를 남길 수 있습니다.'
+    : '플레이리스트를 계속 편집하거나 삭제할 수 있습니다.';
+  const deleteButton = isReadLater
+    ? ''
+    : '<button type="button" class="btn btn-danger" onclick="deletePlaylist()">삭제</button>';
+
   return `
     <section class="owner-controls card">
       <div>
         <h2>내 플레이리스트 관리</h2>
-        <p>플레이리스트를 계속 편집하거나 삭제할 수 있습니다.</p>
+        <p>${ownerDescription}</p>
       </div>
       <div class="owner-actions">
         <a href="/my/playlists" class="btn">관리 페이지</a>
         <a href="/p/new" class="btn">새 플레이리스트</a>
-        <button type="button" class="btn btn-danger" onclick="deletePlaylist()">삭제</button>
+        ${deleteButton}
       </div>
     </section>
     ${visibilityTitle ? `
@@ -308,6 +323,21 @@ const PAGE_STYLES = `
         margin-bottom: var(--space-xl);
       }
 
+      .playlist-kicker {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-xs);
+        margin-bottom: var(--space-sm);
+        padding: 4px 10px;
+        border: 1px solid var(--color-primary);
+        border-radius: 999px;
+        background: var(--color-bg-secondary);
+        color: var(--color-primary);
+        font-size: 0.8rem;
+        font-weight: 700;
+        letter-spacing: 0.02em;
+      }
+
       .playlist-title {
         font-size: clamp(2rem, 4vw, 2.75rem);
         line-height: 1.2;
@@ -319,6 +349,11 @@ const PAGE_STYLES = `
         color: var(--color-text-muted);
         font-size: 1.05rem;
         margin-bottom: var(--space-md);
+      }
+
+      .playlist-description-system {
+        color: var(--color-primary);
+        font-weight: 600;
       }
 
       .playlist-meta {
@@ -776,18 +811,19 @@ const PAGE_STYLES = `
       }
 
       .btn-visibility {
-        background: rgba(245, 124, 34, 0.1);
+        background: var(--color-bg-secondary);
         color: var(--color-primary);
-        border-color: rgba(245, 124, 34, 0.2);
+        border-color: var(--color-primary);
         white-space: nowrap;
       }
 
       .btn-visibility:hover {
-        background: rgba(245, 124, 34, 0.2);
+        background: var(--color-bg);
+        box-shadow: var(--shadow-sm);
       }
 
       .btn-danger {
-        border-color: rgba(239, 68, 68, 0.35);
+        border-color: var(--color-danger);
         color: var(--color-danger);
       }
 
@@ -943,6 +979,12 @@ const PAGE_STYLES = `
       .tag-editor-hint {
         font-size: 0.8rem;
         color: var(--color-text-muted);
+      }
+
+      .badge-read-later {
+        background: var(--color-bg-secondary);
+        color: var(--color-primary);
+        border-color: var(--color-primary);
       }
 
       .article-search-section {
@@ -1112,7 +1154,11 @@ function renderStatusPage(status: number, title: string, message: string, canoni
 }
 
 export const onRequest: AppPagesFunction = async ({ env, request, params }) => {
-  const playlistId = params.id;
+  const playlistId = Array.isArray(params.id) ? params.id[0] : params.id;
+
+  if (!playlistId) {
+    return renderStatusPage(404, '플레이리스트를 찾을 수 없습니다', '요청하신 플레이리스트가 존재하지 않거나 삭제되었습니다.', getCanonicalUrl(request.url, ''));
+  }
 
   // /p/new is a static Astro page — delegate to static asset serving
   if (playlistId === 'new') {
@@ -1143,6 +1189,7 @@ export const onRequest: AppPagesFunction = async ({ env, request, params }) => {
 
   const description = getDescription(playlist);
   const ownerName = getOwnerName(playlist);
+  const isReadLater = isReadLaterPlaylist(playlist);
   const visibleName = playlist.user.display_name?.trim()
     ? `${playlist.user.display_name} (@${playlist.user.username})`
     : `@${playlist.user.username}`;
@@ -1159,12 +1206,17 @@ export const onRequest: AppPagesFunction = async ({ env, request, params }) => {
     body: `
       <article class="playlist-detail">
         <header class="playlist-header">
+          ${isReadLater ? '<span class="playlist-kicker">🔖 나중에 볼 기사</span>' : ''}
           <h1 class="playlist-title">${escapeHtml(playlist.title)}</h1>
-          ${playlist.description ? `<p class="playlist-description">${escapeHtml(playlist.description)}</p>` : ''}
+          ${isReadLater
+            ? '<p class="playlist-description playlist-description-system">북마크한 기사가 자동으로 모입니다.</p>'
+            : playlist.description ? `<p class="playlist-description">${escapeHtml(playlist.description)}</p>` : ''}
           <div class="playlist-meta">
             <span class="playlist-owner">${renderAvatar(playlist)}<span>by ${escapeHtml(visibleName)}</span></span>
             <span class="meta-text">${playlist.items.length}개 기사</span>
-            <span class="badge">${escapeHtml(getVisibilityLabel(playlist))}</span>
+            ${isReadLater
+              ? '<span class="badge badge-read-later">🔖 나중에 볼 기사</span>'
+              : `<span class="badge">${escapeHtml(getVisibilityLabel(playlist))}</span>`}
             ${playlist.playlist_type === 'editor' ? '<span class="badge badge-editor">🏷️ 에디터 큐레이션</span>' : ''}
             <time class="updated-at">최종 업데이트: ${escapeHtml(formatDate(playlist.updated_at))}</time>
           </div>
@@ -1188,7 +1240,7 @@ export const onRequest: AppPagesFunction = async ({ env, request, params }) => {
             </div>
           ` : ''}
           ${playlist.tags && playlist.tags.length > 0 ? `<div class="playlist-tags">${playlist.tags.map(t => `<span class="tag">${escapeHtml(t)}</span>`).join('')}</div>` : ''}
-          <p class="meta-text">${escapeHtml(ownerName)}가 모은 기술 콘텐츠를 한 번에 확인해보세요.</p>
+          <p class="meta-text">${isReadLater ? '북마크 버튼으로 저장한 기사가 이곳에 자동으로 추가됩니다.' : `${escapeHtml(ownerName)}가 모은 기술 콘텐츠를 한 번에 확인해보세요.`}</p>
         </header>
         ${isOwner && playlist.items.length > 1 ? `
           <div class="items-toolbar">

--- a/migrations/0005_playlist_category.sql
+++ b/migrations/0005_playlist_category.sql
@@ -1,0 +1,17 @@
+-- Migration 0005: Add playlist_category column for auto-created playlists
+-- Distinguishes different auto-playlist types:
+--   'read_later'  — Bookmarks (나중에 볼 기사), created on first bookmark click
+--   'submissions' — Auto-playlist for approved submissions (내 제출 기사, legacy)
+--   NULL          — User-created playlists (community/editor)
+
+ALTER TABLE user_playlists ADD COLUMN playlist_category TEXT;
+
+-- Backfill: existing is_auto_created=1 playlists are 'submissions' type
+UPDATE user_playlists SET playlist_category = 'submissions' WHERE is_auto_created = 1;
+
+-- Enforce uniqueness: at most one playlist per (user_id, category) when category is set.
+-- Partial unique index so multiple user-created playlists (NULL category) remain allowed.
+-- Prevents race conditions during lazy creation of 'read_later' playlists.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_user_playlist_category
+  ON user_playlists(user_id, playlist_category)
+  WHERE playlist_category IS NOT NULL;

--- a/src/components/AddToPlaylist.astro
+++ b/src/components/AddToPlaylist.astro
@@ -84,7 +84,7 @@ function initAddToPlaylistContainer(container: Element) {
       }
 
       const playlistsRes = await fetch(
-        `/api/playlists?mine=true&source_id=${encodeURIComponent(articleId!)}&item_type=${encodeURIComponent(sourceType!)}`
+        `/api/playlists?mine=true&source_id=${encodeURIComponent(articleId!)}&item_type=${encodeURIComponent(sourceType!)}&exclude_category=read_later`
       );
       if (!playlistsRes.ok) throw new Error('Failed to fetch playlists');
       

--- a/src/components/ArticleCard.astro
+++ b/src/components/ArticleCard.astro
@@ -48,7 +48,14 @@ const formattedDate = new Date(date).toLocaleDateString('ko-KR', { year: 'numeri
     </div>
     <div class="article-footer">
       <div class="article-stats">
-        <BookmarkButton articleId={slug || id} size="sm" />
+        <BookmarkButton
+          articleId={slug || id}
+          title={title}
+          url={url}
+          description={description}
+          sourceType={sourceType}
+          size="sm"
+        />
         <a href={`/articles/${slug || id}/#comments`} class="comment-indicator" data-comment-path={articlePath}>
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
             <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"></path>

--- a/src/components/BookmarkButton.astro
+++ b/src/components/BookmarkButton.astro
@@ -1,71 +1,354 @@
 ---
 interface Props {
   articleId: string;
+  title: string;
+  url: string;
+  description?: string;
+  sourceType: 'curated' | 'feed';
   size?: 'sm' | 'md';
 }
-const { articleId, size = 'md' } = Astro.props;
+
+const { articleId, title, url, description, sourceType, size = 'md' } = Astro.props;
 const iconSize = size === 'sm' ? 14 : 18;
 ---
 
 <button
   class:list={['bookmark-btn', `bookmark-${size}`]}
   data-bookmark-id={articleId}
+  data-bookmark-title={title}
+  data-bookmark-url={url}
+  data-bookmark-description={description ?? ''}
+  data-bookmark-source-type={sourceType}
   title="북마크"
   aria-label="북마크"
+  aria-pressed="false"
 >
   <svg class="bookmark-icon-outline" width={iconSize} height={iconSize} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-    <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path>
+    <path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z"></path>
   </svg>
   <svg class="bookmark-icon-filled" width={iconSize} height={iconSize} viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-    <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path>
+    <path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z"></path>
   </svg>
 </button>
 
 <script>
-  const STORAGE_KEY = 'honeycombo:bookmarks';
+  const SESSION_CACHE_KEY = 'honeycombo:bookmark-ids';
+  const LEGACY_STORAGE_KEY = 'honeycombo:bookmarks';
 
-  function getBookmarks(): string[] {
-    try { return JSON.parse(localStorage.getItem(STORAGE_KEY) || '[]'); }
-    catch { return []; }
+  type BookmarkSourceType = 'curated' | 'feed';
+
+  interface BookmarkIdsResponse {
+    bookmarked_ids?: unknown;
+    playlist_id?: string | null;
   }
 
-  function setBookmarks(ids: string[]) {
-    try { localStorage.setItem(STORAGE_KEY, JSON.stringify(ids)); }
-    catch { /* storage full or unavailable */ }
+  interface MigrateBookmarksResponse {
+    imported?: unknown;
+    skipped?: unknown;
+    playlist_id?: string;
   }
 
-  function initBookmarkButtons() {
-    const bookmarks = getBookmarks();
-    document.querySelectorAll<HTMLButtonElement>('[data-bookmark-id]').forEach(btn => {
-      const id = btn.dataset.bookmarkId!;
-      btn.classList.toggle('bookmarked', bookmarks.includes(id));
+  interface LegacyArticle {
+    _id?: unknown;
+    origin?: unknown;
+    title?: unknown;
+    url?: unknown;
+    description?: unknown;
+  }
 
-      // Avoid duplicate listeners by checking init flag
-      if (btn.dataset.bookmarkInit) return;
-      btn.dataset.bookmarkInit = 'true';
+  interface BookmarkTogglePayload {
+    source_id: string;
+    item_type: BookmarkSourceType;
+    title_snapshot: string;
+    url_snapshot: string;
+    description_snapshot?: string;
+  }
 
-      btn.addEventListener('click', (e) => {
-        e.preventDefault();
-        e.stopPropagation();
-        const current = getBookmarks();
-        const idx = current.indexOf(id);
-        if (idx >= 0) {
-          current.splice(idx, 1);
-        } else {
-          current.push(id);
+  interface BookmarkButtonWindow extends Window {
+    __initBookmarkButtons?: () => Promise<void>;
+  }
+
+  let cachedIds: Set<string> | null = null;
+  let pendingStatusFetch: Promise<Set<string> | null> | null = null;
+  const toastTimers = new WeakMap<HTMLDivElement, number>();
+
+  async function fetchBookmarkIds(): Promise<Set<string> | null> {
+    if (cachedIds) return cachedIds;
+    if (pendingStatusFetch) return pendingStatusFetch;
+
+    pendingStatusFetch = (async () => {
+      try {
+        try {
+          const raw = sessionStorage.getItem(SESSION_CACHE_KEY);
+          if (raw) {
+            const parsed = JSON.parse(raw);
+            if (Array.isArray(parsed)) {
+              cachedIds = new Set(parsed.map((value) => String(value)));
+              return cachedIds;
+            }
+          }
+        } catch {
+          // Ignore storage parse errors.
         }
-        setBookmarks(current);
-        btn.classList.toggle('bookmarked', current.includes(id));
 
-        // Sync all bookmark buttons with the same ID on the page
-        document.querySelectorAll<HTMLButtonElement>(`[data-bookmark-id="${id}"]`).forEach(other => {
-          if (other !== btn) other.classList.toggle('bookmarked', current.includes(id));
+        try {
+          const res = await fetch('/api/bookmarks/ids', { credentials: 'same-origin' });
+
+          if (res.status === 401) {
+            cachedIds = new Set();
+            return null;
+          }
+
+          if (!res.ok) {
+            cachedIds = new Set();
+            return cachedIds;
+          }
+
+          const data: BookmarkIdsResponse = await res.json();
+          const ids = new Set<string>(
+            Array.isArray(data.bookmarked_ids)
+              ? data.bookmarked_ids.map((value) => String(value))
+              : [],
+          );
+
+          cachedIds = ids;
+
+          try {
+            sessionStorage.setItem(SESSION_CACHE_KEY, JSON.stringify([...ids]));
+          } catch {
+            // Ignore storage write errors.
+          }
+
+          void maybeMigrateLegacyBookmarks();
+
+          return ids;
+        } catch {
+          cachedIds = new Set();
+          return cachedIds;
+        }
+      } finally {
+        pendingStatusFetch = null;
+      }
+    })();
+
+    return pendingStatusFetch;
+  }
+
+  function invalidateBookmarkCache(updatedIds: Set<string>) {
+    cachedIds = updatedIds;
+    pendingStatusFetch = null;
+
+    try {
+      sessionStorage.setItem(SESSION_CACHE_KEY, JSON.stringify([...updatedIds]));
+    } catch {
+      // Ignore storage write errors.
+    }
+  }
+
+  async function maybeMigrateLegacyBookmarks() {
+    try {
+      const raw = localStorage.getItem(LEGACY_STORAGE_KEY);
+      if (!raw) return;
+
+      const legacy = JSON.parse(raw);
+      if (!Array.isArray(legacy) || legacy.length === 0) {
+        localStorage.removeItem(LEGACY_STORAGE_KEY);
+        return;
+      }
+
+      const items: BookmarkTogglePayload[] = [];
+      const dataEl = document.getElementById('all-articles-data');
+      const allArticles: LegacyArticle[] = dataEl
+        ? (() => {
+            try {
+              const parsed = JSON.parse(dataEl.textContent || '[]');
+              return Array.isArray(parsed) ? parsed : [];
+            } catch {
+              return [];
+            }
+          })()
+        : [];
+      const lookup = new Map<string, LegacyArticle>();
+
+      for (const article of allArticles) {
+        if (article && article._id) {
+          lookup.set(String(article._id), article);
+        }
+      }
+
+      for (const id of legacy.slice(0, 200)) {
+        const article = lookup.get(String(id));
+        if (!article) continue;
+
+        const itemType: BookmarkSourceType = article.origin === 'feed' ? 'feed' : 'curated';
+        items.push({
+          source_id: String(id),
+          item_type: itemType,
+          title_snapshot: String(article.title ?? 'Untitled'),
+          url_snapshot: String(article.url ?? ''),
+          description_snapshot: article.description ? String(article.description) : undefined,
         });
+      }
+
+      if (items.length === 0) {
+        localStorage.removeItem(LEGACY_STORAGE_KEY);
+        return;
+      }
+
+      const res = await fetch('/api/bookmarks/migrate', {
+        method: 'POST',
+        credentials: 'same-origin',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ items }),
+      });
+
+      if (!res.ok) return;
+
+      const result: MigrateBookmarksResponse = await res.json();
+      const imported = Number(result.imported ?? 0);
+
+      if (imported > 0) {
+        showBookmarkToast(`${imported}개의 북마크를 '나중에 볼 기사'로 옮겼습니다.`);
+        cachedIds = null;
+        pendingStatusFetch = null;
+        sessionStorage.removeItem(SESSION_CACHE_KEY);
+        await fetchBookmarkIds();
+        syncAllButtons();
+      }
+
+      localStorage.removeItem(LEGACY_STORAGE_KEY);
+    } catch (err) {
+      console.warn('bookmark migration failed', err);
+    }
+  }
+
+  function showBookmarkToast(message: string, isError = false) {
+    let toast = document.getElementById('bookmark-toast') as HTMLDivElement | null;
+
+    if (!toast) {
+      toast = document.createElement('div');
+      toast.id = 'bookmark-toast';
+      toast.className = 'bookmark-toast';
+      document.body.appendChild(toast);
+    }
+
+    toast.textContent = message;
+    toast.classList.toggle('error', isError);
+    toast.classList.add('visible');
+
+    const previousTimer = toastTimers.get(toast);
+    if (previousTimer !== undefined) {
+      window.clearTimeout(previousTimer);
+    }
+
+    const nextTimer = window.setTimeout(() => {
+      toast?.classList.remove('visible');
+    }, 3000);
+
+    toastTimers.set(toast, nextTimer);
+  }
+
+  function syncAllButtons() {
+    const ids = cachedIds ?? new Set<string>();
+
+    document.querySelectorAll<HTMLButtonElement>('[data-bookmark-id]').forEach((btn) => {
+      const id = btn.dataset.bookmarkId;
+      if (!id) return;
+
+      const isBookmarked = ids.has(id);
+      btn.classList.toggle('bookmarked', isBookmarked);
+      btn.setAttribute('aria-pressed', isBookmarked ? 'true' : 'false');
+    });
+  }
+
+  async function handleBookmarkClick(btn: HTMLButtonElement, ev: MouseEvent) {
+    ev.preventDefault();
+    ev.stopPropagation();
+
+    const id = btn.dataset.bookmarkId;
+    if (!id) return;
+
+    const title = btn.dataset.bookmarkTitle || '';
+    const url = btn.dataset.bookmarkUrl || '';
+    const description = btn.dataset.bookmarkDescription || undefined;
+    const sourceType = (btn.dataset.bookmarkSourceType as BookmarkSourceType | undefined) || 'curated';
+
+    const currentlyOn = btn.classList.contains('bookmarked');
+    const nextState = !currentlyOn;
+
+    btn.classList.toggle('bookmarked', nextState);
+    btn.setAttribute('aria-pressed', nextState ? 'true' : 'false');
+    btn.disabled = true;
+
+    try {
+      const res = await fetch('/api/bookmarks/toggle', {
+        method: 'POST',
+        credentials: 'same-origin',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          source_id: id,
+          item_type: sourceType,
+          title_snapshot: title,
+          url_snapshot: url,
+          description_snapshot: description,
+        }),
+      });
+
+      if (res.status === 401) {
+        btn.classList.toggle('bookmarked', currentlyOn);
+        btn.setAttribute('aria-pressed', currentlyOn ? 'true' : 'false');
+
+        const returnTo = encodeURIComponent(window.location.pathname + window.location.search);
+        window.location.href = `/api/auth/github/login?return_to=${returnTo}`;
+        return;
+      }
+
+      if (!res.ok) {
+        throw new Error(`HTTP ${res.status}`);
+      }
+
+      const data = await res.json() as { bookmarked?: unknown };
+      const bookmarked = Boolean(data.bookmarked);
+      const nextSet = new Set(cachedIds ?? []);
+
+      if (bookmarked) {
+        nextSet.add(id);
+      } else {
+        nextSet.delete(id);
+      }
+
+      invalidateBookmarkCache(nextSet);
+
+      document.querySelectorAll<HTMLButtonElement>('[data-bookmark-id]').forEach((other) => {
+        if (other.dataset.bookmarkId !== id) return;
+        other.classList.toggle('bookmarked', bookmarked);
+        other.setAttribute('aria-pressed', bookmarked ? 'true' : 'false');
+      });
+    } catch (err) {
+      console.error('bookmark toggle failed', err);
+      btn.classList.toggle('bookmarked', currentlyOn);
+      btn.setAttribute('aria-pressed', currentlyOn ? 'true' : 'false');
+      showBookmarkToast('북마크 처리에 실패했습니다.', true);
+    } finally {
+      btn.disabled = false;
+    }
+  }
+
+  async function initBookmarkButtons() {
+    await fetchBookmarkIds();
+    syncAllButtons();
+
+    document.querySelectorAll<HTMLButtonElement>('[data-bookmark-id]').forEach((btn) => {
+      if (btn.dataset.bookmarkInit) return;
+
+      btn.dataset.bookmarkInit = 'true';
+      btn.addEventListener('click', (event) => {
+        void handleBookmarkClick(btn, event);
       });
     });
   }
 
-  (window as any).__initBookmarkButtons = initBookmarkButtons;
+  (window as BookmarkButtonWindow).__initBookmarkButtons = initBookmarkButtons;
   document.addEventListener('astro:page-load', initBookmarkButtons);
 </script>
 
@@ -74,13 +357,24 @@ const iconSize = size === 'sm' ? 14 : 18;
     display: inline-flex;
     align-items: center;
     justify-content: center;
+    gap: var(--space-xs);
     border: 1px solid var(--color-border);
     border-radius: var(--radius-sm);
     background: var(--color-bg);
     color: var(--color-text-muted);
     cursor: pointer;
-    transition: all 0.2s;
     line-height: 1;
+    box-shadow: none;
+    transition:
+      color 0.2s cubic-bezier(0.4, 0, 0.2, 1),
+      border-color 0.2s cubic-bezier(0.4, 0, 0.2, 1),
+      background 0.2s cubic-bezier(0.4, 0, 0.2, 1),
+      box-shadow 0.2s cubic-bezier(0.4, 0, 0.2, 1),
+      transform 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+  }
+
+  .bookmark-btn svg {
+    flex-shrink: 0;
   }
 
   .bookmark-md {
@@ -93,32 +387,97 @@ const iconSize = size === 'sm' ? 14 : 18;
     background: none;
   }
 
-  .bookmark-icon-filled { display: none; }
+  .bookmark-icon-filled {
+    display: none;
+  }
 
   .bookmark-btn:hover {
-    color: #e74c6f;
-    border-color: #e74c6f;
+    color: var(--color-primary);
+    border-color: var(--color-primary);
+    box-shadow: var(--shadow-sm);
+  }
+
+  .bookmark-btn:focus-visible {
+    outline: none;
+    color: var(--color-primary);
+    border-color: var(--color-primary);
+    box-shadow:
+      0 0 0 2px var(--color-bg),
+      0 0 0 4px var(--color-primary);
   }
 
   .bookmark-btn.bookmarked {
-    color: #e74c6f;
-    border-color: #e74c6f;
+    color: var(--color-primary);
+    border-color: var(--color-primary);
   }
 
-  .bookmark-btn.bookmarked .bookmark-icon-outline { display: none; }
-  .bookmark-btn.bookmarked .bookmark-icon-filled { display: inline-block; }
+  .bookmark-md.bookmarked {
+    background: var(--color-bg-secondary);
+    box-shadow: var(--shadow-sm);
+  }
+
+  .bookmark-btn.bookmarked .bookmark-icon-outline {
+    display: none;
+  }
+
+  .bookmark-btn.bookmarked .bookmark-icon-filled {
+    display: inline-block;
+  }
 
   .bookmark-sm:hover {
+    color: var(--color-primary-hover);
     transform: scale(1.15);
+    box-shadow: none;
   }
 
   .bookmark-sm.bookmarked {
-    animation: bookmark-pop 0.3s ease;
+    animation: bookmark-pop 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  }
+
+  .bookmark-btn:disabled {
+    opacity: 0.6;
+    cursor: wait;
+  }
+
+  .bookmark-toast {
+    position: fixed;
+    bottom: 24px;
+    left: 50%;
+    transform: translate(-50%, 20px);
+    background: var(--color-text);
+    color: var(--color-bg);
+    padding: 12px 20px;
+    border-radius: var(--radius-md);
+    box-shadow: var(--shadow-md);
+    font-size: 14px;
+    opacity: 0;
+    pointer-events: none;
+    transition:
+      opacity 0.25s,
+      transform 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+    z-index: 1000;
+  }
+
+  .bookmark-toast.visible {
+    opacity: 1;
+    transform: translate(-50%, 0);
+  }
+
+  .bookmark-toast.error {
+    background: var(--color-danger);
   }
 
   @keyframes bookmark-pop {
-    0% { transform: scale(1); }
-    50% { transform: scale(1.3); }
-    100% { transform: scale(1); }
+    0% {
+      transform: scale(1);
+    }
+
+    50% {
+      transform: scale(1.3);
+    }
+
+    100% {
+      transform: scale(1);
+    }
   }
 </style>

--- a/src/components/InterestTagPanel.astro
+++ b/src/components/InterestTagPanel.astro
@@ -414,12 +414,21 @@ const tagCountsJson = JSON.stringify(tagCounts);
     <div class="article-tags">${tagsHtml}</div>
     <div class="article-footer">
       <div class="article-stats">
-        <button class="bookmark-btn bookmark-sm" data-bookmark-id="${escapeHtml(articleSlug)}" title="북마크" aria-label="북마크">
+        <button class="bookmark-btn bookmark-sm"
+          data-bookmark-id="${escapeHtml(articleSlug)}"
+          data-bookmark-title="${title}"
+          data-bookmark-url="${escapeHtml(articleUrl)}"
+          data-bookmark-description="${escapeHtml(a.description || '')}"
+          data-bookmark-source-type="${sourceType}"
+          title="북마크"
+          aria-label="북마크"
+          aria-pressed="false"
+        >
           <svg class="bookmark-icon-outline" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-            <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path>
+            <path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z"></path>
           </svg>
           <svg class="bookmark-icon-filled" width="14" height="14" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-            <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path>
+            <path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z"></path>
           </svg>
         </button>
         <a href="/articles/${escapeHtml(articleSlug)}/#comments" class="comment-indicator" data-comment-path="${articlePath}">

--- a/src/pages/articles/[...slug].astro
+++ b/src/pages/articles/[...slug].astro
@@ -77,7 +77,13 @@ const pageUrl = new URL(canonicalPath, 'https://honeycombo.pages.dev').href;
 
     <div class="article-actions">
       <div class="actions-left">
-        <BookmarkButton articleId={entry.id} />
+        <BookmarkButton
+          articleId={entry.id}
+          title={article.title}
+          url={article.url}
+          description={article.description}
+          sourceType={sourceType}
+        />
         <ShareButtons title={article.title} url={pageUrl} />
       </div>
       <AddToPlaylist 

--- a/src/pages/my/playlists.astro
+++ b/src/pages/my/playlists.astro
@@ -51,6 +51,26 @@ document.addEventListener('astro:page-load', () => {
 
   let isAuthed = false;
 
+  interface PlaylistListItem {
+    id: string;
+    title: string;
+    description?: string | null;
+    tags?: unknown;
+    item_count?: number;
+    created_at?: string;
+    updated_at?: string;
+    playlist_type?: 'community' | 'editor' | string;
+    visibility?: 'public' | 'unlisted';
+    status?: 'draft' | 'pending' | 'approved' | 'rejected';
+    is_auto_created?: number | boolean | null;
+    playlist_category?: string | null;
+  }
+
+  function isReadLaterPlaylist(playlist: PlaylistListItem) {
+    return playlist.playlist_category === 'read_later'
+      || (Number(playlist.is_auto_created ?? 0) === 1 && playlist.playlist_category === 'read_later');
+  }
+
   async function checkAuthAndLoad() {
     hideAllStates();
     if (loadingEl) loadingEl.style.display = 'block';
@@ -91,7 +111,7 @@ document.addEventListener('astro:page-load', () => {
       }
 
       const data = await res.json();
-      const playlists = data.playlists || [];
+      const playlists: PlaylistListItem[] = Array.isArray(data.playlists) ? data.playlists : [];
 
       hideAllStates();
 
@@ -110,14 +130,15 @@ document.addEventListener('astro:page-load', () => {
     }
   }
 
-  function renderPlaylists(playlists: any[]) {
+  function renderPlaylists(playlists: PlaylistListItem[]) {
     if (!gridEl) return;
     
     gridEl.innerHTML = '';
     
     playlists.forEach(playlist => {
+      const isReadLater = isReadLaterPlaylist(playlist);
       const card = document.createElement('div');
-      card.className = 'card playlist-card';
+      card.className = `card playlist-card${isReadLater ? ' playlist-card-read-later' : ''}`;
       
       const formattedDate = new Date(playlist.updated_at || playlist.created_at).toLocaleDateString('ko-KR', { 
         year: 'numeric', 
@@ -125,15 +146,16 @@ document.addEventListener('astro:page-load', () => {
         day: 'numeric' 
       });
 
-      // Visibility badge
       const isEditor = playlist.playlist_type === 'editor';
       const isPublic = playlist.visibility === 'public' || isEditor;
       const visibilityIcon = isPublic ? '🌐' : '🔒';
       const visibilityText = isPublic ? '공개' : '비공개';
       const visibilityClass = isPublic ? 'badge-public' : 'badge-unlisted';
-      // Status badge (only relevant for public)
+      const safeId = escapeHtml(playlist.id);
+      const safeTitle = escapeHtml(playlist.title || '제목 없음');
+      const safeDescription = typeof playlist.description === 'string' ? playlist.description : '';
       let statusBadgeHtml = '';
-      if (isPublic) {
+      if (isPublic && !isReadLater) {
         const status = playlist.status || 'draft';
         let statusText = '';
         let statusClass = '';
@@ -151,42 +173,49 @@ document.addEventListener('astro:page-load', () => {
           statusText = '반려';
           statusClass = 'badge-rejected';
         }
-        
+
         statusBadgeHtml = `<span class="badge ${statusClass}">${statusText}</span>`;
       }
 
-      // Visibility action button
       let visibilityActionHtml = '';
-      if (!isEditor) {
+      if (!isEditor && !isReadLater) {
         if (!isPublic || playlist.status === 'draft') {
-          visibilityActionHtml = `<button class="btn btn-sm visibility-btn visibility-btn-public" data-id="${playlist.id}" data-visibility="public">🌐 공개 신청</button>`;
+          visibilityActionHtml = `<button class="btn btn-sm visibility-btn visibility-btn-public" data-id="${safeId}" data-visibility="public">🌐 공개 신청</button>`;
         } else if (playlist.status === 'approved') {
-          visibilityActionHtml = `<button class="btn btn-sm visibility-btn visibility-btn-unlisted" data-id="${playlist.id}" data-visibility="unlisted">🔒 비공개로 전환</button>`;
+          visibilityActionHtml = `<button class="btn btn-sm visibility-btn visibility-btn-unlisted" data-id="${safeId}" data-visibility="unlisted">🔒 비공개로 전환</button>`;
         } else if (playlist.status === 'rejected') {
-          visibilityActionHtml = `<button class="btn btn-sm visibility-btn visibility-btn-public" data-id="${playlist.id}" data-visibility="public">🔄 재신청</button>`;
+          visibilityActionHtml = `<button class="btn btn-sm visibility-btn visibility-btn-public" data-id="${safeId}" data-visibility="public">🔄 재신청</button>`;
         }
       }
-      // pending: no action button needed
+
+      const badgesHtml = isReadLater
+        ? '<span class="badge badge-read-later">🔖 나중에 볼 기사</span>'
+        : `
+            <span class="badge ${visibilityClass}">${visibilityIcon} ${visibilityText}</span>
+            ${statusBadgeHtml}
+          `;
+      const deleteActionHtml = isReadLater
+        ? ''
+        : `<button class="btn-icon delete-btn" data-id="${safeId}" aria-label="삭제" title="삭제">🗑️</button>`;
 
       card.innerHTML = `
         <div class="playlist-header">
           <h3 class="playlist-title">
-            <a href="/p/${playlist.id}">${escapeHtml(playlist.title)}</a>
+            <a href="/p/${encodeURIComponent(playlist.id)}">${safeTitle}</a>
             ${isEditor ? '<span class="badge badge-editor">🏷️ 에디터</span>' : ''}
           </h3>
           <div class="playlist-actions">
-            <button class="btn-icon delete-btn" data-id="${playlist.id}" aria-label="삭제" title="삭제">🗑️</button>
+            ${deleteActionHtml}
           </div>
         </div>
         
-        ${playlist.description ? `<p class="playlist-description">${escapeHtml(playlist.description)}</p>` : ''}
+        ${safeDescription ? `<p class="playlist-description">${escapeHtml(safeDescription)}</p>` : ''}
         
         ${renderTags(playlist.tags)}
         
         <div class="playlist-meta">
           <div class="badges">
-            <span class="badge ${visibilityClass}">${visibilityIcon} ${visibilityText}</span>
-            ${statusBadgeHtml}
+            ${badgesHtml}
           </div>
           <span class="playlist-count">${playlist.item_count || 0}개 항목</span>
         </div>
@@ -287,7 +316,7 @@ document.addEventListener('astro:page-load', () => {
          .replace(/'/g, "&#039;");
   }
 
-  function renderTags(tagsData: any) {
+  function renderTags(tagsData: unknown) {
     if (!tagsData) return '';
     let tags: string[] = [];
     if (typeof tagsData === 'string') {
@@ -367,7 +396,12 @@ document.addEventListener('astro:page-load', () => {
   border-radius: var(--radius-md);
   font-weight: 600;
   font-size: 0.95rem;
-  transition: all 0.15s;
+  transition:
+    transform 0.2s cubic-bezier(0.4, 0, 0.2, 1),
+    background 0.2s cubic-bezier(0.4, 0, 0.2, 1),
+    border-color 0.2s cubic-bezier(0.4, 0, 0.2, 1),
+    box-shadow 0.2s cubic-bezier(0.4, 0, 0.2, 1),
+    color 0.2s cubic-bezier(0.4, 0, 0.2, 1);
   text-decoration: none;
   border: 1px solid var(--color-border);
   background: var(--color-bg);
@@ -378,6 +412,17 @@ document.addEventListener('astro:page-load', () => {
 .my-playlists-content :global(.btn:hover),
 .header-actions :global(.btn:hover) {
   background: var(--color-bg-secondary);
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-sm);
+}
+
+.my-playlists-content :global(.btn:focus-visible),
+.header-actions :global(.btn:focus-visible) {
+  outline: none;
+  border-color: var(--color-primary);
+  box-shadow:
+    0 0 0 2px var(--color-bg),
+    0 0 0 4px var(--color-primary);
 }
 
 .my-playlists-content :global(.btn-primary),
@@ -409,6 +454,12 @@ document.addEventListener('astro:page-load', () => {
   display: flex;
   flex-direction: column;
   gap: var(--space-md);
+}
+
+.my-playlists-content :global(.playlist-card-read-later) {
+  border-left: 3px solid var(--color-primary);
+  background: linear-gradient(135deg, var(--color-bg-secondary), var(--color-bg));
+  box-shadow: var(--shadow-sm);
 }
 
 .my-playlists-content :global(.playlist-header) {
@@ -504,6 +555,14 @@ document.addEventListener('astro:page-load', () => {
   border-color: rgba(245, 158, 11, 0.2);
 }
 
+.my-playlists-content :global(.badge-read-later) {
+  background: var(--color-bg-secondary);
+  color: var(--color-primary);
+  border-color: var(--color-primary);
+  text-transform: none;
+  letter-spacing: 0.02em;
+}
+
 .my-playlists-content :global(.playlist-tags) {
   display: flex;
   flex-wrap: wrap;
@@ -551,7 +610,11 @@ document.addEventListener('astro:page-load', () => {
   cursor: pointer;
   padding: var(--space-xs);
   border-radius: var(--radius-sm);
-  transition: background 0.2s;
+  transition:
+    transform 0.2s cubic-bezier(0.4, 0, 0.2, 1),
+    background 0.2s cubic-bezier(0.4, 0, 0.2, 1),
+    opacity 0.2s cubic-bezier(0.4, 0, 0.2, 1),
+    box-shadow 0.2s cubic-bezier(0.4, 0, 0.2, 1);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -561,6 +624,15 @@ document.addEventListener('astro:page-load', () => {
 .my-playlists-content :global(.btn-icon:hover) {
   background: var(--color-bg-secondary);
   opacity: 1;
+  transform: translateY(-1px);
+}
+
+.my-playlists-content :global(.btn-icon:focus-visible) {
+  outline: none;
+  opacity: 1;
+  box-shadow:
+    0 0 0 2px var(--color-bg),
+    0 0 0 4px var(--color-primary);
 }
 
 .my-playlists-content :global(.delete-btn:hover) {
@@ -573,7 +645,12 @@ document.addEventListener('astro:page-load', () => {
   font-weight: 500;
   border-radius: var(--radius-sm);
   cursor: pointer;
-  transition: all 0.15s;
+  transition:
+    transform 0.2s cubic-bezier(0.4, 0, 0.2, 1),
+    background 0.2s cubic-bezier(0.4, 0, 0.2, 1),
+    border-color 0.2s cubic-bezier(0.4, 0, 0.2, 1),
+    box-shadow 0.2s cubic-bezier(0.4, 0, 0.2, 1),
+    color 0.2s cubic-bezier(0.4, 0, 0.2, 1);
   border: 1px solid var(--color-border);
   background: var(--color-bg);
   color: var(--color-text);
@@ -587,6 +664,8 @@ document.addEventListener('astro:page-load', () => {
 
 .my-playlists-content :global(.visibility-btn-public:hover:not(:disabled)) {
   background: rgba(37, 99, 235, 0.2);
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-sm);
 }
 
 .my-playlists-content :global(.visibility-btn-unlisted) {
@@ -597,6 +676,16 @@ document.addEventListener('astro:page-load', () => {
 .my-playlists-content :global(.visibility-btn-unlisted:hover:not(:disabled)) {
   background: var(--color-bg-secondary);
   border-color: var(--color-text-muted);
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-sm);
+}
+
+.my-playlists-content :global(.visibility-btn:focus-visible) {
+  outline: none;
+  border-color: var(--color-primary);
+  box-shadow:
+    0 0 0 2px var(--color-bg),
+    0 0 0 4px var(--color-primary);
 }
 
 .my-playlists-content :global(.visibility-btn:disabled) {

--- a/tests/api/bookmarks-ids.test.ts
+++ b/tests/api/bookmarks-ids.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import { createMockContext } from '../helpers/context-mock';
+import { createMockD1 } from '../helpers/d1-mock';
+import type { UserRow } from '../../functions/lib/types';
+import { onRequestGet } from '../../functions/api/bookmarks/ids';
+
+const user = {
+  id: 'user_1',
+  username: 'alice',
+  display_name: 'Alice',
+  avatar_url: 'https://example.com/alice.png',
+  created_at: '2026-04-23T00:00:00.000Z',
+} satisfies UserRow;
+
+describe('GET /api/bookmarks/ids', () => {
+  it('returns 401 when unauthenticated', async () => {
+    const context = createMockContext({
+      method: 'GET',
+      url: 'https://example.com/api/bookmarks/ids',
+    });
+
+    const response = await onRequestGet(context);
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({ error: 'Unauthorized' });
+  });
+
+  it('returns empty bookmark ids when read later playlist does not exist', async () => {
+    const controller = createMockD1();
+    controller.setResults([null]);
+
+    const context = createMockContext({
+      method: 'GET',
+      url: 'https://example.com/api/bookmarks/ids',
+      user,
+      env: { DB: controller.db },
+    });
+
+    const response = await onRequestGet(context);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ bookmarked_ids: [], playlist_id: null });
+
+    const queries = controller.getQueries();
+    expect(queries[0]?.sql).toContain('SELECT id FROM user_playlists');
+    expect(queries[0]?.params).toEqual([user.id, 'read_later']);
+  });
+
+  it('returns source ids from the existing read later playlist', async () => {
+    const controller = createMockD1();
+    controller.setResults([{ id: 'pl_read_later' }, [{ source_id: 'article-1' }, { source_id: 'article-2' }]]);
+
+    const context = createMockContext({
+      method: 'GET',
+      url: 'https://example.com/api/bookmarks/ids',
+      user,
+      env: { DB: controller.db },
+    });
+
+    const response = await onRequestGet(context);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      bookmarked_ids: ['article-1', 'article-2'],
+      playlist_id: 'pl_read_later',
+    });
+
+    const queries = controller.getQueries();
+    expect(queries[1]?.sql).toContain('SELECT source_id FROM playlist_items');
+    expect(queries[1]?.params).toEqual(['pl_read_later']);
+  });
+});

--- a/tests/api/bookmarks-migrate.test.ts
+++ b/tests/api/bookmarks-migrate.test.ts
@@ -1,0 +1,166 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createMockContext } from '../helpers/context-mock';
+import type { PlaylistItemRow, PlaylistRow, UserRow } from '../../functions/lib/types';
+
+const { addItemMock, getOrCreateReadLaterPlaylistMock, DuplicateItemErrorMock } = vi.hoisted(() => {
+  class DuplicateItemError extends Error {
+    constructor() {
+      super('Duplicate item');
+      this.name = 'DuplicateItemError';
+    }
+  }
+
+  return {
+    addItemMock: vi.fn(),
+    getOrCreateReadLaterPlaylistMock: vi.fn(),
+    DuplicateItemErrorMock: DuplicateItemError,
+  };
+});
+
+vi.mock('../../functions/lib/playlist-items', () => ({
+  addItem: addItemMock,
+  DuplicateItemError: DuplicateItemErrorMock,
+}));
+
+vi.mock('../../functions/lib/playlists', () => ({
+  getOrCreateReadLaterPlaylist: getOrCreateReadLaterPlaylistMock,
+}));
+
+import { onRequestPost } from '../../functions/api/bookmarks/migrate';
+
+const user = {
+  id: 'user_1',
+  username: 'alice',
+  display_name: 'Alice',
+  avatar_url: 'https://example.com/alice.png',
+  created_at: '2026-04-23T00:00:00.000Z',
+} satisfies UserRow;
+
+function createReadLaterPlaylist(): PlaylistRow {
+  return {
+    id: 'pl_read_later',
+    user_id: user.id,
+    title: '나중에 볼 기사',
+    description: null,
+    visibility: 'unlisted',
+    status: 'draft',
+    playlist_type: 'community',
+    tags: null,
+    is_auto_created: 1,
+    playlist_category: 'read_later',
+    created_at: '2026-04-23T00:00:00.000Z',
+    updated_at: '2026-04-23T00:00:00.000Z',
+  };
+}
+
+function createPlaylistItem(sourceId: string): PlaylistItemRow {
+  return {
+    id: `item_${sourceId}`,
+    playlist_id: 'pl_read_later',
+    item_type: 'curated',
+    source_id: sourceId,
+    external_url: null,
+    title_snapshot: `Title ${sourceId}`,
+    url_snapshot: `https://example.com/${sourceId}`,
+    description_snapshot: null,
+    note: null,
+    position: 0,
+    added_at: '2026-04-23T00:00:00.000Z',
+  };
+}
+
+describe('POST /api/bookmarks/migrate', () => {
+  beforeEach(() => {
+    addItemMock.mockReset();
+    getOrCreateReadLaterPlaylistMock.mockReset();
+    getOrCreateReadLaterPlaylistMock.mockResolvedValue(createReadLaterPlaylist());
+    addItemMock.mockResolvedValue(createPlaylistItem('article-1'));
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    const context = createMockContext({
+      method: 'POST',
+      url: 'https://example.com/api/bookmarks/migrate',
+      body: JSON.stringify({ items: [] }),
+    });
+
+    const response = await onRequestPost(context);
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({ error: 'Unauthorized' });
+  });
+
+  it('returns 400 for an empty items array', async () => {
+    const context = createMockContext({
+      method: 'POST',
+      url: 'https://example.com/api/bookmarks/migrate',
+      user,
+      body: JSON.stringify({ items: [] }),
+    });
+
+    const response = await onRequestPost(context);
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: 'Invalid input' });
+    expect(getOrCreateReadLaterPlaylistMock).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when more than 200 items are submitted', async () => {
+    const items = Array.from({ length: 201 }, (_, index) => ({
+      source_id: `article-${index}`,
+      item_type: 'curated',
+      title_snapshot: `Article ${index}`,
+      url_snapshot: `https://example.com/article-${index}`,
+    }));
+
+    const context = createMockContext({
+      method: 'POST',
+      url: 'https://example.com/api/bookmarks/migrate',
+      user,
+      body: JSON.stringify({ items }),
+    });
+
+    const response = await onRequestPost(context);
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: 'Invalid input' });
+  });
+
+  it('imports unique items and skips duplicates', async () => {
+    addItemMock
+      .mockResolvedValueOnce(createPlaylistItem('article-1'))
+      .mockRejectedValueOnce(new DuplicateItemErrorMock());
+
+    const context = createMockContext({
+      method: 'POST',
+      url: 'https://example.com/api/bookmarks/migrate',
+      user,
+      body: JSON.stringify({
+        items: [
+          {
+            source_id: 'article-1',
+            item_type: 'curated',
+            title_snapshot: 'Article 1',
+            url_snapshot: 'https://example.com/article-1',
+          },
+          {
+            source_id: 'article-2',
+            item_type: 'feed',
+            title_snapshot: 'Article 2',
+            url_snapshot: 'https://example.com/article-2',
+          },
+        ],
+      }),
+    });
+
+    const response = await onRequestPost(context);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      imported: 1,
+      skipped: 1,
+      playlist_id: 'pl_read_later',
+    });
+    expect(addItemMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/api/bookmarks-toggle.test.ts
+++ b/tests/api/bookmarks-toggle.test.ts
@@ -1,0 +1,202 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createMockContext } from '../helpers/context-mock';
+import { createMockD1 } from '../helpers/d1-mock';
+import type { PlaylistItemRow, PlaylistRow, UserRow } from '../../functions/lib/types';
+
+const { addItemMock, getOrCreateReadLaterPlaylistMock, removeItemMock, DuplicateItemErrorMock } = vi.hoisted(() => {
+  class DuplicateItemError extends Error {
+    constructor() {
+      super('Duplicate item');
+      this.name = 'DuplicateItemError';
+    }
+  }
+
+  return {
+    addItemMock: vi.fn(),
+    getOrCreateReadLaterPlaylistMock: vi.fn(),
+    removeItemMock: vi.fn(),
+    DuplicateItemErrorMock: DuplicateItemError,
+  };
+});
+
+vi.mock('../../functions/lib/playlist-items', () => ({
+  addItem: addItemMock,
+  removeItem: removeItemMock,
+  DuplicateItemError: DuplicateItemErrorMock,
+}));
+
+vi.mock('../../functions/lib/playlists', () => ({
+  getOrCreateReadLaterPlaylist: getOrCreateReadLaterPlaylistMock,
+}));
+
+import { onRequestPost } from '../../functions/api/bookmarks/toggle';
+
+const user = {
+  id: 'user_1',
+  username: 'alice',
+  display_name: 'Alice',
+  avatar_url: 'https://example.com/alice.png',
+  created_at: '2026-04-23T00:00:00.000Z',
+} satisfies UserRow;
+
+function createReadLaterPlaylist(): PlaylistRow {
+  return {
+    id: 'pl_read_later',
+    user_id: user.id,
+    title: '나중에 볼 기사',
+    description: null,
+    visibility: 'unlisted',
+    status: 'draft',
+    playlist_type: 'community',
+    tags: null,
+    is_auto_created: 1,
+    playlist_category: 'read_later',
+    created_at: '2026-04-23T00:00:00.000Z',
+    updated_at: '2026-04-23T00:00:00.000Z',
+  };
+}
+
+function createPlaylistItem(): PlaylistItemRow {
+  return {
+    id: 'item_1',
+    playlist_id: 'pl_read_later',
+    item_type: 'curated',
+    source_id: 'article-1',
+    external_url: null,
+    title_snapshot: 'Article 1',
+    url_snapshot: 'https://example.com/article-1',
+    description_snapshot: null,
+    note: null,
+    position: 0,
+    added_at: '2026-04-23T00:00:00.000Z',
+  };
+}
+
+describe('POST /api/bookmarks/toggle', () => {
+  beforeEach(() => {
+    addItemMock.mockReset();
+    getOrCreateReadLaterPlaylistMock.mockReset();
+    removeItemMock.mockReset();
+    getOrCreateReadLaterPlaylistMock.mockResolvedValue(createReadLaterPlaylist());
+    addItemMock.mockResolvedValue(createPlaylistItem());
+    removeItemMock.mockResolvedValue(true);
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    const context = createMockContext({
+      method: 'POST',
+      url: 'https://example.com/api/bookmarks/toggle',
+      body: JSON.stringify({}),
+    });
+
+    const response = await onRequestPost(context);
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({ error: 'Unauthorized' });
+    expect(getOrCreateReadLaterPlaylistMock).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for invalid input', async () => {
+    const context = createMockContext({
+      method: 'POST',
+      url: 'https://example.com/api/bookmarks/toggle',
+      user,
+      body: JSON.stringify({
+        source_id: 'article-1',
+        item_type: 'external',
+        title_snapshot: 'Article 1',
+        url_snapshot: 'https://example.com/article-1',
+      }),
+    });
+
+    const response = await onRequestPost(context);
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: 'Invalid input' });
+    expect(getOrCreateReadLaterPlaylistMock).not.toHaveBeenCalled();
+  });
+
+  it('adds a bookmark when item is not yet saved', async () => {
+    const controller = createMockD1();
+    controller.setResults([null]);
+
+    const context = createMockContext({
+      method: 'POST',
+      url: 'https://example.com/api/bookmarks/toggle',
+      user,
+      env: { DB: controller.db },
+      body: JSON.stringify({
+        source_id: 'article-1',
+        item_type: 'curated',
+        title_snapshot: 'Article 1',
+        url_snapshot: 'https://example.com/article-1',
+      }),
+    });
+
+    const response = await onRequestPost(context);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ bookmarked: true, playlist_id: 'pl_read_later' });
+    expect(getOrCreateReadLaterPlaylistMock).toHaveBeenCalledWith(context.env.DB, user.id);
+    expect(addItemMock).toHaveBeenCalledWith(context.env.DB, 'pl_read_later', user.id, {
+      source_id: 'article-1',
+      item_type: 'curated',
+      title_snapshot: 'Article 1',
+      url_snapshot: 'https://example.com/article-1',
+    });
+    expect(removeItemMock).not.toHaveBeenCalled();
+
+    const queries = controller.getQueries();
+    expect(queries[0]?.sql).toContain('SELECT id FROM playlist_items');
+    expect(queries[0]?.params).toEqual(['pl_read_later', 'curated', 'article-1']);
+  });
+
+  it('removes a bookmark when item already exists', async () => {
+    const controller = createMockD1();
+    controller.setResults([{ id: 'item_existing' }]);
+
+    const context = createMockContext({
+      method: 'POST',
+      url: 'https://example.com/api/bookmarks/toggle',
+      user,
+      env: { DB: controller.db },
+      body: JSON.stringify({
+        source_id: 'article-1',
+        item_type: 'curated',
+        title_snapshot: 'Article 1',
+        url_snapshot: 'https://example.com/article-1',
+      }),
+    });
+
+    const response = await onRequestPost(context);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ bookmarked: false, playlist_id: 'pl_read_later' });
+    expect(removeItemMock).toHaveBeenCalledWith(context.env.DB, 'item_existing', 'pl_read_later', user.id);
+    expect(addItemMock).not.toHaveBeenCalled();
+  });
+
+  it('treats DuplicateItemError as a successful bookmark add', async () => {
+    const controller = createMockD1();
+    controller.setResults([null]);
+    addItemMock.mockRejectedValueOnce(new DuplicateItemErrorMock());
+
+    const context = createMockContext({
+      method: 'POST',
+      url: 'https://example.com/api/bookmarks/toggle',
+      user,
+      env: { DB: controller.db },
+      body: JSON.stringify({
+        source_id: 'article-1',
+        item_type: 'curated',
+        title_snapshot: 'Article 1',
+        url_snapshot: 'https://example.com/article-1',
+      }),
+    });
+
+    const response = await onRequestPost(context);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ bookmarked: true, playlist_id: 'pl_read_later' });
+  });
+});

--- a/tests/lib/playlists.test.ts
+++ b/tests/lib/playlists.test.ts
@@ -3,9 +3,13 @@ import { createMockD1 } from '../helpers/d1-mock';
 import {
   createPlaylist,
   deletePlaylist,
+  getOrCreateAutoPlaylist,
+  getOrCreateReadLaterPlaylist,
   getPlaylist,
+  isReadLaterPlaylist,
   listPublicPlaylists,
   listUserPlaylists,
+  ReadLaterProtectedError,
   setVisibility,
   updatePlaylist,
 } from '../../functions/lib/playlists';
@@ -21,6 +25,10 @@ const basePlaylist = {
   description: 'Great links',
   visibility: 'unlisted' as const,
   status: 'draft' as const,
+  playlist_type: 'community' as const,
+  tags: null,
+  is_auto_created: 0,
+  playlist_category: null,
   created_at: '2026-04-12T00:00:00.000Z',
   updated_at: '2026-04-12T00:00:00.000Z',
 };
@@ -64,6 +72,8 @@ describe('playlists repository', () => {
         status: 'approved',
         playlist_type: 'community',
         tags: null,
+        is_auto_created: 0,
+        playlist_category: null,
         created_at: '2026-04-12T00:00:00.000Z',
         updated_at: '2026-04-12T00:00:00.000Z',
         user_id: 'user_1',
@@ -110,6 +120,8 @@ describe('playlists repository', () => {
       visibility: 'public',
       status: 'approved',
       playlist_type: 'community',
+      playlist_category: null,
+      is_auto_created: 0,
       tags: [],
       created_at: '2026-04-12T00:00:00.000Z',
       updated_at: '2026-04-12T00:00:00.000Z',
@@ -220,13 +232,112 @@ describe('playlists repository', () => {
 
     const queries = controller.getQueries();
     expect(queries[0]?.params).toEqual(['user_1']);
-    expect(queries[0]?.sql).toContain('ORDER BY p.updated_at DESC');
+    expect(queries[0]?.sql).toContain("ORDER BY (p.playlist_category = 'read_later') DESC, p.updated_at DESC");
     expect(queries[0]?.sql).toContain('SELECT COUNT(*)');
+  });
+
+  it('listUserPlaylists excludes a category when requested', async () => {
+    controller.setResults([[]]);
+
+    const playlists = await listUserPlaylists(controller.db, 'user_1', undefined, 'read_later');
+
+    expect(playlists).toEqual([]);
+
+    const queries = controller.getQueries();
+    expect(queries[0]?.sql).toContain('AND (p.playlist_category IS NULL OR p.playlist_category != ?)');
+    expect(queries[0]?.params).toEqual(['user_1', 'read_later']);
+  });
+
+  it('getOrCreateReadLaterPlaylist creates a new playlist when missing', async () => {
+    controller.setResults([
+      null,
+      [],
+      {
+        ...basePlaylist,
+        id: 'pl_testid123',
+        title: '나중에 볼 기사',
+        visibility: 'unlisted',
+        status: 'draft',
+        playlist_type: 'community',
+        is_auto_created: 1,
+        playlist_category: 'read_later',
+      },
+    ]);
+
+    const playlist = await getOrCreateReadLaterPlaylist(controller.db, 'user_1');
+
+    expect(playlist).toMatchObject({
+      id: 'pl_testid123',
+      title: '나중에 볼 기사',
+      visibility: 'unlisted',
+      status: 'draft',
+      playlist_type: 'community',
+      is_auto_created: 1,
+      playlist_category: 'read_later',
+    });
+
+    const queries = controller.getQueries();
+    expect(queries[0]?.sql).toContain('WHERE user_id = ? AND playlist_category = ?');
+    expect(queries[0]?.params).toEqual(['user_1', 'read_later']);
+    expect(queries[1]?.sql).toContain('INSERT INTO user_playlists');
+    expect(queries[1]?.params).toEqual(['pl_testid123', 'user_1', '나중에 볼 기사', 'read_later']);
+    expect(queries[2]?.sql).toContain('FROM user_playlists');
+    expect(queries[2]?.params).toEqual(['pl_testid123']);
+  });
+
+  it('getOrCreateReadLaterPlaylist returns existing playlist', async () => {
+    controller.setResults([
+      {
+        ...basePlaylist,
+        id: 'pl_read_later',
+        title: '나중에 볼 기사',
+        is_auto_created: 1,
+        playlist_category: 'read_later',
+      },
+    ]);
+
+    const playlist = await getOrCreateReadLaterPlaylist(controller.db, 'user_1');
+
+    expect(playlist).toMatchObject({
+      id: 'pl_read_later',
+      playlist_category: 'read_later',
+    });
+    expect(controller.getQueries()).toHaveLength(1);
+  });
+
+  it('getOrCreateAutoPlaylist filters by submissions category', async () => {
+    controller.setResults([
+      {
+        ...basePlaylist,
+        id: 'pl_submissions',
+        title: '내 제출 기사',
+        is_auto_created: 1,
+        playlist_category: 'submissions',
+      },
+    ]);
+
+    const playlist = await getOrCreateAutoPlaylist(controller.db, 'user_1');
+
+    expect(playlist).toMatchObject({
+      id: 'pl_submissions',
+      playlist_category: 'submissions',
+    });
+
+    const queries = controller.getQueries();
+    expect(queries[0]?.sql).toContain('WHERE user_id = ? AND playlist_category = ?');
+    expect(queries[0]?.params).toEqual(['user_1', 'submissions']);
+  });
+
+  it('isReadLaterPlaylist detects read_later category only', () => {
+    expect(isReadLaterPlaylist({ playlist_category: 'read_later' })).toBe(true);
+    expect(isReadLaterPlaylist({ playlist_category: null })).toBe(false);
+    expect(isReadLaterPlaylist({ playlist_category: 'submissions' })).toBe(false);
   });
 
   it('updatePlaylist returns updated row for owner', async () => {
     controller.setResults([
       { user_id: 'user_1' },
+      { playlist_category: null },
       [],
       { ...basePlaylist, title: 'Updated title', description: 'Updated description' },
     ]);
@@ -243,8 +354,8 @@ describe('playlists repository', () => {
     });
 
     const queries = controller.getQueries();
-    expect(queries[1]?.sql).toContain('SET title = ?, description = ?, updated_at = CURRENT_TIMESTAMP');
-    expect(queries[1]?.params).toEqual(['Updated title', 'Updated description', 'pl_1']);
+    expect(queries[2]?.sql).toContain('SET title = ?, description = ?, updated_at = CURRENT_TIMESTAMP');
+    expect(queries[2]?.params).toEqual(['Updated title', 'Updated description', 'pl_1']);
   });
 
   it('updatePlaylist returns null for non-owner', async () => {
@@ -258,13 +369,23 @@ describe('playlists repository', () => {
     expect(controller.getQueries()).toHaveLength(1);
   });
 
+  it('updatePlaylist throws for read later playlist', async () => {
+    controller.setResults([{ user_id: 'user_1' }, { playlist_category: 'read_later' }]);
+
+    await expect(
+      updatePlaylist(controller.db, 'pl_1', 'user_1', {
+        title: 'Updated title',
+      }),
+    ).rejects.toBeInstanceOf(ReadLaterProtectedError);
+  });
+
   it('deletePlaylist cascades, returns true for owner, false for non-owner', async () => {
-    controller.setResults([{ user_id: 'user_1' }, []]);
+    controller.setResults([{ user_id: 'user_1' }, { playlist_category: null }, []]);
 
     const deleted = await deletePlaylist(controller.db, 'pl_1', 'user_1');
 
     expect(deleted).toBe(true);
-    expect(controller.getQueries()[1]?.sql).toContain('DELETE FROM user_playlists');
+    expect(controller.getQueries()[2]?.sql).toContain('DELETE FROM user_playlists');
 
     controller.setResults([{ user_id: 'other_user' }]);
 
@@ -273,10 +394,16 @@ describe('playlists repository', () => {
     expect(notDeleted).toBe(false);
   });
 
+  it('deletePlaylist throws for read later playlist', async () => {
+    controller.setResults([{ user_id: 'user_1' }, { playlist_category: 'read_later' }]);
+
+    await expect(deletePlaylist(controller.db, 'pl_1', 'user_1')).rejects.toBeInstanceOf(ReadLaterProtectedError);
+  });
+
   it('setVisibility auto-sets status pending when changing to public', async () => {
     controller.setResults([
       { user_id: 'user_1' },
-      { playlist_type: 'community' },
+      { playlist_type: 'community', playlist_category: null },
       [],
       { ...basePlaylist, visibility: 'public', status: 'pending' },
     ]);
@@ -296,7 +423,7 @@ describe('playlists repository', () => {
   it('setVisibility resets status to draft when changing to unlisted', async () => {
     controller.setResults([
       { user_id: 'user_1' },
-      { playlist_type: 'community' },
+      { playlist_type: 'community', playlist_category: null },
       [],
       { ...basePlaylist, visibility: 'unlisted', status: 'draft' },
     ]);
@@ -308,5 +435,16 @@ describe('playlists repository', () => {
       status: 'draft',
     });
     expect(controller.getQueries()[2]?.params).toEqual(['unlisted', 'draft', 'pl_1']);
+  });
+
+  it('setVisibility throws for read later playlist', async () => {
+    controller.setResults([
+      { user_id: 'user_1' },
+      { playlist_type: 'community', playlist_category: 'read_later' },
+    ]);
+
+    await expect(setVisibility(controller.db, 'pl_1', 'user_1', 'public')).rejects.toBeInstanceOf(
+      ReadLaterProtectedError,
+    );
   });
 });


### PR DESCRIPTION
## Summary

- 북마크 기능을 localStorage 기반에서 **D1 기반 private 플레이리스트** (`나중에 볼 기사`, `playlist_category='read_later'`)로 통합
- 하트 아이콘 ↔ 플레이리스트 좋아요 충돌 해소: **책갈피 아이콘 + `var(--color-primary)` 컬러**로 교체
- 북마크 조회 UX 공백 해소: `/my/playlists`에서 최상단 고정된 특수 카드 + `/p/{id}` 상세 페이지에서 항목 관리
- 관련 배경과 대안 검토는 `docs/decisions/0005-bookmark-as-read-later-playlist.md` 참조

## What changed

### DB & Backend
- `migrations/0005_playlist_category.sql`: `playlist_category` 컬럼 + 부분 UNIQUE 인덱스 `uq_user_playlist_category (user_id, playlist_category) WHERE playlist_category IS NOT NULL` 추가. 기존 auto-created 레코드는 `'submissions'`으로 backfill.
- `functions/lib/playlists.ts`:
  - 신규 `getOrCreateReadLaterPlaylist()`, `isReadLaterPlaylist()`, `ReadLaterProtectedError`
  - 공용 헬퍼 `getOrCreateCategoryPlaylist()` (unique-index 경합 재시도)
  - **버그 수정**: `getOrCreateAutoPlaylist()`가 `category='submissions'`로 필터링 (기존엔 임의의 최근 플레이리스트 반환)
  - `listUserPlaylists()`에 `excludeCategory` 파라미터 + `ORDER BY (playlist_category = 'read_later') DESC, updated_at DESC`
  - `deletePlaylist` / `setVisibility` / `updatePlaylist` 에 Read Later 보호 가드
- 신규 API (`functions/api/bookmarks/`)
  - `POST /api/bookmarks/toggle` — 기사 추가/제거 토글
  - `GET  /api/bookmarks/ids` — 현재 사용자의 북마크 source_id 배열 (UI 상태 복원)
  - `POST /api/bookmarks/migrate` — localStorage 북마크 배치 이관 (최대 200건)
- 기존 playlist API 가드 + `?exclude_category=read_later` 필터 추가

### Frontend
- `src/components/BookmarkButton.astro` 전면 재작성
  - 하트 → **책갈피** SVG
  - localStorage → `/api/bookmarks/*` 호출, sessionStorage `honeycombo:bookmark-ids`로 캐시
  - 미로그인 클릭 시 `return_to` 포함 로그인 리다이렉트
  - 기존 localStorage 북마크 자동 마이그레이션 + 토스트
- `src/components/ArticleCard.astro`, `src/components/InterestTagPanel.astro` (동적 카드), `src/pages/articles/[...slug].astro`: 새 props 전달
- `src/components/AddToPlaylist.astro`: Read Later 드롭다운 제외 (`&exclude_category=read_later`)
- `src/pages/my/playlists.astro`: Read Later 카드 특수 렌더링 (🔖 뱃지, 삭제/공개 버튼 숨김, 좌측 primary accent)
- `functions/p/[id].ts`: Read Later 상세 페이지 관리 버튼 숨김 + 설명 텍스트

### Tests & Docs
- `tests/lib/playlists.test.ts` 스키마 변경 반영 + 신규 테스트 8개 (Read Later 생성/가드/excludeCategory/isReadLaterPlaylist)
- `tests/api/bookmarks-{toggle,ids,migrate}.test.ts` 신규 (401/토글/배치/검증 케이스)
- 문서: ADR 0005 + 신규 `features/bookmark-read-later.md` + `features/playlists.md` / `features/article-detail-community.md` / `architecture/overview.md` 업데이트

## Breaking changes

- 북마크 기능은 **로그인 필수**로 전환됨. 미로그인 클릭 시 `/api/auth/github/login?return_to=...`로 리다이렉트.
- 기존 `localStorage['honeycombo:bookmarks']`는 첫 페이지 로드 시 자동으로 D1로 이관 후 제거됨.

## Test plan

로컬 CI 전 단계 통과:

\`\`\`
bun run validate              ✅ 300 files valid
bun run validate:docs         ✅ 48 files valid
bun run validate:docs -- --check-coverage  ✅ coverage OK
bun run build                 ✅ 844 pages
bun run test                  ✅ 375/375 passed
\`\`\`

수동 QA 체크리스트 (머지 후 프로덕션에서 재검증 권장):
- [ ] 미로그인 상태에서 북마크 클릭 → 로그인 페이지로 리다이렉트, 로그인 후 return
- [ ] 로그인 후 북마크 클릭 → 책갈피 채워짐, 다시 클릭 → 비워짐
- [ ] `/my/playlists` 에 "🔖 나중에 볼 기사" 카드가 최상단에 노출, 삭제/공개 버튼 없음
- [ ] `/p/{readLaterId}` 상세 페이지 진입, 북마크 항목 확인/삭제/메모 가능, 삭제/공개 버튼 없음
- [ ] AddToPlaylist 드롭다운에 "나중에 볼 기사"가 노출되지 않음
- [ ] 기존 localStorage 북마크 보유 사용자 첫 방문 시 "N개의 북마크를 '나중에 볼 기사'로 옮겼습니다" 토스트 + `/my/playlists`에 반영

## 관련 문서

- `docs/decisions/0005-bookmark-as-read-later-playlist.md` (ADR)
- `docs/features/bookmark-read-later.md` (신규 기능 문서)
- `docs/features/playlists.md` (업데이트)
- `docs/features/article-detail-community.md` (업데이트)
- `docs/architecture/overview.md` (업데이트)