### PR TITLE
ci: GitHub 인프라 장애·stale submission 브랜치 재발 방지

### DIFF
--- a/.github/workflows/ci-auto-rerun.yml
+++ b/.github/workflows/ci-auto-rerun.yml
@@ -1,0 +1,113 @@
+name: CI Auto-Rerun
+
+# CI 워크플로우가 GitHub 인프라 일시 장애로 실패했을 때만 자동으로 재실행한다.
+#
+# 전제:
+#   - actions/checkout, git fetch 등이 HTTP 500/502/503/504 또는 네트워크 타임아웃으로 실패한 경우는
+#     코드 문제가 아니라 GitHub 쪽 장애라서 단순 재실행만으로 해결된다.
+#   - 테스트/빌드 실패처럼 결정적인(deterministic) 실패는 재실행해봐야 똑같이 실패하므로
+#     자동 재실행 대상에서 명시적으로 제외한다.
+#
+# 안전장치:
+#   - run_attempt < 3 — 동일 run이 3회를 넘기면 사람이 개입.
+#   - 실패 로그를 훑어 infra-transient 시그니처가 있을 때만 rerun.
+#   - 매칭되지 않으면 아무 것도 하지 않음 (조용히 종료).
+#
+# 관련 문서: docs/troubleshooting/rss-submission-ci-failure.md
+
+on:
+  workflow_run:
+    workflows: ['CI']
+    types: [completed]
+
+concurrency:
+  group: ci-auto-rerun-${{ github.event.workflow_run.id }}
+  cancel-in-progress: false
+
+jobs:
+  rerun-on-infra-failure:
+    if: >-
+      github.event.workflow_run.conclusion == 'failure'
+      && github.event.workflow_run.run_attempt < 3
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
+    steps:
+      - name: Classify failure (infra-transient vs deterministic)
+        id: classify
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
+        run: |
+          set -euo pipefail
+
+          echo "Inspecting failed run #$RUN_ID (attempt $RUN_ATTEMPT)"
+
+          # 실패 스텝의 로그만 뽑아서 검사한다.
+          # gh run view --log-failed 는 실패한 job/step 로그만 반환한다.
+          LOG_FILE="$(mktemp)"
+          if ! gh run view "$RUN_ID" --repo "$REPO" --log-failed > "$LOG_FILE" 2>/dev/null; then
+            # 아직 로그가 준비 안 됐을 수 있다 — 보수적으로 skip.
+            echo "Failed-log not available yet; skipping rerun."
+            echo "should_rerun=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # 매칭할 infra-transient 시그니처 목록.
+          # 하나라도 걸리면 rerun 후보로 간주한다.
+          #
+          # 주의: 과잉 매칭을 피하기 위해 아주 보수적으로만 잡는다.
+          # 예컨대 단순한 "error" 같은 단어는 포함하지 않는다.
+          PATTERNS=(
+            'remote: Internal Server Error'
+            'The requested URL returned error: 5[0-9][0-9]'
+            'RPC failed; HTTP 5[0-9][0-9]'
+            'fatal: expected flush after ref listing'
+            'unable to access .* The requested URL returned error: 5[0-9][0-9]'
+            'Connection timed out'
+            'Connect Timeout Error'
+            'connect ETIMEDOUT'
+            'connect ECONNREFUSED'
+            'getaddrinfo ENOTFOUND github.com'
+            'server is currently unable to handle the request'
+            'The operation was canceled'
+            '502 Bad Gateway'
+            '503 Service Unavailable'
+            '504 Gateway Time-?out'
+          )
+
+          MATCHED=""
+          for p in "${PATTERNS[@]}"; do
+            if grep -E -i -q "$p" "$LOG_FILE"; then
+              MATCHED="$p"
+              break
+            fi
+          done
+
+          if [ -n "$MATCHED" ]; then
+            echo "Matched infra-transient signature: $MATCHED"
+            echo "should_rerun=true" >> "$GITHUB_OUTPUT"
+            echo "matched_pattern=$MATCHED" >> "$GITHUB_OUTPUT"
+          else
+            echo "No infra-transient signature matched — skipping rerun (treating as deterministic failure)."
+            echo "should_rerun=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          rm -f "$LOG_FILE"
+
+      - name: Rerun failed jobs
+        if: steps.classify.outputs.should_rerun == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
+          MATCHED: ${{ steps.classify.outputs.matched_pattern }}
+        run: |
+          set -euo pipefail
+          echo "Rerunning failed jobs of run #$RUN_ID (attempt $RUN_ATTEMPT) — matched: $MATCHED"
+          gh run rerun "$RUN_ID" --repo "$REPO" --failed
+          echo "Rerun requested."

