### PR TITLE
fix: Read Later 삭제 시 북마크 UI 동기화 + D1 배포 가드레일

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,58 @@ jobs:
       - name: Test
         run: bun run test
 
+      # -------------------------------------------------------------------
+      # D1 migration advisory (PR-only)
+      #
+      # When a PR touches migrations/, remind the reviewer that the remote
+      # D1 database must be migrated *before* master is merged, because the
+      # code in `functions/lib/playlists.ts` (and others) references columns
+      # that only exist after `wrangler d1 migrations apply ... --remote`.
+      # Missing this step causes runtime "no such column" errors on the
+      # deployed Pages worker. See:
+      #   docs/troubleshooting/d1-migration-deployment.md
+      #
+      # This step does NOT fail the CI: the runner intentionally has no D1
+      # write credentials. It writes a GitHub Actions job summary and emits
+      # a ::warning:: annotation so it shows up on the PR "Files changed"
+      # tab and in the check summary.
+      # -------------------------------------------------------------------
+      - name: Detect pending D1 migrations (advisory)
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          set -euo pipefail
+          BASE="origin/${BASE_REF}"
+          # origin/master is fetched via fetch-depth: 0 at checkout
+          CHANGED_MIGRATIONS=$(git diff --name-only --diff-filter=A "${BASE}...HEAD" -- 'migrations/*.sql' || true)
+          if [ -z "${CHANGED_MIGRATIONS}" ]; then
+            echo "No new D1 migrations in this PR."
+            exit 0
+          fi
+          {
+            echo '### ⚠️ New D1 migrations detected'
+            echo ''
+            echo 'The following migration files were added in this PR:'
+            echo ''
+            echo '```'
+            echo "${CHANGED_MIGRATIONS}"
+            echo '```'
+            echo ''
+            echo 'Before merging to `master`, a maintainer must apply these migrations to the remote D1:'
+            echo ''
+            echo '```bash'
+            echo 'npx wrangler d1 migrations list honeycombo-db --remote'
+            echo 'npx wrangler d1 migrations apply honeycombo-db --remote'
+            echo '```'
+            echo ''
+            echo 'Cloudflare Pages auto-deploys code but does **not** run D1 migrations.'
+            echo 'Skipping this step causes runtime "no such column / table" errors.'
+            echo ''
+            echo 'See [`docs/troubleshooting/d1-migration-deployment.md`](../blob/HEAD/docs/troubleshooting/d1-migration-deployment.md).'
+          } >> "${GITHUB_STEP_SUMMARY}"
+          echo "::warning title=Pending D1 migrations::This PR adds migration files. Apply them to the remote D1 before merging to master (see job summary)."
+
       - name: Deploy to Cloudflare Pages
         if: github.ref == 'refs/heads/master' && github.event_name == 'push'
         env:

--- a/docs/features/bookmark-read-later.md
+++ b/docs/features/bookmark-read-later.md
@@ -41,6 +41,15 @@
        → 항목 확인, 메모 추가, 순서 변경 등 수행
 ```
 
+### 5. 상세 페이지에서 삭제 시 북마크 UI 동기화
+
+Read Later 플레이리스트 상세 페이지(`/p/{id}`)에서 기사 카드의 “삭제” 버튼을 누르면 해당 기사가 플레이리스트에서 제거되는 동시에 북마크 상태 또한 해제되어야 한다. `functions/p/[id].ts`는 Read Later 플레이리스트일 때 삽입되는 `syncBookmarkRemoval()` 헬퍼를 사용해 다음을 수행한다.
+
+1. `sessionStorage['honeycombo:bookmark-ids']` 목록에서 해당 `source_id`를 제거.
+2. 현재 로드된 DOM 내의 `[data-bookmark-id="{source_id}"]` 버튼에서 `bookmarked` 클래스와 `aria-pressed`를 해제.
+
+이 동기화는 `item-card` 태그에 서버가 렌더링한 `data-source-id`/`data-item-type` 속성을 읽어 동작하므로, 외부 URL 항목처럼 `source_id`가 없는 항목은 북마크 개념과 무관하므로 아무 작업도 하지 않는다.
+
 ## 관련 파일
 
 | 파일 | 역할 |
@@ -84,3 +93,4 @@
 | 날짜 | 변경 내용 |
 |------|----------|
 | 2026-04-23 | 최초 작성. 북마크를 D1 기반 Read Later 플레이리스트로 통합 |
+| 2026-04-24 | 상세 페이지에서 기사 삭제 시 북마크 UI 미동기화 버그 수정. `syncBookmarkRemoval()` 헬퍼 추가 및 `item-card` 태그에 `data-source-id`/`data-item-type` 속성 렌더링. |

--- a/docs/troubleshooting/d1-migration-deployment.md
+++ b/docs/troubleshooting/d1-migration-deployment.md
@@ -1,0 +1,114 @@
+# D1 마이그레이션 미적용으로 인한 런타임 SQL 에러
+
+> 코드는 새 컬럼을 참조하지만 프로덕션 D1에는 해당 컬럼이 없어 `/api/playlists?mine=true`가 500을 반환하고 "내 플레이리스트" 페이지가 실패하던 문제. 코드 머지 전 D1 마이그레이션을 먼저 적용해야 한다.
+
+## 증상
+
+PR #188(`feat: 북마크를 '나중에 볼 기사' Read Later 플레이리스트로 통합`) 머지 후 로그인 상태로 `/my/playlists`에 접근하면 아래 에러 메시지만 노출된다.
+
+```
+플레이리스트를 불러오는데 실패했습니다.
+```
+
+네트워크 탭에서 `/api/playlists?mine=true`가 **500 Internal Server Error**를 반환하며, 내부 SQL 에러는 다음과 같다.
+
+```
+D1_ERROR: no such column: playlist_category
+```
+
+**재현 환경**: Cloudflare Pages Production(honeycombo) + D1 `honeycombo-db`, master 기준 브랜치 `feat/bookmark-read-later`(commit `0e4073a`).
+
+## 원인
+
+PR #188이 두 가지를 동시에 변경했다.
+
+1. **코드**: `functions/lib/playlists.ts`의 모든 playlist SELECT 쿼리가 `playlist_category` 컬럼을 선택/정렬/필터에 사용하도록 변경됨 (예: `listUserPlaylists` L377, `getPlaylist` L221, `PLAYLIST_ROW_COLUMNS` L52).
+2. **스키마**: `migrations/0005_playlist_category.sql`에서 `ALTER TABLE user_playlists ADD COLUMN playlist_category TEXT`로 새 컬럼을 추가.
+
+Cloudflare Pages는 GitHub 연동으로 코드만 자동 배포하며 **D1 마이그레이션은 자동 적용하지 않는다**. 운영자는 별도 명령(`wrangler d1 migrations apply ...`)으로 수동 적용해야 하는데, 이 단계가 누락된 채 코드만 배포되어 런타임에서 `no such column` 에러가 발생했다.
+
+즉 **코드가 스키마보다 앞서 배포된 배포 순서 버그**다.
+
+## 해결 방법
+
+프로덕션 D1에 누락된 마이그레이션을 즉시 적용한다.
+
+```bash
+# 1. 적용 대상 확인
+npx wrangler d1 migrations list honeycombo-db --remote
+
+# 2. 적용
+npx wrangler d1 migrations apply honeycombo-db --remote
+
+# 3. 검증 (컬럼 존재 확인)
+npx wrangler d1 execute honeycombo-db --remote \
+  --command "PRAGMA table_info(user_playlists);"
+
+# 4. 재확인: pending 없음이어야 함
+npx wrangler d1 migrations list honeycombo-db --remote
+# → ✅ No migrations to apply!
+```
+
+적용 즉시 `/api/playlists?mine=true`가 정상 200을 반환하며, 북마크 토글(`/api/bookmarks/toggle`), 북마크 ID 조회(`/api/bookmarks/ids`), 레거시 마이그레이션(`/api/bookmarks/migrate`)도 모두 복구된다.
+
+```diff
+- SELECT ... playlist_category FROM user_playlists  -- ❌ no such column
++ SELECT ... playlist_category FROM user_playlists  -- ✅ 정상 동작
+```
+
+## 관련 파일
+
+| 파일 | 역할 |
+|------|------|
+| `migrations/0005_playlist_category.sql` | 누락돼 있던 D1 마이그레이션 (`playlist_category` 컬럼 추가 + 부분 유니크 인덱스) |
+| `functions/lib/playlists.ts` | `playlist_category`를 SELECT/ORDER/WHERE에 사용하는 모든 쿼리 |
+| `functions/api/playlists/index.ts` | `/api/playlists?mine=true` 엔드포인트 (500을 반환하던 지점) |
+| `src/pages/my/playlists.astro` | 에러 메시지를 노출하는 프론트엔드 (`loadPlaylists()` L106-131) |
+| `.github/workflows/ci.yml` | CI. pending D1 마이그레이션을 감지하는 스텝이 추가됨 (예방 조치 참고) |
+| `wrangler.jsonc` | D1 바인딩 및 `migrations_dir` 설정 |
+
+## 예방 조치
+
+### 1. 마이그레이션 우선 배포 체크리스트 (필수)
+
+`migrations/` 하위에 새 `.sql` 파일을 추가하는 PR을 머지할 때는 **반드시** 아래 순서를 지킨다.
+
+1. **로컬 검증**: `npx wrangler d1 execute honeycombo-db --local --file=migrations/NNNN_*.sql`로 문법/의도 확인.
+2. **머지 직전 적용 대상 확인**: `npx wrangler d1 migrations list honeycombo-db --remote`로 pending 목록 확인.
+3. **프로덕션 적용 선행**: **코드가 master로 머지되기 전에** `npx wrangler d1 migrations apply honeycombo-db --remote` 실행. (마이그레이션은 하위 호환 — 새 컬럼/인덱스 추가만 — 이어야 이 순서가 안전함.)
+4. **컬럼 존재 검증**: `PRAGMA table_info(...)`로 기대 컬럼이 생겼는지 확인.
+5. **코드 머지 및 배포**: PR 머지 → CI → Cloudflare Pages 자동 배포.
+6. **스모크 테스트**: 프로덕션에서 영향받은 엔드포인트(`/api/playlists?mine=true`, `/my/playlists` 등)를 직접 확인.
+
+하위 호환되지 않는 파괴적 마이그레이션(컬럼 삭제, 타입 변경 등)은 별도 결정 문서(`docs/decisions/`)를 먼저 작성하고 점진적 배포 전략을 세운 뒤에만 진행한다.
+
+### 2. CI에서 pending 마이그레이션 감지 (적용 완료)
+
+`.github/workflows/ci.yml`에 `migrations/` 경로 변경을 감지하면 경고를 띄우는 스텝을 추가했다. PR 리뷰 단계에서 `wrangler d1 migrations apply`를 잊지 않도록 상기시킨다.
+
+> 해당 스텝은 `DETECT_D1_MIGRATIONS` 단계에서 `git diff --name-only origin/master...HEAD -- migrations/`를 검사한다. 새 마이그레이션 파일이 있으면 **차단은 하지 않지만** 요약 커멘트와 함께 리뷰어의 수동 적용을 요청한다. (CI 러너에 프로덕션 D1 쓰기 권한을 부여하지 않기 위한 의도적 설계.)
+
+### 3. 배포 전 점검 루틴
+
+코드만 머지하고 배포가 자동화돼 있다는 이유로 방심하지 말 것. **D1 스키마 변경은 수동 적용 단계**임을 기억한다. 모든 배포 전 다음 한 줄을 확인한다.
+
+```bash
+npx wrangler d1 migrations list honeycombo-db --remote
+# 기대 결과: ✅ No migrations to apply!
+```
+
+---
+
+## 관련 문서
+
+- [Cloudflare Pages 자동 배포 미트리거 문제](./cloudflare-pages-auto-deploy-failure.md)
+- [아키텍처 개요](../architecture/overview.md)
+- [북마크/Read Later 기능](../features/bookmark-read-later.md)
+- [플레이리스트 기능](../features/playlists.md)
+- ADR: [북마크를 Read Later 플레이리스트로 통합](../decisions/0005-bookmark-as-read-later-playlist.md)
+
+## 변경 이력
+
+| 날짜 | 변경 내용 |
+|------|----------|
+| 2026-04-24 | 최초 작성. PR #188 배포 후 `/my/playlists` 실패 사건 기록. 예방책: 체크리스트 + CI 감지 스텝 추가. |

--- a/docs/troubleshooting/read-later-delete-bookmark-desync.md
+++ b/docs/troubleshooting/read-later-delete-bookmark-desync.md
@@ -1,0 +1,111 @@
+# '나중에 볼 기사'에서 삭제해도 북마크 UI가 유지되던 문제
+
+> Read Later 플레이리스트 상세 페이지에서 기사 카드의 "삭제" 버튼을 누르면 서버에선 정상 제거되지만, 이후 해당 기사 페이지로 이동하면 북마크 아이콘이 여전히 활성(bookmarked) 상태로 보이던 버그. `sessionStorage` 캐시를 같이 무효화하지 않았던 것이 원인.
+
+## 증상
+
+PR #188 머지 이후 다음 절차로 재현된다.
+
+```
+1. 기사 상세 페이지에서 북마크 아이콘 클릭 → 북마크됨 (🔖 활성)
+2. /p/{read_later_id} 에 진입 → 방금 북마크한 기사 카드가 존재함
+3. 카드의 "삭제" 버튼 클릭 → 카드가 사라짐 (서버 DELETE 성공)
+4. 같은 탭에서 원래 기사 페이지로 네비게이션 (뒤로가기 / 링크 / 검색)
+5. 북마크 아이콘이 여전히 "bookmarked" 상태로 보임 (❌)
+```
+
+**재현 환경**: 로그인 상태, 단일 탭, PR #188 (commit `0e4073a`) 배포 이후.
+
+## 원인
+
+북마크 UI 상태는 두 곳에서 결정된다.
+
+1. **서버 소스 오브 트루스**: D1 `playlist_items` (read_later 플레이리스트의 `source_id` 목록).
+2. **클라이언트 캐시**: `sessionStorage['honeycombo:bookmark-ids']` — `BookmarkButton.astro`가 탭 내부에서 반복적인 `/api/bookmarks/ids` 호출을 피하려고 캐시한 source_id 배열.
+
+기존 토글 플로우(`BookmarkButton` 내부)는 토글 시 서버에 `POST /api/bookmarks/toggle` 한 뒤 `invalidateBookmarkCache()`로 `sessionStorage`를 즉시 갱신한다. 덕분에 같은 탭 내에서 상태가 일관된다.
+
+그러나 **Read Later 상세 페이지(`/p/{id}`)의 "삭제" 버튼은 이 캐시 동기화 경로를 거치지 않았다.** `functions/p/[id].ts`의 `item-delete` 클릭 핸들러(기존 L1549 전후)는 `DELETE /api/playlists/{playlistId}/items/{itemId}`만 호출하고, DOM 카드만 제거했다. 결과:
+
+- 서버 D1: 해당 `playlist_items` 행이 삭제됨 → **북마크 아님**이 정답.
+- 클라이언트 `sessionStorage['honeycombo:bookmark-ids']`: 해당 `source_id`가 **그대로 남아 있음** → 이후 같은 탭의 `BookmarkButton.initBookmarkButtons()`가 이 배열을 읽어 UI를 "bookmarked"로 렌더링.
+
+즉, **"두 개의 삭제 입구"**(토글 vs. 플레이리스트 삭제) 중 한 쪽만 캐시를 갱신하던 누락 버그다.
+
+## 해결 방법
+
+`functions/p/[id].ts`의 오너 스크립트 블록에 다음을 추가했다.
+
+1. **`item-card`에 `data-source-id` / `data-item-type` 렌더링**: 클라이언트가 어떤 기사인지 식별할 수 있도록 서버가 메타 정보를 HTML 속성으로 내려준다 (`item.source_id`가 있는 내부 기사만).
+2. **`syncBookmarkRemoval(sourceId)` 헬퍼**: Read Later 플레이리스트일 때에 한해
+   - `sessionStorage['honeycombo:bookmark-ids']`에서 해당 `source_id`를 제거.
+   - 현재 DOM에 있는 `[data-bookmark-id="{source_id}"]` 버튼에서 `bookmarked` 클래스와 `aria-pressed`를 해제.
+3. **삭제 핸들러에서 호출**: `DELETE /api/playlists/{playlistId}/items/{itemId}` 성공 직후, 카드를 DOM에서 제거하기 전에 `syncBookmarkRemoval(card.dataset.sourceId)`를 호출.
+
+```diff
++ const playlistIsReadLater = ${isReadLater ? 'true' : 'false'};
++ const BOOKMARK_CACHE_KEY = 'honeycombo:bookmark-ids';
++
++ function syncBookmarkRemoval(sourceId) {
++   if (!playlistIsReadLater || !sourceId) return;
++   try {
++     const raw = sessionStorage.getItem(BOOKMARK_CACHE_KEY);
++     if (raw) {
++       const parsed = JSON.parse(raw);
++       if (Array.isArray(parsed)) {
++         const next = parsed.filter(id => String(id) !== String(sourceId));
++         sessionStorage.setItem(BOOKMARK_CACHE_KEY, JSON.stringify(next));
++       }
++     }
++   } catch (_err) { /* non-fatal */ }
++
++   document.querySelectorAll('[data-bookmark-id="' + ... + '"]').forEach(btn => {
++     btn.classList.remove('bookmarked');
++     btn.setAttribute('aria-pressed', 'false');
++   });
++ }
+
+  document.querySelectorAll('.item-delete').forEach((btn) => {
+    btn.addEventListener('click', async () => {
+      ...
+      const card = btn.closest('.item-card');
+      if (!card) return;
++     syncBookmarkRemoval(card.dataset.sourceId);
+      card.classList.add('removing');
+      ...
+```
+
+이후 동일 탭에서 기사로 이동할 때 `BookmarkButton.fetchBookmarkIds()`가 `sessionStorage` 캐시를 읽어 올바른 상태(북마크 해제됨)로 UI를 그린다. 다른 탭이나 다른 디바이스는 다음 `/api/bookmarks/ids` 호출(새 탭/하드 리로드) 때 서버 기준으로 자연스럽게 재동기화된다.
+
+### 외부 URL 항목 처리
+
+플레이리스트 항목 중 `item_type === 'external'`인 항목은 `source_id`가 `null`이다. 이 경우 `data-source-id` 속성 자체가 렌더링되지 않으므로 `card.dataset.sourceId`는 `undefined`가 되고 `syncBookmarkRemoval(undefined)` 내부의 `!sourceId` 가드에서 즉시 반환한다. 북마크 개념이 적용되지 않는 항목을 잘못 건드릴 위험이 없다.
+
+## 관련 파일
+
+| 파일 | 변경 내용 |
+|------|----------|
+| `functions/p/[id].ts` | `item-card`에 `data-source-id`/`data-item-type` 속성 추가, 오너 스크립트에 `syncBookmarkRemoval()` 헬퍼 삽입, `item-delete` 핸들러에서 호출 |
+| `docs/features/bookmark-read-later.md` | 5번 절(상세 페이지에서 삭제 시 UI 동기화) 신설 및 변경 이력 갱신 |
+
+## 예방 조치
+
+- **"동일한 도메인 상태를 바꾸는 모든 입구"를 동기화하라**: 북마크는 두 UI(북마크 버튼, Read Later 삭제 버튼)에서 변경될 수 있다. 새 입구가 생기면 반드시 `sessionStorage['honeycombo:bookmark-ids']` 캐시 경로도 함께 갱신해야 한다.
+- **캐시 갱신 헬퍼를 공유하라**: 현재 캐시 조작 로직이 `BookmarkButton.astro`(`invalidateBookmarkCache`)와 `functions/p/[id].ts`(`syncBookmarkRemoval`) 두 곳에 분산되어 있다. 세 번째 입구가 생기기 전에 공통 모듈로 추출하는 것이 바람직하다. (후속 과제)
+- **삭제 API에 `source_id`를 응답에 포함하는 안**: 서버 응답에 삭제된 항목의 `source_id`를 돌려주면 클라이언트가 `data-source-id` 속성에 의존하지 않아도 된다. 다만 현재 DELETE는 `204 No Content`로 설계되어 있으므로, 이 방식은 계약 변경을 수반한다. 지금 수정은 최소 침습적으로 속성 전달 방식을 택했다.
+- **회귀 테스트**: `tests/api/bookmarks-ids.test.ts`는 서버 단의 ID 조회만 검증한다. 클라이언트 캐시 동기화는 통합 테스트 범위이므로, 향후 Playwright 시나리오("Read Later에서 삭제 후 기사 페이지 방문") 추가를 고려한다.
+
+---
+
+## 관련 문서
+
+- [북마크 — 나중에 볼 기사 (Read Later)](../features/bookmark-read-later.md)
+- [플레이리스트](../features/playlists.md)
+- [D1 마이그레이션 미적용 문제](./d1-migration-deployment.md)
+- ADR: [북마크를 Read Later 플레이리스트로 통합](../decisions/0005-bookmark-as-read-later-playlist.md)
+
+## 변경 이력
+
+| 날짜 | 변경 내용 |
+|------|----------|
+| 2026-04-24 | 최초 작성. Read Later 상세 페이지에서 삭제 시 `sessionStorage` 캐시 미갱신 버그 수정. |

--- a/functions/p/[id].ts
+++ b/functions/p/[id].ts
@@ -157,7 +157,7 @@ function renderItems(items: PlaylistItemRow[], isOwner: boolean, playlistId: str
         : '';
 
       return `
-        <article class="item-card card" data-item-id="${escapeAttr(item.id)}" data-position="${item.position}">
+        <article class="item-card card" data-item-id="${escapeAttr(item.id)}" data-position="${item.position}"${item.source_id ? ` data-source-id="${escapeAttr(item.source_id)}"` : ''} data-item-type="${escapeAttr(item.item_type)}">
           ${isOwner ? `<div class="drag-handle" aria-label="드래그하여 순서 변경"></div>` : ''}
           ${thumbnail ? `<div class="item-thumbnail"><img src="${escapeAttr(thumbnail)}" alt="" loading="lazy" width="160" height="90" /></div>` : ''}
           <div class="item-body">
@@ -1310,6 +1310,41 @@ export const onRequest: AppPagesFunction = async ({ env, request, params }) => {
         </script>` : '',
       isOwner ? `<script>
           const playlistId = '${encodeURIComponent(playlist.id)}';
+          const playlistIsReadLater = ${isReadLater ? 'true' : 'false'};
+
+          // Keep the bookmark UI in sync when items are removed from the
+          // Read Later playlist. The <BookmarkButton> script caches
+          // bookmarked source_ids in sessionStorage so article pages can
+          // render the correct state without an extra request. If we delete
+          // an item here without updating that cache, the bookmark button
+          // on the article page keeps showing 'bookmarked' until the next
+          // sessionStorage refresh (new tab / hard reload). Fix: remove the
+          // source_id from the cache and re-sync any in-page bookmark
+          // buttons for that article.
+          const BOOKMARK_CACHE_KEY = 'honeycombo:bookmark-ids';
+
+          function syncBookmarkRemoval(sourceId) {
+            if (!playlistIsReadLater || !sourceId) return;
+
+            try {
+              const raw = sessionStorage.getItem(BOOKMARK_CACHE_KEY);
+              if (raw) {
+                const parsed = JSON.parse(raw);
+                if (Array.isArray(parsed)) {
+                  const next = parsed.filter(function(id) { return String(id) !== String(sourceId); });
+                  sessionStorage.setItem(BOOKMARK_CACHE_KEY, JSON.stringify(next));
+                }
+              }
+            } catch (_err) {
+              // Storage errors are non-fatal — BookmarkButton will refetch
+              // /api/bookmarks/ids on next load.
+            }
+
+            document.querySelectorAll('[data-bookmark-id="' + (window.CSS && CSS.escape ? CSS.escape(sourceId) : sourceId) + '"]').forEach(function(button) {
+              button.classList.remove('bookmarked');
+              button.setAttribute('aria-pressed', 'false');
+            });
+          }
 
           async function deletePlaylist() {
             if (!window.confirm('이 플레이리스트를 삭제할까요?')) {
@@ -1568,6 +1603,10 @@ export const onRequest: AppPagesFunction = async ({ env, request, params }) => {
                 if (!card) {
                   return;
                 }
+
+                // Keep bookmark UI in sync before the card is removed so
+                // the dataset is still readable.
+                syncBookmarkRemoval(card.dataset.sourceId);
 
                 card.classList.add('removing');
                 window.setTimeout(() => {


### PR DESCRIPTION
## Summary

- `/p/{readLaterId}` 에서 기사 카드를 삭제해도 다른 페이지의 북마크 아이콘이 여전히 '북마크됨'으로 남던 버그를 수정합니다.
- PR #188 머지 이후 '플레이리스트를 불러오는데 실패했습니다' 로 드러났던 D1 마이그레이션 미적용 사건을 문서화하고, CI에 pending 마이그레이션 감지 스텝(advisory)을 추가해 재발을 예방합니다.

## Bug fix — Read Later 삭제 시 북마크 UI 동기화

### 증상
1. 기사에서 북마크 클릭 → 🔖 활성
2. \`/my/playlists\` → '나중에 볼 기사' 카드 → \`/p/{id}\` 진입
3. 해당 기사 카드의 '삭제' 버튼 클릭 → 카드가 사라짐 (서버 DELETE 성공)
4. 같은 탭에서 원래 기사로 이동 → 북마크 아이콘이 여전히 'bookmarked' 상태 ❌

### 원인
북마크 UI는 서버(\`playlist_items\`)와 클라이언트 캐시(\`sessionStorage['honeycombo:bookmark-ids']\`) 두 곳에서 결정됩니다. \`BookmarkButton\`의 토글 경로는 캐시를 같이 갱신하지만, \`functions/p/[id].ts\` 의 item-delete 핸들러는 캐시를 건드리지 않아 상태가 어긋났습니다.

### 수정
- \`item-card\` 태그에 \`data-source-id\` / \`data-item-type\` 속성을 서버가 렌더링 (내부 기사만).
- 오너 스크립트에 Read Later 한정 \`syncBookmarkRemoval(sourceId)\` 헬퍼 추가 → \`sessionStorage\` 배열에서 해당 id 제거 + 현재 DOM의 \`[data-bookmark-id]\` 버튼에서 \`bookmarked\` 클래스/\`aria-pressed\` 해제.
- \`item-delete\` 핸들러가 DOM 제거 직전에 호출.

외부 URL 항목(\`item_type === 'external'\`)은 \`source_id\`가 없으므로 자동으로 no-op 처리됩니다.

상세 원인/해결: \`docs/troubleshooting/read-later-delete-bookmark-desync.md\`

## Deployment guardrails

### \"플레이리스트를 불러오는데 실패했습니다\" 사건 기록
PR #188 을 머지했는데 remote D1 에 마이그레이션 \`0005_playlist_category.sql\` 이 적용되지 않아 \`/api/playlists?mine=true\` 가 \`no such column: playlist_category\` 로 500 반환 → \`/my/playlists\` 전체 실패. 원인·해결·체크리스트를 \`docs/troubleshooting/d1-migration-deployment.md\` 에 기록했습니다 (이번 세션에서 \`npx wrangler d1 migrations apply honeycombo-db --remote\` 로 복구 완료).

### CI advisory step
\`.github/workflows/ci.yml\` 의 PR 이벤트에만 작동하는 'Detect pending D1 migrations' 스텝을 추가했습니다. PR이 \`migrations/*.sql\` 파일을 추가하면 Job Summary + \`::warning::\` 어노테이션으로 리뷰어에게 머지 전 \`wrangler d1 migrations apply --remote\` 실행을 상기시킵니다. CI 러너에는 D1 쓰기 권한이 없어 advisory only, fail 하지 않습니다.

## Test plan

### Bug fix
1. 로그인 후 기사 A 에 북마크 → \`/p/{readLater}\` 에서 A 카드 존재 확인.
2. A 카드 '삭제' 클릭 → 카드 사라짐.
3. A 기사 페이지로 이동 → 북마크 아이콘 '북마크 안 됨' 상태여야 함 ✅
4. 외부 URL 항목을 동일하게 삭제해도 에러 없이 동작하는지 확인 (\`source_id\` 없음 → no-op).

### CI step (이 PR 자체는 마이그레이션 변경이 없어 조용히 지나감)
실제 동작은 다음 마이그레이션 추가 PR 에서 확인됩니다.

## Local verification
- ✅ \`bun run validate\`
- ✅ \`bun run validate:docs\` — 73 파일 유효
- ✅ \`bun run build\` — 844 pages
- ✅ \`bun run test\` — 375/375

## Files
- \`functions/p/[id].ts\` — \`item-card\` 에 \`data-source-id\` / \`data-item-type\` 속성, \`syncBookmarkRemoval()\` 헬퍼, delete 핸들러 호출
- \`.github/workflows/ci.yml\` — Detect pending D1 migrations 스텝 (PR-only, advisory)
- \`docs/troubleshooting/d1-migration-deployment.md\` — 신규
- \`docs/troubleshooting/read-later-delete-bookmark-desync.md\` — 신규
- \`docs/features/bookmark-read-later.md\` — \"5. 상세 페이지에서 삭제 시 북마크 UI 동기화\" 절 추가