--- a/.github/workflows/process-submission.yml
+++ b/.github/workflows/process-submission.yml
@@ -195,14 +195,36 @@ jobs:
           fi
 
           git commit -m "feat: add submission from issue #$ISSUE_NUM"
-          git push origin "$BRANCH"
 
-          gh pr create \
-            --title "$PR_TITLE" \
-            --body "Closes #$ISSUE_NUM. Auto-generated submission." \
-            --base master \
-            --head "$BRANCH" \
-            --label "submission"
+          # stale 원격 브랜치 방어:
+          #   이전 run이 같은 issue에 대해 submission/$ISSUE_NUM 브랜치를 만들고
+          #   PR이 이미 닫힌(merged/closed) 상태라면 origin 브랜치를 정리한다.
+          #   열린 PR이 있으면 브랜치를 건드리지 않는다 (PR이 사라지면 안 됨).
+          # 경쟁 상태는 --force-with-lease가 감지한다.
+          OPEN_PR=$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number // ""')
+          if [ -z "$OPEN_PR" ]; then
+            if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+              echo "Removing stale remote branch $BRANCH (no open PR)"
+              git push origin --delete "$BRANCH" || true
+            fi
+          fi
+
+          # 이번 run에서 아직 원격 브랜치를 fetch한 적이 없으면 --force-with-lease가
+          # 비어 있는 expected value로 실패할 수 있다. 현 원격 tip을 먼저 가져와서
+          # --force-with-lease가 "내가 방금 본 상태" 대비 비교하도록 한다.
+          git fetch origin "$BRANCH" || true
+          git push --force-with-lease origin "$BRANCH"
+
+          if [ -n "$OPEN_PR" ]; then
+            echo "Reusing existing open PR #$OPEN_PR on branch $BRANCH"
+          else
+            gh pr create \
+              --title "$PR_TITLE" \
+              --body "Closes #$ISSUE_NUM. Auto-generated submission." \
+              --base master \
+              --head "$BRANCH" \
+              --label "submission"
+          fi
 
       - name: Auto-merge if editor
         env:

--- a/docs/troubleshooting/rss-submission-ci-failure.md
+++ b/docs/troubleshooting/rss-submission-ci-failure.md
@@ -1,0 +1,141 @@
+# RSS/Submission PR의 CI가 GitHub 인프라 장애·stale 브랜치로 실패한다
+
+> Issue 제출 처리 워크플로우와 그 결과 PR의 CI가 HTTP 500과 non-fast-forward push로 연쇄 실패한 사건을 기록한다. infra-transient 자동 재실행 워크플로우와 stale 브랜치 방어 로직을 추가해 재발을 막는다.
+
+## 증상
+
+2026-04-23 16:17 UTC, issue #192("온라인/설치형 무료 한글 에디터 프로그램") 제출 처리가 실패하고, 생성된 PR #193의 CI도 실패해 master 머지가 차단됐다.
+
+### 증상 1 — `Process Submission` 워크플로우 실패
+
+`Create PR with new submission` 스텝에서 `git push`가 거부됐다.
+
+```
+To https://github.com/orientpine/honeycombo
+ ! [rejected]        submission/192 -> submission/192 (non-fast-forward)
+error: failed to push some refs to 'https://github.com/orientpine/honeycombo'
+hint: Updates were rejected because the tip of your current branch is behind
+hint: its remote counterpart.
+##[error]Process completed with exit code 1.
+```
+
+이로 인해 issue #192에는 "❌ 제출 처리 중 오류가 발생했습니다" 코멘트가 달렸지만, 실제로는 PR #193이 이미 존재했다(오탐).
+
+### 증상 2 — PR #193의 `CI` 워크플로우 실패
+
+`actions/checkout@v6`가 내부 retry 3회를 모두 HTTP 500으로 소진하고 최종 실패했다.
+
+```
+Run actions/checkout@v6
+...
+remote: Internal Server Error
+fatal: unable to access 'https://github.com/orientpine/honeycombo/': The requested URL returned error: 500
+error: RPC failed; HTTP 500 curl 22 The requested URL returned error: 500
+fatal: expected flush after ref listing
+```
+
+이후 `Install dependencies`, `Build`, `Test`, `Deploy` 등 모든 스텝이 skip 되고 CI 전체가 빨간 X. master Ruleset(`ci` status check 필수) 때문에 PR 머지가 차단됐다.
+
+**재현 환경**: GitHub Actions hosted runner(`ubuntu-24.04`), `actions/checkout@v6`, `git 2.53`, 2026-04-23 16:17 UTC.
+
+## 원인
+
+두 개의 **독립된** 원인이 같은 이벤트에서 겹쳤다.
+
+### 원인 1 — GitHub 인프라 일시 장애 (transient)
+
+해당 시각에 github.com git 서버가 일시적으로 HTTP 500을 반환했다. `actions/checkout`은 fetch 단계에서 retry helper로 최대 3회 재시도를 수행하지만, 장애가 retry 창을 넘기면 모두 실패한다. 코드·콘텐츠 문제가 아니라 외부 장애이므로 단순 재실행으로 해소된다.
+
+### 원인 2 — stale submission 브랜치 재사용 (버그)
+
+`.github/workflows/process-submission.yml`의 `Create PR with new submission` 스텝은 이슈 번호만으로 `submission/$ISSUE_NUM` 브랜치를 만들고 `git push origin "$BRANCH"`를 실행한다 (force 없음).
+
+```bash
+# (이전)
+git checkout -b "$BRANCH"
+git commit -m "..."
+git push origin "$BRANCH"     # ← 원격에 같은 이름 브랜치가 남아 있으면 non-fast-forward로 거부
+```
+
+원격 `submission/<N>` 브랜치가 이전 run에서 남아있는 상태로 같은 이슈가 재트리거되면 (issue 재라벨링, workflow_dispatch 등) push가 non-fast-forward로 거부된다. 이번 장애에서는 원인 1과 맞물려 동일 run 안에서 먼저 `submission/192`가 원격에 생긴 뒤 두 번째 push 시도가 거부된 것으로 관찰된다.
+
+`.github/workflows/admin-pr-auto-merge.yml`은 `submission/*` 브랜치를 명시적으로 건너뛰고, `process-submission.yml` 내부 `Auto-merge if editor` 스텝도 `gh pr merge --merge --auto`만 쓰고 `--delete-branch` 플래그가 없다. 따라서 stale 브랜치가 쉽게 누적될 수 있는 구조였다.
+
+## 해결 방법
+
+### P0 — PR #193 즉시 복구
+
+`gh run rerun 24846153285 --failed`로 단순 재실행. 2번째 시도에서 GitHub 인프라가 회복되어 CI 통과 확인.
+
+### P1-1 — `process-submission.yml`의 push 로직을 견고화
+
+`Create PR with new submission` 스텝에서 원격 브랜치 상태를 먼저 정리하고 `--force-with-lease`로 push 하도록 수정했다.
+
+```diff
+- git push origin "$BRANCH"
++ # stale 원격 브랜치 방어:
++ OPEN_PR=$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number // ""')
++ if [ -z "$OPEN_PR" ]; then
++   if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
++     echo "Removing stale remote branch $BRANCH (no open PR)"
++     git push origin --delete "$BRANCH" || true
++   fi
++ fi
++ git fetch origin "$BRANCH" || true
++ git push --force-with-lease origin "$BRANCH"
++
++ if [ -n "$OPEN_PR" ]; then
++   echo "Reusing existing open PR #$OPEN_PR on branch $BRANCH"
++ else
++   gh pr create --title "$PR_TITLE" --body "..." --base master --head "$BRANCH" --label "submission"
++ fi
+```
+
+핵심 포인트:
+- **열린 PR이 있으면** 브랜치를 지우지 않는다. PR이 사라지면 안 된다. 대신 `--force-with-lease`로 같은 브랜치에 새 commit을 덮어쓴다 (기존 PR이 새 commit으로 업데이트됨).
+- **열린 PR이 없고 stale 원격 브랜치만 남아있으면** 브랜치를 지운 뒤 재push.
+- `git fetch origin "$BRANCH" || true`로 `--force-with-lease`가 비교할 remote-tracking ref를 확보.
+- PR 생성은 open PR이 없을 때만.
+
+### P1-2 — `ci-auto-rerun.yml` 신규 워크플로우로 infra 장애 자동 복구
+
+`.github/workflows/ci-auto-rerun.yml`을 추가했다.
+
+- 트리거: `workflow_run: workflows: ["CI"], types: [completed]`
+- 조건: `conclusion == 'failure' && run_attempt < 3`
+- 실패 로그(`gh run view --log-failed`)에서 infra-transient 시그니처가 하나라도 매칭될 때만 `gh run rerun "$RUN_ID" --failed` 수행.
+- 시그니처: `remote: Internal Server Error`, `RPC failed; HTTP 5xx`, `unable to access ... error: 5xx`, `Connection timed out`, `Connect Timeout Error`, `connect ETIMEDOUT`, `getaddrinfo ENOTFOUND github.com`, `502/503/504`, `fatal: expected flush after ref listing` 등.
+- 테스트/빌드 실패 같은 **결정적** 실패는 시그니처에 포함하지 않는다. 재실행해봐야 같은 결과라 리소스 낭비이므로.
+
+로직은 로컬에서 4개 골든 로그 샘플로 단위 검증했다 (infra 로그 → MATCH, jest/tsc 실패 로그 → NO_MATCH, timeout 로그 → MATCH).
+
+## 관련 파일
+
+| 파일 | 변경 내용 |
+|------|----------|
+| `.github/workflows/process-submission.yml` | `Create PR with new submission` 스텝에 stale 브랜치 정리 + `--force-with-lease` + 기존 PR 재사용 분기 추가 |
+| `.github/workflows/ci-auto-rerun.yml` | 신규. CI 실패 시 infra-transient 시그니처 매칭 후 `gh run rerun --failed` |
+| `docs/troubleshooting/rss-submission-ci-failure.md` | 이 문서 |
+
+## 예방 조치
+
+- **GitHub 인프라 장애는 언제든 재발한다.** `actions/checkout`의 내부 retry는 부족할 수 있으므로 `ci-auto-rerun.yml`이 안전망이다. 시그니처가 매칭되지 않아도 `gh run rerun --failed`는 수동으로 항상 가능하다.
+- **같은 issue를 재처리할 때는 절대로 non-fast-forward 실패가 나면 안 된다.** 브랜치 이름이 `submission/<N>`처럼 결정적이라면 항상 (a) 기존 열린 PR 확인 → (b) 안전한 브랜치 정리 → (c) `--force-with-lease` 패턴을 쓴다.
+- **동일 시그니처를 쓰는 다른 워크플로우에도 적용 가능**: `content-update-base.yml`은 이미 rebase+retry 구조를 갖고 있어 OK. `rss-collect.yml`·`summarize.yml`은 `auto/rss-feeds`·`auto/summarize` 브랜치에 `--force`를 사용하므로 이 문제와 무관.
+- **자동 재실행이 3회를 넘기면 사람이 개입**해야 한다 (`run_attempt < 3` 조건). 시그니처가 계속 매칭된다면 GitHub Status(status.github.com)를 확인하고 수동으로 기다린다.
+- **재실행된 CI도 로그에 원인을 남겨라**: `ci-auto-rerun.yml`은 매칭된 패턴을 로그에 찍어서 왜 재실행됐는지 추적 가능하다.
+
+---
+
+## 관련 문서
+
+- [직접 master push가 Ruleset 때문에 실패하는 문제](./workflow-direct-push-to-protected-master.md)
+- [Cloudflare Pages 자동 배포 실패](./cloudflare-pages-auto-deploy-failure.md)
+- [Process Submission 멀티라인 Summary 파싱](./multiline-summary-parsing.md)
+- [아키텍처 개요](../architecture/overview.md)
+
+## 변경 이력
+
+| 날짜 | 변경 내용 |
+|------|----------|
+| 2026-04-24 | 최초 작성 — PR #193 CI 장애 대응 (HTTP 500 retry 소진 + stale submission/192 브랜치 non-fast-forward) |


### PR DESCRIPTION
## 배경

PR #193(issue #192 'hwp/hwpx 에디터')의 CI가 실패해 머지가 차단됐던 사건에서 두 개의 **독립된** 실패 원인을 발견했다. 첫 번째는 GitHub 인프라 일시 장애(HTTP 500), 두 번째는 그 와중에 노출된 `process-submission.yml`의 stale 브랜치 재사용 버그다.

## 변경 내용

### 1. `process-submission.yml` 강화 — non-fast-forward 방지

`Create PR with new submission` 스텝에서 `git push origin "$BRANCH"`만 했던 것을 다음으로 교체:

- 같은 브랜치에 **열린 PR이 있으면** 브랜치를 건드리지 않고 `--force-with-lease`로 새 commit을 덮어쓴다 (기존 PR이 update 됨).
- 열린 PR이 없는데 stale 원격 브랜치만 남아있으면 먼저 삭제 후 push.
- `git fetch origin "$BRANCH" || true`로 `--force-with-lease` 비교 기준을 확보.
- PR 생성은 open PR이 없을 때만 (있으면 재사용 메시지 출력).

### 2. `ci-auto-rerun.yml` 신규 — infra-transient 자동 재실행

- Trigger: `workflow_run` on CI `completed`
- Condition: `conclusion == 'failure' && run_attempt < 3` (loop 차단)
- 실패 로그(\`gh run view --log-failed\`)에서 infra-transient 시그니처(HTTP 5xx, ETIMEDOUT, ENOTFOUND, RPC failed 등)가 매칭될 때만 \`gh run rerun --failed\`
- 결정적 실패(테스트/빌드 오류)는 자동 재실행하지 않음 — 같은 결과를 반복할 뿐이라 리소스 낭비

로컬에서 4개 골든 로그 샘플로 단위 검증 완료:
- 실제 24846153285의 infra 로그 → MATCH ✅
- Jest 테스트 실패 로그 → NO_MATCH ✅
- TypeScript compile 오류 로그 → NO_MATCH ✅
- Connect Timeout 로그 → MATCH ✅

### 3. `docs/troubleshooting/rss-submission-ci-failure.md` 신규

증상·원인·해결·예방 조치를 모두 기록.

## 검증

```
bun run validate                          → ✅ 465 files
bun run validate:docs                     → ✅ 72 files
bun run validate:docs -- --check-coverage → ✅ pass
bun run build                             → ✅ 967 pages
bun run test                              → ✅ 375 tests
```

## 즉시 효과

- PR #193 자체는 \`gh run rerun 24846153285 --failed\`로 이미 복구되어 머지 가능 상태.
- 본 PR이 머지된 이후의 CI 실패는 인프라 장애일 경우 자동 재실행됨.
- 같은 issue를 재처리해도 stale 브랜치 때문에 fail 하지 않음.

## 비범위

- `ci.yml` 자체는 수정하지 않음 (`nick-fields/retry`로 step-level wrap은 효과 적음 — 장애가 checkout 단계라).
- `process-submission.yml`의 \`Auto-merge if editor\` 스텝은 그대로 유지 (\`--delete-branch\` 추가는 별도 개선 기회).

Closes-related: PR #193 (이미 단순 rerun으로 복구)